### PR TITLE
Transaction Fix

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+* MikeGC: Fix bug in settings engine that can cause unnecessary conflicts to appear upon sync failure in certain situations
+
+* MikeGC: In settings engine, remove parameter from CfgEnumerateProducts() that was never used and has not worked for a long time anyway
+
 * RobMen: Merge recent changes through WiX v3.9.313.0
 
 * SeanHall: WIXBUG:3643 - Incorrect operation for detect-only package

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -355,7 +355,7 @@ BOOL ProcessMessage(
         break;
     case WM_BROWSE_ENUMERATE_PRODUCTS:
         dwIndex = static_cast<DWORD>(msg->wParam);
-        hrSend = CfgEnumerateProducts(bdlDatabaseList.rgDatabases[dwIndex].cdb, NULL, &cehHandle, &dwEnumCount);
+        hrSend = CfgEnumerateProducts(bdlDatabaseList.rgDatabases[dwIndex].cdb, &cehHandle, &dwEnumCount);
 
         ::EnterCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = TRUE;

--- a/src/SettingsEngine/lib/backgrnd.cpp
+++ b/src/SettingsEngine/lib/backgrnd.cpp
@@ -1043,7 +1043,6 @@ static HRESULT HandleSyncRequest(
         // If we previously failed to connect to this remote and now we can again, don't check timestamp, because we need to both push and pull changes
         fCheckDbTimestamp = !fReconnected;
 
-        syncSession.fWriteBackToMachine = TRUE;
         if (!::PostThreadMessageW(pcdb->dwBackgroundThreadId, BACKGROUND_THREAD_SYNC_FROM_REMOTE, reinterpret_cast<WPARAM>(sczTemp), static_cast<LPARAM>(fCheckDbTimestamp)))
         {
             ExitWithLastError1(hr, "Failed to send message to background thread to sync from remote %ls", sczTemp);

--- a/src/SettingsEngine/lib/inc/cfgapi.h
+++ b/src/SettingsEngine/lib/inc/cfgapi.h
@@ -248,7 +248,6 @@ HRESULT CFGAPI CfgEnumerateValues(
 // Enumerate products
 HRESULT CFGAPI CfgEnumerateProducts(
     __in_bcount(CFGDB_HANDLE_BYTES) CFGDB_HANDLE cdHandle,
-    __in_z_opt LPCWSTR wzPublicKey,
     __deref_opt_out_bcount_opt(CFG_ENUMERATION_HANDLE_BYTES) CFG_ENUMERATION_HANDLE *ppvHandle,
     __out_opt DWORD *pcCount
     );

--- a/test/src/SettingsEngineTests/PerUserProductTest.cpp
+++ b/test/src/SettingsEngineTests/PerUserProductTest.cpp
@@ -29,7 +29,7 @@ namespace CfgTests
             BOOL fBool = FALSE;
             CFG_ENUMERATION_HANDLE cehHandle = NULL;
 
-            hr = CfgEnumerateProducts(cdbHandle, NULL, &cehHandle, &dwCount);
+            hr = CfgEnumerateProducts(cdbHandle, &cehHandle, &dwCount);
             ExitOnFailure(hr, "Failed to enumerate products in user DB");
 
             if (dwIndex >= dwCount)
@@ -84,7 +84,7 @@ namespace CfgTests
             DWORD dwCount = 0;
             CFG_ENUMERATION_HANDLE cehHandle = NULL;
 
-            hr = CfgEnumerateProducts(cdbHandle, NULL, &cehHandle, &dwCount);
+            hr = CfgEnumerateProducts(cdbHandle, &cehHandle, &dwCount);
             ExitOnFailure(hr, "Failed to enumerate products in admin DB");
 
             if (dwExpectedNumber != dwCount)

--- a/test/src/SettingsEngineTests/SettingsEngineTest.cpp
+++ b/test/src/SettingsEngineTests/SettingsEngineTest.cpp
@@ -873,7 +873,7 @@ namespace CfgTests
     void CfgTest::WaitForDbToBeIdle(CFGDB_HANDLE cdHandle)
     {
         CFG_ENUMERATION_HANDLE cehProductList = NULL;
-        HRESULT hr = CfgEnumerateProducts(cdHandle, NULL, &cehProductList, NULL);
+        HRESULT hr = CfgEnumerateProducts(cdHandle, &cehProductList, NULL);
         ExitOnFailure(hr, "Failed to enumerate products to confirm DB is idle");
 
     LExit:


### PR DESCRIPTION
Fix bug in settings engine that can cause unnecessary conflicts to appear upon sync failure in certain situations, typically when an app writes a file (v1), then a short time later rewrites the same file (v2) with different data. Because remote changes were not (prior to this change) in their own transaction, v1 would get picked up and written to both local and remote, then when app is flushing database changes back to the local machine, it would notice the file on disk was v2 (different) and fail the sync (by design), rolling back the local transaction, but leaving v1 in the remote db. Autosync would then try to sync the product again, pickup v2 into the local, and find it conflicts with v1 in the remote. In reality, both v1 and v2 came from the local machine, so there should be no conflict, and putting the remote database operations in a transaction fixes that.

I previously thought remote changes shouldn't be in a transaction, because remote doesn't need to be in perfect sync state with any local files, so propagating more changes should always be a good thing. This case makes it clear that is wrong.

Also remove parameter from CfgEnumerateProducts() that is not used and has not worked for a long time anyway.
