### PR TITLE
Delete the RestartRequired event

### DIFF
--- a/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
@@ -286,11 +286,6 @@ namespace WixToolset.Bootstrapper
         public event EventHandler<ExecuteCompleteEventArgs> ExecuteComplete;
 
         /// <summary>
-        /// Fired by the engine to request a restart now or inform the user a manual restart is required later.
-        /// </summary>
-        public event EventHandler<RestartRequiredEventArgs> RestartRequired;
-
-        /// <summary>
         /// Fired when the engine has completed installing the bundle.
         /// </summary>
         public event EventHandler<ApplyCompleteEventArgs> ApplyComplete;
@@ -969,19 +964,6 @@ namespace WixToolset.Bootstrapper
         protected virtual void OnExecuteComplete(ExecuteCompleteEventArgs args)
         {
             EventHandler<ExecuteCompleteEventArgs> handler = this.ExecuteComplete;
-            if (null != handler)
-            {
-                handler(this, args);
-            }
-        }
-
-        /// <summary>
-        /// Called by the engine to request a restart now or inform the user a manual restart is required later.
-        /// </summary>
-        /// <param name="args">Additional arguments for this event.</param>
-        protected virtual void OnRestartRequired(RestartRequiredEventArgs args)
-        {
-            EventHandler<RestartRequiredEventArgs> handler = this.RestartRequired;
             if (null != handler)
             {
                 handler(this, args);

--- a/src/ext/BalExtension/mba/core/EventArgs.cs
+++ b/src/ext/BalExtension/mba/core/EventArgs.cs
@@ -1697,31 +1697,6 @@ namespace WixToolset.Bootstrapper
     }
 
     /// <summary>
-    /// Additional arguments used by the engine to request a restart now or inform the user a manual restart is required later.
-    /// </summary>
-    [Serializable]
-    public class RestartRequiredEventArgs : EventArgs
-    {
-        private bool restart;
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="RestartRequiredEventArgs"/> class.
-        /// </summary>
-        public RestartRequiredEventArgs()
-        {
-        }
-
-        /// <summary>
-        /// Gets or sets whether the engine should restart now. The default is false.
-        /// </summary>
-        public bool Restart
-        {
-            get { return this.restart; }
-            set { this.restart = value; }
-        }
-    }
-
-    /// <summary>
     /// Additional arguments used when the engine has completed installing the bundle.
     /// </summary>
     [Serializable]


### PR DESCRIPTION
Delete the RestartRequired event from the mba core, because it's not a real BootstrapperApplication event.
