### PR TITLE
Settings Browser Fixes

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* MikeGC: Fix bug in settings browser that can in certain situations result in an inability to look at history of a conflicting value, and other minor bugfixes
+
 * RobMen: Merge recent changes through WiX v3.9.313.0
 
 * SeanHall: WIXBUG:3643 - Incorrect operation for detect-only package

--- a/src/SettingsEngine/browse/precomp.h
+++ b/src/SettingsEngine/browse/precomp.h
@@ -13,6 +13,11 @@
 
 #pragma once
 
+#define ExitTrace LogErrorString
+#define ExitTrace1 LogErrorString
+#define ExitTrace2 LogErrorString
+#define ExitTrace3 LogErrorString
+
 #include <windows.h>
 #include <windowsx.h>
 #include <intsafe.h>


### PR DESCRIPTION
Fix bug in settings browser that can in certain situations result in an inability to look at history of a conflicting value, and other minor bugfixes. Also enable logging for all browser errors, because it really should be on at this stage of development.
