### PR TITLE
Add WixToolset.Tool.nuget to build for feature #3981.

### DIFF
--- a/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swixproj
+++ b/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swixproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="Bundle.wixproj" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <ProductVersion>4.0</ProductVersion>
+    <ProjectGuid>{B61C24EE-26A2-4663-B12A-49EB7E6F9531}</ProjectGuid>
+    <OutputName>WixToolset.Tools</OutputName>
+    <OutputType>Nuget</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Package Include="WixToolset.Tools.swr" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
+</Project>

--- a/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
+++ b/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
@@ -1,0 +1,82 @@
+use nuget
+
+package name=WixToolset.Tools
+        manufacturer="Outercurve Foundation"
+        version=$(version)
+        description="WiX Toolset tools that create MSI, MSP and MSM packages from XML source code."
+        about=http://wixtoolset.org/
+        license=http://wixtoolset.org/about/license/
+
+nuget.metadata developmentDependency=true
+
+folder build\
+  file WixToolset.Tools.props source=redirect.wix.nuget.props
+
+folder tools\
+  file candle.exe
+  file candle.exe.config
+  file dark.exe
+  file dark.exe.config
+  file heat.exe
+  file heat.exe.config
+  file insignia.exe
+  file insignia.exe.config
+  file light.exe
+  file light.exe.config
+  file lit.exe
+  file lit.exe.config
+  file melt.exe
+  file melt.exe.config
+  file pyro.exe
+  file pyro.exe.config
+  file retina.exe
+  file retina.exe.config
+  file shine.exe
+  file shine.exe.config
+  file smoke.exe
+  file smoke.exe.config
+  file torch.exe
+  file torch.exe.config
+  file wconsole.dll
+  file winterop.dll
+  file wix.dll
+  file WixCop.exe
+
+  file darice.cub
+  file mergemod.cub
+  file mergemod.dll
+  file mspatchc.dll
+  file x86\burn.exe
+
+  file WixTasks.dll
+  file wix.targets
+  file wix.harvest.targets
+  file wix.signing.targets
+
+  file WixToolset.Data.dll
+  file WixToolset.Extensibility.dll
+
+  file WixToolset.Dtf.Compression.dll
+  file WixToolset.Dtf.Compression.Cab.dll
+  file WixToolset.Dtf.Resources.dll
+  file WixToolset.Dtf.WindowsInstaller.dll
+  file WixToolset.Dtf.WindowsInstaller.Package.dll
+
+  file WixBalExtension.dll
+  file WixDifxAppExtension.dll
+  file WixDependencyExtension.dll
+  file WixDirectXExtension.dll
+  file WixFirewallExtension.dll
+  file WixGamingExtension.dll
+  file WixIIsExtension.dll
+  file WixMsmqExtension.dll 
+  file WixNetFxExtension.dll
+  file WixPSExtension.dll
+  file WixSqlExtension.dll
+  file WixTagExtension.dll
+  file WixUIExtension.dll
+  file WixUtilExtension.dll
+  file WixVSExtension.dll
+
+  file difxapp_x86.wixlib
+  file difxapp_x64.wixlib

--- a/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
+++ b/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
@@ -63,6 +63,7 @@ folder tools\
   file WixToolset.Dtf.WindowsInstaller.Package.dll
 
   file WixBalExtension.dll
+  file WixComPlusExtension.dll
   file WixDifxAppExtension.dll
   file WixDependencyExtension.dll
   file WixDirectXExtension.dll

--- a/src/Setup/Zip/binaries.zipproj
+++ b/src/Setup/Zip/binaries.zipproj
@@ -73,6 +73,7 @@
 
     <!-- extensions -->
     <Stage Include="$(OutputPath)WixBalExtension.dll" />
+    <Stage Include="$(OutputPath)WixComPlusExtension.dll" />
     <Stage Include="$(OutputPath)WixDifxAppExtension.dll" />
     <Stage Include="$(OutputPath)WixDependencyExtension.dll" />
     <Stage Include="$(OutputPath)WixDirectXExtension.dll" />

--- a/src/Setup/setup.proj
+++ b/src/Setup/setup.proj
@@ -14,6 +14,7 @@
     </ProjectReference>
 
     <ProjectReference Include="Bundle\Bundle.wixproj" />
+    <ProjectReference Include="Nuget\WixToolset.Tools\WixToolset.Tools.swixproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\Traversal.targets" />

--- a/src/swix.sln
+++ b/src/swix.sln
@@ -1,0 +1,185 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30110.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "swcore", "tools\swix\swcore\swcore.csproj", "{724901A4-16FF-4759-87A8-FDF85F2C3304}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WixToolset.BlockDeflateStream", "tools\swix\BlockDeflateStream\BlockDeflateStream.vcxproj", "{FA4862F1-BA70-4F42-82D7-8D298E6006FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "swc", "tools\swix\swc\swc.csproj", "{28886709-2988-45B3-8A0F-A419CEE75540}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compression.Zip", "DTF\Libraries\Compression.Zip\Compression.Zip.csproj", "{261F2857-B521-42A4-A3E0-B5165F225E50}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dtf", "dtf", "{8937D3D9-55DE-48B4-AB9C-D6329423226C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "unittest", "unittest", "{D28C820B-AACA-457F-A763-8EFE7E17CB04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "swcoreTests", "tools\swix\unittests\swcoreTests\swcoreTests.csproj", "{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test", "tools\swix\test\test.csproj", "{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|arm = Debug|arm
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|arm = Release|arm
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|arm.ActiveCfg = Debug|arm
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|arm.Build.0 = Debug|arm
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Win32.ActiveCfg = Debug|Win32
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|Win32.Build.0 = Debug|Win32
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|x64.ActiveCfg = Debug|x64
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|x64.Build.0 = Debug|x64
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|x86.ActiveCfg = Debug|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Debug|x86.Build.0 = Debug|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Any CPU.Build.0 = Release|Any CPU
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|arm.ActiveCfg = Release|arm
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|arm.Build.0 = Release|arm
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Mixed Platforms.Build.0 = Release|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Win32.ActiveCfg = Release|Win32
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|Win32.Build.0 = Release|Win32
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|x64.ActiveCfg = Release|x64
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|x64.Build.0 = Release|x64
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|x86.ActiveCfg = Release|x86
+		{724901A4-16FF-4759-87A8-FDF85F2C3304}.Release|x86.Build.0 = Release|x86
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|arm.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|Win32.Build.0 = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|x64.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|x86.ActiveCfg = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Debug|x86.Build.0 = Debug|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|Any CPU.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|arm.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|Win32.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|Win32.Build.0 = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|x64.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|x86.ActiveCfg = Release|Win32
+		{FA4862F1-BA70-4F42-82D7-8D298E6006FB}.Release|x86.Build.0 = Release|Win32
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|arm.ActiveCfg = Debug|arm
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|arm.Build.0 = Debug|arm
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Win32.ActiveCfg = Debug|Win32
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|Win32.Build.0 = Debug|Win32
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|x64.ActiveCfg = Debug|x64
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|x64.Build.0 = Debug|x64
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|x86.ActiveCfg = Debug|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Debug|x86.Build.0 = Debug|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|arm.ActiveCfg = Release|arm
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|arm.Build.0 = Release|arm
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Mixed Platforms.Build.0 = Release|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Win32.ActiveCfg = Release|Win32
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|Win32.Build.0 = Release|Win32
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|x64.ActiveCfg = Release|x64
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|x64.Build.0 = Release|x64
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|x86.ActiveCfg = Release|x86
+		{28886709-2988-45B3-8A0F-A419CEE75540}.Release|x86.Build.0 = Release|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|arm.ActiveCfg = Debug|arm
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|arm.Build.0 = Debug|arm
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Win32.ActiveCfg = Debug|Win32
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|Win32.Build.0 = Debug|Win32
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|x64.ActiveCfg = Debug|x64
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|x64.Build.0 = Debug|x64
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|x86.ActiveCfg = Debug|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Debug|x86.Build.0 = Debug|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|arm.ActiveCfg = Release|arm
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|arm.Build.0 = Release|arm
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Mixed Platforms.Build.0 = Release|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Win32.ActiveCfg = Release|Win32
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|Win32.Build.0 = Release|Win32
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|x64.ActiveCfg = Release|x64
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|x64.Build.0 = Release|x64
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|x86.ActiveCfg = Release|x86
+		{261F2857-B521-42A4-A3E0-B5165F225E50}.Release|x86.Build.0 = Release|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|arm.ActiveCfg = Debug|arm
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|arm.Build.0 = Debug|arm
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|Win32.Build.0 = Debug|Win32
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|x64.ActiveCfg = Debug|x64
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|x64.Build.0 = Debug|x64
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|x86.ActiveCfg = Debug|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Debug|x86.Build.0 = Debug|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|arm.ActiveCfg = Release|arm
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|arm.Build.0 = Release|arm
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Mixed Platforms.Build.0 = Release|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Win32.ActiveCfg = Release|Win32
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|Win32.Build.0 = Release|Win32
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|x64.ActiveCfg = Release|x64
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|x64.Build.0 = Release|x64
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|x86.ActiveCfg = Release|x86
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F}.Release|x86.Build.0 = Release|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|arm.ActiveCfg = Debug|arm
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|arm.Build.0 = Debug|arm
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|Win32.Build.0 = Debug|Win32
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|x64.ActiveCfg = Debug|x64
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|x64.Build.0 = Debug|x64
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|x86.ActiveCfg = Debug|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Debug|x86.Build.0 = Debug|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|arm.ActiveCfg = Release|arm
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|arm.Build.0 = Release|arm
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Mixed Platforms.Build.0 = Release|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Win32.ActiveCfg = Release|Win32
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|Win32.Build.0 = Release|Win32
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|x64.ActiveCfg = Release|x64
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|x64.Build.0 = Release|x64
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|x86.ActiveCfg = Release|x86
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{261F2857-B521-42A4-A3E0-B5165F225E50} = {8937D3D9-55DE-48B4-AB9C-D6329423226C}
+		{461A7BEA-0E83-4F38-9885-B81EF90C7D2F} = {D28C820B-AACA-457F-A763-8EFE7E17CB04}
+		{B8D8ECE7-DE54-4827-A420-BF34C1D61C1A} = {D28C820B-AACA-457F-A763-8EFE7E17CB04}
+	EndGlobalSection
+EndGlobal

--- a/src/tools/WixTasks/WixTasks.csproj
+++ b/src/tools/WixTasks/WixTasks.csproj
@@ -52,6 +52,9 @@
     <Compile Include="WixToolTask.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="redirect.wix.nuget.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="redirect.wix.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/tools/WixTasks/redirect.wix.nuget.props
+++ b/src/tools/WixTasks/redirect.wix.nuget.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  <copyright file="WixToolset.Tools.props" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <WixTargetsPath>$(MSBuildThisFileDirectory)..\tools\wix.targets</WixTargetsPath>
+  </PropertyGroup>
+</Project>

--- a/src/tools/swix/swc/Messaging.cs
+++ b/src/tools/swix/swc/Messaging.cs
@@ -11,8 +11,8 @@ namespace WixToolset.Simplified
 {
     using System;
     using System.Globalization;
+    using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
-    using WixToolset.Simplified;
 
     /// <summary>
     /// Internal messaging system to appropriately route messages to command-line or MSBuild logger.
@@ -116,12 +116,15 @@ namespace WixToolset.Simplified
                     break;
 
                 case CompilerMessage.CompilerMessageType.Warning:
-                    this.logger.LogWarning("SWIX", e.Message.Id, null, e.FileName, e.LineNumber, e.LinePosition, 0, 0, e.Message.Message);
+                    this.logger.LogWarning("SWIX", e.Message.Id, null, e.FileName, e.LineNumber, e.LinePosition, 0, e.LinePositionEnd, e.Message.Message);
                     break;
 
                 case CompilerMessage.CompilerMessageType.Information:
+                    this.logger.LogMessage(MessageImportance.Normal, e.Message.Message);
+                    break;
+
                 case CompilerMessage.CompilerMessageType.Verbose:
-                    this.logger.LogMessage("SWIX", e.Message.Id, null, e.FileName, e.LineNumber, e.LinePosition, 0, 0, e.Message.Message);
+                    this.logger.LogMessage(MessageImportance.Low, e.Message.Message);
                     break;
             }
         }

--- a/src/tools/swix/swc/SimplifiedWiX.targets
+++ b/src/tools/swix/swc/SimplifiedWiX.targets
@@ -10,6 +10,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetExt Condition=" '$(OutputType)' == 'Appx' ">.appx</TargetExt>
+    <TargetExt Condition=" '$(OutputType)' == 'Nuget' ">.nupkg</TargetExt>
+    <TargetExt Condition=" '$(OutputType)' == 'Nupkg' ">.nupkg</TargetExt>
     <TargetExt Condition=" '$(OutputType)' == 'Wixlib' ">.wixlib</TargetExt>
     <TargetExt Condition=" '$(OutputType)' == 'Vsix' ">.vsix</TargetExt>
   </PropertyGroup>
@@ -76,6 +78,8 @@
         SearchPaths="@(PackageSearchPaths)"
         Type="$(PackageType)"
         />
+
+    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; @(PackageOutput->'%(FullPath)')" />
   </Target>
 
   <!--

--- a/src/tools/swix/swc/SimplifiedWixCompiler.cs
+++ b/src/tools/swix/swc/SimplifiedWixCompiler.cs
@@ -105,7 +105,7 @@ namespace WixToolset.Simplified
             {
                 if (this.OutputPath == null)
                 {
-                    messaging.OnError(this, "Package type cannot be inferred from output path. Explicitly specify PackageType in your MSBuild project or -type from the swc.exe command-line. Valid options are: appx, msi, vsix, or wixlib");
+                    messaging.OnError(this, "Package type cannot be inferred from output path. Explicitly specify PackageType in your MSBuild project or -type from the swc.exe command-line. Valid options are: appx, msi, nuget, vsix, or wixlib");
                 }
                 else
                 {
@@ -159,11 +159,11 @@ namespace WixToolset.Simplified
             PackageType type = PackageType.Unknown;
             if (String.IsNullOrEmpty(this.Type))
             {
-                messaging.OnError(this, "A package type must specified. Use the PackageType in your MSBuild project or -type from the swc.exe command-line. Valid options are: appx, msi, vsix or wixlib");
+                messaging.OnError(this, "A package type must specified. Use the PackageType in your MSBuild project or -type from the swc.exe command-line. Valid options are: appx, msi, nuget, vsix or wixlib");
             }
             else if (!SimplifiedWixCompiler.TryConvertPackageType(this.Type, out type))
             {
-                messaging.OnError(this, "Unknown package type specified: {0}. Valid options are: appx, msi, vsix or wixlib", this.Type);
+                messaging.OnError(this, "Unknown package type specified: {0}. Valid options are: appx, msi, nuget, vsix or wixlib", this.Type);
             }
 
             if (type == PackageType.Appx && locales.Count == 0)
@@ -236,7 +236,7 @@ namespace WixToolset.Simplified
             Console.WriteLine("   -o[ut]         specify output file (default: write to current directory)");
             Console.WriteLine("   -sp            ordered list of paths to find source files");
             Console.WriteLine("   -type          type of package to output (default: inferred from -out)");
-            Console.WriteLine("                     values: appx, msi, vsix or wixlib");
+            Console.WriteLine("                     values: appx, msi, nuget, vsix or wixlib");
             Console.WriteLine("   -? | -help     this help information");
             Console.WriteLine();
         }
@@ -282,6 +282,11 @@ namespace WixToolset.Simplified
             {
                 case "appx":
                     type = PackageType.Appx;
+                    break;
+
+                case "nuget":
+                case "nupkg":
+                    type = PackageType.Nuget;
                     break;
 
                 case "msi":

--- a/src/tools/swix/swc/swc.csproj
+++ b/src/tools/swix/swc/swc.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   <copyright file="swc.csproj" company="Outercurve Foundation">
     Copyright (c) 2004, Outercurve Foundation.
@@ -14,7 +14,6 @@
     <RootNamespace>WixToolset</RootNamespace>
     <AssemblyName>swc</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CommandLine.cs" />
@@ -25,15 +24,17 @@
   <ItemGroup>
     <None Include="SimplifiedWiX.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\swcore\swcore.csproj" />
+    <ProjectReference Include="..\swcore\swcore.csproj">
+      <Project>{724901A4-16FF-4759-87A8-FDF85F2C3304}</Project>
+      <Name>swcore</Name>
+    </ProjectReference>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/tools/swix/swcore/AssemblyInfo.cs
+++ b/src/tools/swix/swcore/AssemblyInfo.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Markup;
 
@@ -24,11 +23,13 @@ using System.Windows.Markup;
 [assembly: XmlnsPrefix("http://wixtoolset.org/schemas/v4/swx/appx", "appx")]
 [assembly: XmlnsPrefix("http://wixtoolset.org/schemas/v4/swx/msi", "msi")]
 [assembly: XmlnsPrefix("http://wixtoolset.org/schemas/v4/swx/vsix", "vsix")]
+[assembly: XmlnsPrefix("http://wixtoolset.org/schemas/v4/swx/nuget", "nuget")]
 
 [assembly: XmlnsDefinition("http://wixtoolset.org/schemas/v4/swx", "WixToolset.Simplified.Lexicon")]
 [assembly: XmlnsDefinition("http://wixtoolset.org/schemas/v4/swx/appx", "WixToolset.Simplified.Lexicon.Appx")]
 [assembly: XmlnsDefinition("http://wixtoolset.org/schemas/v4/swx/msi", "WixToolset.Simplified.Lexicon.Msi")]
 [assembly: XmlnsDefinition("http://wixtoolset.org/schemas/v4/swx/vsix", "WixToolset.Simplified.Lexicon.Vsix")]
+[assembly: XmlnsDefinition("http://wixtoolset.org/schemas/v4/swx/nuget", "WixToolset.Simplified.Lexicon.Nuget")]
 
 // Expose our internal types to the unit test assembly.
 //[assembly: InternalsVisibleTo("WixToolset.Simplified.UnitTest.Swcore")]

--- a/src/tools/swix/swcore/CompilerBackend/BackendCompiler.cs
+++ b/src/tools/swix/swcore/CompilerBackend/BackendCompiler.cs
@@ -14,12 +14,14 @@ namespace WixToolset.Simplified.CompilerBackend
     using System.Globalization;
     using System.IO;
     using WixToolset.Simplified.CompilerBackend.Appx;
+    using WixToolset.Simplified.CompilerBackend.Nuget;
     using WixToolset.Simplified.CompilerBackend.Vsix;
     using WixToolset.Simplified.CompilerBackend.Wix;
 
     internal enum CompilerOutputType
     {
         AppxPackage,
+        NugetPackage,
         MsiModule,
         MsiPackage,
         VsixPackage,
@@ -85,6 +87,10 @@ namespace WixToolset.Simplified.CompilerBackend
             {
                 case PackageType.Appx:
                     backend = new AppxBackendCompiler(CompilerOutputType.AppxPackage);
+                    break;
+
+                case PackageType.Nuget:
+                    backend = new NugetBackendCompiler();
                     break;
 
                 case PackageType.Msi:

--- a/src/tools/swix/swcore/CompilerBackend/Nuget/NugetBackendCompiler.cs
+++ b/src/tools/swix/swcore/CompilerBackend/Nuget/NugetBackendCompiler.cs
@@ -1,0 +1,146 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="NugetBackendCompiler.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//-------------------------------------------------------------------------------------------------
+
+namespace WixToolset.Simplified.CompilerBackend.Nuget
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Packaging;
+    using System.Xml.Schema;
+
+    /// <summary>
+    /// Backend compiler that generates .nupkg files.
+    /// </summary>
+    internal class NugetBackendCompiler : BackendCompiler
+    {
+        /// <summary>
+        /// Creates a backend compiler for a specific architecture.
+        /// </summary>
+        internal NugetBackendCompiler() :
+            base(CompilerOutputType.NugetPackage)
+        {
+        }
+
+        /// <summary>
+        /// Generates the final output from a set of intermediates.
+        /// </summary>
+        /// <param name="intermediates">Intermediates that provide data to be generated.</param>
+        /// <param name="outputPath">Path for output file to be generated.</param>
+        public override void Generate(IEnumerable<Intermediate> intermediates, string outputPath)
+        {
+            NugetManifest manifest = new NugetManifest(this);
+
+            manifest.ProcessIntermediates(intermediates);
+            if (this.EncounteredError)
+            {
+                return;
+            }
+
+            manifest.Validate(this.ValidationErrorHandler);
+            if (this.EncounteredError)
+            {
+                string tempPath = Path.GetTempFileName();
+                this.OnMessage(new CompilerMessageEventArgs(CompilerMessage.SavedManifest(tempPath), null, 0, 0));
+
+                this.SaveManifest(manifest, tempPath);
+                return;
+            }
+
+            FileTransfer packageTransfer = FileTransfer.Create(null, Path.GetTempFileName(), outputPath, "NugetPackage", true);
+            using (Package package = Package.Open(packageTransfer.Source, FileMode.Create))
+            {
+                // Add all the manifest files.
+                foreach (PackageFile file in manifest.Files)
+                {
+                    this.OnMessage(new CompilerMessageEventArgs(CompilerMessage.CompressFile(file.SourcePath), file.File.LineNumber));
+
+                    using (Stream fileStream = File.Open(file.SourcePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    {
+                        PackagePart part = package.CreatePart(new Uri(file.PartUri, UriKind.Relative), file.MimeType, CompressionOption.Maximum);
+                        this.SaveStreamToPart(fileStream, part);
+                    }
+                }
+
+                var manifestUri = new Uri(String.Concat("/", manifest.Name, ".nuspec"), UriKind.Relative);
+
+                // Create the manifest relationship
+                package.CreateRelationship(manifestUri, TargetMode.Internal, "http://schemas.microsoft.com/packaging/2010/07/manifest");
+
+                // Save the manifest to the package.
+                using (Stream manifestStream = manifest.GetStream())
+                {
+                    PackagePart part = package.CreatePart(manifestUri, "application/octet", CompressionOption.Maximum);
+                    this.SaveStreamToPart(manifestStream, part);
+                }
+
+                package.PackageProperties.Creator = manifest.Manufacturer;
+                package.PackageProperties.Description = manifest.Description;
+                package.PackageProperties.Identifier = manifest.Name;
+                package.PackageProperties.Version = manifest.Version;
+                package.PackageProperties.Language = manifest.Language;
+                package.PackageProperties.Keywords = manifest.Tags;
+                package.PackageProperties.Title = manifest.DisplayName;
+                package.PackageProperties.LastModifiedBy = "WiX Toolset v#.#.#.#";
+            }
+
+            FileTransfer.ExecuteTransfer(this, packageTransfer);
+        }
+
+        /// <summary>
+        /// Saves the stream to a package part's stream.
+        /// </summary>
+        /// <param name="stream">Stream to save.</param>
+        /// <param name="part">Package part to get the stream.</param>
+        private void SaveStreamToPart(Stream stream, PackagePart part)
+        {
+            using (Stream partStream = part.GetStream(FileMode.Create))
+            {
+                int read = 0;
+                byte[] buffer = new byte[65536];
+                while (0 < (read = stream.Read(buffer, 0, buffer.Length)))
+                {
+                    partStream.Write(buffer, 0, read);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Saves the manifest stream to a file.
+        /// </summary>
+        /// <param name="manifest">Manifest to save.</param>
+        /// <param name="path">Path to save manifest to.</param>
+        private void SaveManifest(NugetManifest manifest, string path)
+        {
+            using (Stream file = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Delete))
+            {
+                using (Stream manifestStream = manifest.GetStream())
+                {
+                    int read = 0;
+                    byte[] buffer = new byte[65536];
+                    while (0 < (read = manifestStream.Read(buffer, 0, buffer.Length)))
+                    {
+                        file.Write(buffer, 0, read);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Callback for XML schema validation errors that are all treated as errors
+        /// because the compiler should have prevented them from being possible.
+        /// </summary>
+        /// <param name="sender">Object sending the validation error.</param>
+        /// <param name="e">Event arguments about the validation error.</param>
+        private void ValidationErrorHandler(object sender, ValidationEventArgs e)
+        {
+            this.OnMessage(new CompilerMessageEventArgs(CompilerMessage.UnexpectedValidationError(e.Message), null, 0, 0));
+        }
+    }
+}

--- a/src/tools/swix/swcore/CompilerBackend/Nuget/NugetManifest.cs
+++ b/src/tools/swix/swcore/CompilerBackend/Nuget/NugetManifest.cs
@@ -1,0 +1,327 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="NugetManifest.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//-------------------------------------------------------------------------------------------------
+
+namespace WixToolset.Simplified.CompilerBackend.Nuget
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+    using System.Xml.Linq;
+    using System.Xml.Schema;
+    using WixToolset.Simplified.Lexicon;
+    using WixToolset.Simplified.Lexicon.Nuget;
+    using IO = System.IO;
+
+    /// <summary>
+    /// Nuget manifest object that manages the creation of the extension.vsixmanifest file.
+    /// </summary>
+    internal class NugetManifest
+    {
+        private static readonly CultureInfo DefaultLanguage = new CultureInfo("en-US");
+
+        public static readonly XNamespace NugetNamespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
+
+        private XDocument document;
+        private NugetBackendCompiler backend;
+
+        public NugetManifest(NugetBackendCompiler backend)
+        {
+            this.backend = backend;
+        }
+
+        /// <summary>
+        /// List of files found while processing intermediates that need to be packaged.
+        /// </summary>
+        public List<PackageFile> Files { get; private set; }
+
+        public string DisplayName { get; private set; }
+
+        public string Description { get; private set; }
+
+        public string Manufacturer { get; private set; }
+
+        public string Name { get; private set; }
+
+        public string Language { get; private set; }
+
+        public string Tags { get; private set; }
+
+        public string Version { get; private set; }
+
+        /// <summary>
+        /// Gets the manifest as a stream.
+        /// </summary>
+        /// <returns>Stream representing the manifest.</returns>
+        public IO.Stream GetStream()
+        {
+            IO.Stream manifestStream = new IO.MemoryStream();
+
+            this.document.Save(manifestStream);
+            manifestStream.Seek(0, IO.SeekOrigin.Begin);
+            return manifestStream;
+        }
+
+        /// <summary>
+        /// Creates the manifest document from the provided intermediates. Discards a previous
+        /// manifest document if present.
+        /// </summary>
+        /// <param name="intermediates">Intermediates to process into the .nuspec file.</param>
+        public void ProcessIntermediates(IEnumerable<Intermediate> intermediates)
+        {
+            this.document = null;
+            this.Files = new List<PackageFile>();
+
+            Package package = null;
+            Metadata metadata = null;
+            Version minNuget = null;
+            Dictionary<string, List<XElement>> groupedDependencies = new Dictionary<string, List<XElement>>();
+            Dictionary<string, List<XElement>> groupedFrameworks = new Dictionary<string, List<XElement>>();
+            Dictionary<string, List<XElement>> groupedReferences = new Dictionary<string, List<XElement>>();
+
+            foreach (Intermediate intermediate in intermediates)
+            {
+                foreach (PackageItem item in intermediate.Items)
+                {
+                    if (item.System)
+                    {
+                        continue;
+                    }
+
+                    // Files are processed differently since we need to go search for them on disk and such.
+                    if (item is File)
+                    {
+                        PackageFile packageFile;
+                        if (PackageFile.TryCreate(backend, (File)item, out packageFile))
+                        {
+                            this.Files.Add(packageFile);
+                        }
+                    }
+                    else if (item is Package)
+                    {
+                        if (package == null)
+                        {
+                            package = (Package)item;
+                        }
+                        else
+                        {
+                            this.backend.OnMessage(new CompilerMessageEventArgs(CompilerMessage.HighlanderElement("Package"), item));
+                        }
+                    }
+                    else if (item is Prerequisite)
+                    {
+                        Prerequisite prereq = (Prerequisite)item;
+                        switch (prereq.On.ToLowerInvariant())
+                        {
+                            case "nuget":
+                                if (null == minNuget)
+                                {
+                                    if (prereq.Version == null)
+                                    {
+                                        this.backend.OnMessage(new CompilerMessageEventArgs(CompilerMessage.RequiredAttribute("Prerequisite", "Version"), prereq));
+                                    }
+                                    else
+                                    {
+                                        minNuget = prereq.Version;
+                                    }
+
+                                    if (prereq.MaxVersion != null)
+                                    {
+                                        this.backend.OnMessage(new CompilerMessageEventArgs(CompilerMessage.InvalidAttributeValue("Prerequisite", "MaxVersion", prereq.MaxVersion.ToString()), prereq));
+                                    }
+                                }
+                                else
+                                {
+                                    this.backend.OnMessage(new CompilerMessageEventArgs(CompilerMessage.HighlanderElementWithAttributeValue("Prerequisite", "On", prereq.On), prereq));
+                                }
+                                break;
+
+                            default:
+                                // TODO: handle this correctly
+                                //xFrameworkAssemblies.Add(new XElement(NugetNamespace + "frameworkAssembly",
+                                //                            new XAttribute("assemblyName", prereq.On)));
+                                break;
+                        }
+                    }
+                    else if (item is Dependency)
+                    {
+                        Dependency dependency = (Dependency)item;
+                        XElement reference = new XElement(NugetNamespace + "reference",
+                            new XAttribute("Id", dependency.Name),
+                            new XElement(NugetNamespace + "Name", dependency.Publisher)
+                            );
+
+                        string targetFramework = String.Empty;
+
+                        if (dependency.Version != null)
+                        {
+                            reference.Add(new XAttribute("MinVersion", dependency.Version.ToString()));
+                        }
+
+                        if (dependency.MaxVersion != null)
+                        {
+                            reference.Add(new XAttribute("MaxVersion", dependency.MaxVersion.ToString()));
+                        }
+
+                        List<XElement> dependencies;
+                        if (!groupedDependencies.TryGetValue(targetFramework, out dependencies))
+                        {
+                            dependencies = new List<XElement>();
+                            groupedDependencies.Add(targetFramework, dependencies);
+                        }
+
+                        dependencies.Add(reference);
+                    }
+                    // TODO: handle references
+                    //else if (item is Reference)
+                    //{
+                    //    Reference reference = (Reference)item;
+                    //    string targetFramework = reference.TargetFramework ?? String.Empty;
+
+                    //    List<XElement> references;
+                    //    if (!groupedReferences.TryGetValue(targetFramework, out references))
+                    //    {
+                    //        references = new List<XElement>();
+                    //        groupedReferences.Add(targetFramework, references);
+                    //    }
+
+                    //    references.Add(new XElement(NugetNamespace + "reference",
+                    //        new XAttribute("file", IO.Path.GetFileName(reference.File))));
+
+                    //    references.Add(reference);
+                    //}
+                    else if (item is Metadata)
+                    {
+                        if (metadata == null)
+                        {
+                            metadata = (Metadata)item;
+                        }
+                        else
+                        {
+                            this.backend.OnMessage(new CompilerMessageEventArgs(CompilerMessage.HighlanderElement("Metadata"), item));
+                        }
+                    }
+                }
+            }
+
+            if (package != null)
+            {
+                this.Description = package.Description;
+
+                this.Name = package.Name;
+
+                this.Language = (null == backend.Languages || backend.Languages.Length == 0 || backend.Languages[0] == DefaultLanguage) ? null : backend.Languages[0].ToString();
+
+                this.Tags = metadata.Tags;
+
+                this.DisplayName = package.DisplayName;
+
+                this.Version = package.Version.ToString();
+
+                XElement xMetadata = new XElement(NugetNamespace + "metadata");
+                if (null != minNuget)
+                {
+                    xMetadata.Add(new XAttribute("minClientVersion", minNuget.ToString()));
+                }
+
+                xMetadata.Add(
+                    new XElement(NugetNamespace + "id", package.Name),
+                    new XElement(NugetNamespace + "version", this.Version),
+                    String.IsNullOrEmpty(package.DisplayName) ? null : new XElement(NugetNamespace + "title", package.DisplayName),
+                    new XElement(NugetNamespace + "authors", package.Manufacturer),
+                    // TODO: Consider whether owner is useful enough to bring back. NuGet Gallery ignores it so no one will ever see this optional data.
+                    //String.IsNullOrEmpty(metadata.Owner) ? null : new XElement(NugetNamespace + "owners", metadata.Owner),
+                    String.IsNullOrEmpty(package.License) ? null : new XElement(NugetNamespace + "licenseUrl", package.License),
+                    String.IsNullOrEmpty(package.About) ? null : new XElement(NugetNamespace + "projectUrl", package.About),
+                    null == package.Image ? null : new XElement(NugetNamespace + "iconUrl", package.Image),
+                    metadata.DevelopmentDependency ? null : new XElement(NugetNamespace + "developmentDependency", "true"),
+                    new XElement(NugetNamespace + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance ? "true" : "false"),
+                    new XElement(NugetNamespace + "description", package.Description),
+                    String.IsNullOrEmpty(metadata.Summary) ? null : new XElement(NugetNamespace + "summary", metadata.Summary),
+                    String.IsNullOrEmpty(metadata.ReleaseNotes) ? null : new XElement(NugetNamespace + "releaseNotes", metadata.ReleaseNotes),
+                    String.IsNullOrEmpty(package.Copyright) ? null : new XElement(NugetNamespace + "copyright", package.Copyright),
+                    this.Language == null ? null : new XElement(NugetNamespace + "language", this.Language),
+                    String.IsNullOrEmpty(metadata.Tags) ? null : new XElement(NugetNamespace + "tags", metadata.Tags)
+                    );
+
+                // Now put the manifest together.
+                if (groupedDependencies != null)
+                {
+                    XElement xDependencies = new XElement(NugetNamespace + "dependencies");
+                    this.AddGroupedElements(xDependencies, groupedDependencies);
+                    xMetadata.Add(xDependencies);
+                }
+
+                if (groupedFrameworks != null)
+                {
+                    XElement xFrameworkAssemblies = new XElement(NugetNamespace + "frameworkAssemblies");
+                    this.AddGroupedElements(xFrameworkAssemblies, groupedFrameworks);
+                    xMetadata.Add(xFrameworkAssemblies);
+                }
+
+                if (groupedReferences != null)
+                {
+                    XElement xReferences = new XElement(NugetNamespace + "references");
+                    this.AddGroupedElements(xReferences, groupedReferences);
+                    xMetadata.Add(xReferences);
+                }
+
+                this.document = new XDocument(new XElement(NugetNamespace + "package", xMetadata));
+            }
+        }
+
+        private void AddGroupedElements(XElement xParent, Dictionary<string, List<XElement>> groupedElements)
+        {
+            List<XElement> xElements = null;
+            if (groupedElements.Count == 1 && groupedElements.TryGetValue(String.Empty, out xElements))
+            {
+                xParent.Add(xElements);
+            }
+            else
+            {
+                foreach (string group in groupedElements.Keys.OrderBy(s => s))
+                {
+                    xElements = groupedElements[group];
+
+                    XElement xGroup = new XElement(NugetNamespace + "group",
+                        String.IsNullOrEmpty(group) ? null : new XAttribute("targetFramework", group),
+                        xElements);
+
+                    xParent.Add(group);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validate the manifest document against the appropriate AppX manifest.
+        /// </summary>
+        /// <param name="eventHandler">Optional event handler to post validation errors.</param>
+        public void Validate(ValidationEventHandler eventHandler)
+        {
+            string resource = "WixToolset.Simplified.CompilerBackend.Nuget.schema.nuget.xsd";
+            XmlSchema schema = XmlSchema.Read(Assembly.GetExecutingAssembly().GetManifestResourceStream(resource), eventHandler);
+            XmlSchemaSet schemas = new XmlSchemaSet();
+            schemas.Add(schema);
+
+            this.document.Validate(schemas, eventHandler);
+        }
+
+        internal static string StripRootFolderReference(string path)
+        {
+            string[] idPath = path.Split(new char[] { ':' }, 2);
+            if (!idPath[0].Equals("ApplicationFolder"))
+            {
+                // TOOD: send warning that we are ignoring all other roots and we always put files in ApplicationFolder
+            }
+
+            return idPath[1].Substring(1); // skip the backslash.
+        }
+    }
+}

--- a/src/tools/swix/swcore/CompilerBackend/Nuget/NugetManifest.cs
+++ b/src/tools/swix/swcore/CompilerBackend/Nuget/NugetManifest.cs
@@ -21,7 +21,7 @@ namespace WixToolset.Simplified.CompilerBackend.Nuget
     using IO = System.IO;
 
     /// <summary>
-    /// Nuget manifest object that manages the creation of the extension.vsixmanifest file.
+    /// Nuget manifest object that manages the creation of the .nuspec file.
     /// </summary>
     internal class NugetManifest
     {
@@ -150,36 +150,36 @@ namespace WixToolset.Simplified.CompilerBackend.Nuget
                                 break;
                         }
                     }
-                    else if (item is Dependency)
-                    {
-                        Dependency dependency = (Dependency)item;
-                        XElement reference = new XElement(NugetNamespace + "reference",
-                            new XAttribute("Id", dependency.Name),
-                            new XElement(NugetNamespace + "Name", dependency.Publisher)
-                            );
+                    // TODO: handle dependencies and references correctly.
+                    //else if (item is Dependency)
+                    //{
+                    //    Dependency dependency = (Dependency)item;
+                    //    XElement reference = new XElement(NugetNamespace + "reference",
+                    //        new XAttribute("Id", dependency.Name),
+                    //        new XElement(NugetNamespace + "Name", dependency.Publisher)
+                    //        );
 
-                        string targetFramework = String.Empty;
+                    //    string targetFramework = String.Empty;
 
-                        if (dependency.Version != null)
-                        {
-                            reference.Add(new XAttribute("MinVersion", dependency.Version.ToString()));
-                        }
+                    //    if (dependency.Version != null)
+                    //    {
+                    //        reference.Add(new XAttribute("MinVersion", dependency.Version.ToString()));
+                    //    }
 
-                        if (dependency.MaxVersion != null)
-                        {
-                            reference.Add(new XAttribute("MaxVersion", dependency.MaxVersion.ToString()));
-                        }
+                    //    if (dependency.MaxVersion != null)
+                    //    {
+                    //        reference.Add(new XAttribute("MaxVersion", dependency.MaxVersion.ToString()));
+                    //    }
 
-                        List<XElement> dependencies;
-                        if (!groupedDependencies.TryGetValue(targetFramework, out dependencies))
-                        {
-                            dependencies = new List<XElement>();
-                            groupedDependencies.Add(targetFramework, dependencies);
-                        }
+                    //    List<XElement> dependencies;
+                    //    if (!groupedDependencies.TryGetValue(targetFramework, out dependencies))
+                    //    {
+                    //        dependencies = new List<XElement>();
+                    //        groupedDependencies.Add(targetFramework, dependencies);
+                    //    }
 
-                        dependencies.Add(reference);
-                    }
-                    // TODO: handle references
+                    //    dependencies.Add(reference);
+                    //}
                     //else if (item is Reference)
                     //{
                     //    Reference reference = (Reference)item;
@@ -300,7 +300,7 @@ namespace WixToolset.Simplified.CompilerBackend.Nuget
         }
 
         /// <summary>
-        /// Validate the manifest document against the appropriate AppX manifest.
+        /// Validate the manifest document against the appropriate NuGet manifest.
         /// </summary>
         /// <param name="eventHandler">Optional event handler to post validation errors.</param>
         public void Validate(ValidationEventHandler eventHandler)
@@ -318,7 +318,7 @@ namespace WixToolset.Simplified.CompilerBackend.Nuget
             string[] idPath = path.Split(new char[] { ':' }, 2);
             if (!idPath[0].Equals("ApplicationFolder"))
             {
-                // TOOD: send warning that we are ignoring all other roots and we always put files in ApplicationFolder
+                // TODO: send warning that we are ignoring all other roots and we always put files in ApplicationFolder
             }
 
             return idPath[1].Substring(1); // skip the backslash.

--- a/src/tools/swix/swcore/CompilerBackend/Nuget/schema/nuget.xsd
+++ b/src/tools/swix/swcore/CompilerBackend/Nuget/schema/nuget.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema id="nuspec"
+    targetNamespace="{0}"
+    elementFormDefault="qualified"
+    xmlns="{0}"
+    xmlns:mstns="{0}"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+    <xs:complexType name="dependency">
+        <xs:attribute name="id" type="xs:string" use="required" />
+        <xs:attribute name="version" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="dependencyGroup">
+        <xs:sequence>
+            <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="dependency">
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="targetFramework" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="reference">
+        <xs:attribute name="file" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="referenceGroup">
+        <xs:sequence>
+            <xs:element name="reference" minOccurs="1" maxOccurs="unbounded" type="reference">
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="targetFramework" type="xs:string" use="optional" />
+    </xs:complexType>
+    
+    <xs:element name="package">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="metadata" maxOccurs="1" minOccurs="1">
+                    <xs:complexType>
+                        <xs:all>
+                            <xs:element name="id" maxOccurs="1" minOccurs="1" type="xs:string" />
+                            <xs:element name="version" maxOccurs="1" minOccurs="1" type="xs:string" />
+                            <xs:element name="title" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="authors" maxOccurs="1" minOccurs="1" type="xs:string" />
+                            <xs:element name="owners" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="licenseUrl" maxOccurs="1" minOccurs="0" type="xs:anyURI" />
+                            <xs:element name="projectUrl" maxOccurs="1" minOccurs="0" type="xs:anyURI" />
+                            <xs:element name="iconUrl" maxOccurs="1" minOccurs="0" type="xs:anyURI" />
+                            <xs:element name="requireLicenseAcceptance" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                            <xs:element name="developmentDependency" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                            <xs:element name="description" maxOccurs="1" minOccurs="1" type="xs:string" />
+                            <xs:element name="summary" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="releaseNotes" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="copyright" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="language" maxOccurs="1" minOccurs="0" type="xs:string" default="en-US" />
+                            <xs:element name="tags" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="dependencies" maxOccurs="1" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="dependency" type="dependency" />
+                                            <xs:element name="group" type="dependencyGroup" />
+                                        </xs:choice>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="frameworkAssemblies" maxOccurs="1" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="frameworkAssembly" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="assemblyName" type="xs:string" use="required" />
+                                                <xs:attribute name="targetFramework" type="xs:string" use="optional" />
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="references" maxOccurs="1" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="reference" type="reference" />
+                                            <xs:element name="group" type="referenceGroup" />
+                                        </xs:choice>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:all>
+                        <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="files" minOccurs="0" maxOccurs="1" nillable="true">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="src" use="required" type="xs:string" />
+                                    <xs:attribute name="target" use="optional" type="xs:string" />
+                                    <xs:attribute name="exclude" use="optional" type="xs:string" />
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/src/tools/swix/swcore/CompilerBackend/Vsix/VsixManifest.cs
+++ b/src/tools/swix/swcore/CompilerBackend/Vsix/VsixManifest.cs
@@ -9,13 +9,13 @@
 
 namespace WixToolset.Simplified.CompilerBackend.Vsix
 {
+    using System;
     using System.Collections.Generic;
     using System.Reflection;
     using System.Xml.Linq;
     using System.Xml.Schema;
-    using WixToolset.Simplified.Lexicon;
     using IO = System.IO;
-    using System;
+    using WixToolset.Simplified.Lexicon;
     using WixToolset.Simplified.Lexicon.Vsix;
 
     /// <summary>

--- a/src/tools/swix/swcore/Lexicon/Nuget/Metadata.cs
+++ b/src/tools/swix/swcore/Lexicon/Nuget/Metadata.cs
@@ -1,5 +1,5 @@
 ﻿//-------------------------------------------------------------------------------------------------
-// <copyright file="PackageType.cs" company="Outercurve Foundation">
+// <copyright file="Metadata.cs" company="Outercurve Foundation">
 //   Copyright (c) 2004, Outercurve Foundation.
 //   This software is released under Microsoft Reciprocal License (MS-RL).
 //   The license and further copyright text can be found in the file
@@ -7,18 +7,19 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-namespace WixToolset.Simplified
+namespace WixToolset.Simplified.Lexicon.Nuget
 {
-    /// <summary>
-    /// Type of the resulting package.
-    /// </summary>
-    public enum PackageType
+    public class Metadata : PackageItem
     {
-        Unknown,
-        Appx,
-        Nuget,
-        Msi,
-        Vsix,
-        Wixlib,
+        public bool DevelopmentDependency { get; set; }
+
+        public string ReleaseNotes { get; set; }
+
+        public bool RequireLicenseAcceptance { get; set; }
+
+        public string Summary { get; set; }
+
+        // TODO: consider creating type converter to make this a string[]
+        public string Tags { get; set; }
     }
 }

--- a/src/tools/swix/swcore/Lexicon/Nuget/Target.cs
+++ b/src/tools/swix/swcore/Lexicon/Nuget/Target.cs
@@ -1,0 +1,36 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="Target.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//-------------------------------------------------------------------------------------------------
+
+namespace WixToolset.Simplified.Lexicon.Nuget
+{
+    using System;
+    using System.Collections.Generic;
+    using Lexicon = WixToolset.Simplified.Lexicon;
+
+    public static class Target
+    {
+        private static Dictionary<Lexicon.Dependency, string> DependencyFramework = new Dictionary<Lexicon.Dependency, string>();
+        private static Dictionary<Lexicon.Prerequisite, string> PrerequisiteFramework = new Dictionary<Lexicon.Prerequisite, string>();
+
+        public static void SetFramework(Lexicon.Prerequisite prerequisite, string framework)
+        {
+            Target.PrerequisiteFramework.Add(prerequisite, framework);
+        }
+
+        public static string SetFramework(Lexicon.Prerequisite prerequisite)
+        {
+            string framework = null;
+            if (Target.PrerequisiteFramework.TryGetValue(prerequisite, out framework))
+            {
+            }
+
+            return framework;
+        }
+    }
+}

--- a/src/tools/swix/swcore/Lexicon/Nuget/Target.cs
+++ b/src/tools/swix/swcore/Lexicon/Nuget/Target.cs
@@ -23,7 +23,7 @@ namespace WixToolset.Simplified.Lexicon.Nuget
             Target.PrerequisiteFramework.Add(prerequisite, framework);
         }
 
-        public static string SetFramework(Lexicon.Prerequisite prerequisite)
+        public static string GetFramework(Lexicon.Prerequisite prerequisite)
         {
             string framework = null;
             if (Target.PrerequisiteFramework.TryGetValue(prerequisite, out framework))

--- a/src/tools/swix/swcore/Lexicon/Package.cs
+++ b/src/tools/swix/swcore/Lexicon/Package.cs
@@ -25,6 +25,18 @@ namespace WixToolset.Simplified.Lexicon
     public class Package : PackageItem
     {
         /// <summary>
+        /// `about` - URL for more information about the package, For example,
+        /// `about="http://wixtoolset.org/"`
+        /// </summary>
+        public string About { get; set; }
+
+        /// <summary>
+        /// `copyright` - copyright information for the package, For example,
+        /// `copyright="Outercurve Foundation"`
+        /// </summary>
+        public string Copyright { get; set; }
+
+        /// <summary>
         /// `displayName` - human readable name for the package. For example,
         /// `displayName="The WiX Toolset"`
         /// </summary>
@@ -50,6 +62,12 @@ namespace WixToolset.Simplified.Lexicon
         /// example, `image=wixlogo.png`
         /// </summary>
         public QualifiedFile Image { get; set; }
+
+        /// <summary>
+        /// `license` - url to license information for the package. For example,
+        /// `license="http://wixtoolset.org/about/license/"`
+        /// </summary>
+        public string License { get; set; }
 
         /// <summary>
         /// `manufacturer` - human readable company name that creates the package.

--- a/src/tools/swix/swcore/Lexicon/Prerequisite.cs
+++ b/src/tools/swix/swcore/Lexicon/Prerequisite.cs
@@ -22,7 +22,7 @@ namespace WixToolset.Simplified.Lexicon
         public Version MaxVersion { get; set; }
 
         /// <summary>
-        /// Name of platform the prequisite targets. For example: os, netfx or vs.
+        /// Name of platform the prequisite targets. For example: os, netfx, nuget or vs.
         /// </summary>
         public string On { get; set; }
 

--- a/src/tools/swix/swcore/swcore.csproj
+++ b/src/tools/swix/swcore/swcore.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   <copyright file="swcore.csproj" company="Outercurve Foundation">
     Copyright (c) 2004, Outercurve Foundation.
@@ -14,7 +14,6 @@
     <RootNamespace>WixToolset.Simplified</RootNamespace>
     <AssemblyName>swcore</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\ParserCore\Error.cs">
       <Link>CompilerFrontend\Parser\Error.cs</Link>
@@ -41,6 +40,8 @@
     <Compile Include="CompilerBackend\Appx\ManifestApplicationItem.cs" />
     <Compile Include="CompilerBackend\Appx\ManifestPackageItem.cs" />
     <Compile Include="CompilerBackend\Appx\AppxPackage.cs" />
+    <Compile Include="CompilerBackend\Nuget\NugetBackendCompiler.cs" />
+    <Compile Include="CompilerBackend\Nuget\NugetManifest.cs" />
     <Compile Include="CompilerBackend\Wix\MurmurHash3.cs" />
     <Compile Include="CompilerBackend\Wix\WixClassId.cs" />
     <Compile Include="CompilerBackend\Wix\WixFileSearch.cs" />
@@ -148,6 +149,8 @@
     <Compile Include="Lexicon\Msi\Ngen.cs" />
     <Compile Include="Lexicon\Msi\NgenPackageItem.cs" />
     <Compile Include="Lexicon\Msi\Property.cs" />
+    <Compile Include="Lexicon\Nuget\Metadata.cs" />
+    <Compile Include="Lexicon\Nuget\Target.cs" />
     <Compile Include="Lexicon\OutprocServer.cs" />
     <Compile Include="Lexicon\Package.cs" />
     <Compile Include="Lexicon\PackageItem.cs" />
@@ -167,14 +170,15 @@
     <Compile Include="PackageType.cs" />
     <Compile Include="SimplifiedCompiler.cs" />
   </ItemGroup>
-
   <ItemGroup>
+    <EmbeddedResource Include="CompilerBackend\Nuget\schema\nuget.xsd">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <None Include="CompilerMessage.msgs">
       <Generator>TypedMessageGenerator</Generator>
       <LastGenOutput>CompilerMessage.Generated.cs</LastGenOutput>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="CompilerMessage.Generated.resx">
       <DependentUpon>CompilerMessage.msgs</DependentUpon>
@@ -186,17 +190,22 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\BlockDeflateStream\BlockDeflateStream.vcxproj" />
-    <ProjectReference Include="..\..\..\DTF\Libraries\Compression.Zip\Compression.Zip.csproj" />
-
+    <ProjectReference Include="..\BlockDeflateStream\BlockDeflateStream.vcxproj">
+      <Project>{FA4862F1-BA70-4F42-82D7-8D298E6006FB}</Project>
+      <Name>WixToolset.BlockDeflateStream</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\DTF\Libraries\Compression.Zip\Compression.Zip.csproj">
+      <Project>{261F2857-B521-42A4-A3E0-B5165F225E50}</Project>
+      <Name>Compression.Zip</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/tools/swix/test/packages.config
+++ b/src/tools/swix/test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="1.9.2" targetFramework="net40" />
+</packages>

--- a/src/tools/swix/test/test.csproj
+++ b/src/tools/swix/test/test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   <copyright file="test.csproj" company="Outercurve Foundation">
     Copyright (c) 2004, Outercurve Foundation.
@@ -157,15 +157,18 @@
     <Reference Include="WixToolset.Dtf.Compression.Zip">
       <HintPath>..\..\bin\dtf\WixToolset.Dtf.Compression.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="xunit">
-      <HintPath>..\..\bin\xUnit\xunit.dll</HintPath>
-    </Reference>
     <ProjectReference Include="..\swc\swc.csproj">
       <Project>{28886709-2988-45B3-8A0F-A419CEE75540}</Project>
       <Name>swc</Name>
     </ProjectReference>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="Data\appx\charms\package.swr">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -191,6 +194,7 @@
     <Content Include="Data\wixlib\inproc\inproc.swr">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/tools/swix/unittests/swcoreTests/RtypeLexerTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/RtypeLexerTests.cs
@@ -7,15 +7,10 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
 using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/RtypeStatementNodeTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/RtypeStatementNodeTests.cs
@@ -7,15 +7,11 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
 using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/RtypeStatementParserTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/RtypeStatementParserTests.cs
@@ -7,15 +7,11 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
 using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/TokenComparer.cs
+++ b/src/tools/swix/unittests/swcoreTests/TokenComparer.cs
@@ -9,11 +9,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using WixToolset.Simplified.ParserCore;
 using Xunit;
-using Xunit.Extensions;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/XmlLexerTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/XmlLexerTests.cs
@@ -7,15 +7,10 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
 using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/XmlStatementNodeTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/XmlStatementNodeTests.cs
@@ -7,15 +7,9 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
-using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {

--- a/src/tools/swix/unittests/swcoreTests/XmlStatementParserTests.cs
+++ b/src/tools/swix/unittests/swcoreTests/XmlStatementParserTests.cs
@@ -7,15 +7,10 @@
 // </copyright>
 //-------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Xunit;
-using Xunit.Extensions;
 using WixToolset.Simplified.CompilerFrontend.Parser;
 using WixToolset.Simplified.ParserCore;
-using System.Reflection;
+using Xunit;
 
 namespace WixToolset.Simplified.UnitTest.Swcore
 {
@@ -376,61 +371,61 @@ namespace WixToolset.Simplified.UnitTest.Swcore
         ////        );
         ////}
 
-////        [Fact]
-////        public void WixlibFileSearchTest()
-////        {
-////            this.TestParser(
-////                @"use msi
-////
-////msi.fileSearch id=fsC component=c00d5a59-1bd1-4f6b-9b2b-27e0ae64020b
-////
-////msi.fileSearch id=fsRK registry=HKLM\Search\Registry\Key\",
-////                Statement(
-////                ////    StatementType.Use,
-////                ////    Token(ParserTokenType.UseKeyword, "use")
-////                ////    .Token(ParserTokenType.Whitespace, " ")
-////                ////    .Token(ParserTokenType.NamespacePrefixDeclaration, "msi")
-////                ////    .Token(ParserTokenType.Whitespace, "\r\n")
-////                ////    )
-////                ////.Statement(
-////                    StatementType.Ignorable,
-////                    Token(ParserTokenType.Whitespace, "\r\n")
-////                    )
-////                .Statement(
-////                    StatementType.Object,
-////                    Token(ParserTokenType.NamespacePrefix, "msi")
-////                    .Token(ParserTokenType.Period, ".")
-////                    .Token(ParserTokenType.Object, "fileSearch")
-////                    .Token(ParserTokenType.Whitespace, " ")
-////                    .Token(ParserTokenType.PropertyName, "id")
-////                    .Token(ParserTokenType.Equals, "=")
-////                    .Token(ParserTokenType.PropertyValue, "fsC")
-////                    .Token(ParserTokenType.Whitespace, " ")
-////                    .Token(ParserTokenType.PropertyName, "component")
-////                    .Token(ParserTokenType.Equals, "=")
-////                    .Token(ParserTokenType.PropertyValue, "c00d5a59-1bd1-4f6b-9b2b-27e0ae64020b")
-////                    .Token(ParserTokenType.Whitespace, "\r\n")
-////                    )
-////                .Statement(
-////                    StatementType.Ignorable,
-////                    Token(ParserTokenType.Whitespace, "\r\n")
-////                    )
-////                .Statement(
-////                    StatementType.Object,
-////                    Token(ParserTokenType.NamespacePrefix, "msi")
-////                    .Token(ParserTokenType.Period, ".")
-////                    .Token(ParserTokenType.Object, "fileSearch")
-////                    .Token(ParserTokenType.Whitespace, " ")
-////                    .Token(ParserTokenType.PropertyName, "id")
-////                    .Token(ParserTokenType.Equals, "=")
-////                    .Token(ParserTokenType.PropertyValue, "fsRK")
-////                    .Token(ParserTokenType.Whitespace, " ")
-////                    .Token(ParserTokenType.PropertyName, "registry")
-////                    .Token(ParserTokenType.Equals, "=")
-////                    .Token(ParserTokenType.PropertyValue, "HKLM\\Search\\Registry\\Key\\")
-////                    )
-////                );
-////        }
+        ////        [Fact]
+        ////        public void WixlibFileSearchTest()
+        ////        {
+        ////            this.TestParser(
+        ////                @"use msi
+        ////
+        ////msi.fileSearch id=fsC component=c00d5a59-1bd1-4f6b-9b2b-27e0ae64020b
+        ////
+        ////msi.fileSearch id=fsRK registry=HKLM\Search\Registry\Key\",
+        ////                Statement(
+        ////                ////    StatementType.Use,
+        ////                ////    Token(ParserTokenType.UseKeyword, "use")
+        ////                ////    .Token(ParserTokenType.Whitespace, " ")
+        ////                ////    .Token(ParserTokenType.NamespacePrefixDeclaration, "msi")
+        ////                ////    .Token(ParserTokenType.Whitespace, "\r\n")
+        ////                ////    )
+        ////                ////.Statement(
+        ////                    StatementType.Ignorable,
+        ////                    Token(ParserTokenType.Whitespace, "\r\n")
+        ////                    )
+        ////                .Statement(
+        ////                    StatementType.Object,
+        ////                    Token(ParserTokenType.NamespacePrefix, "msi")
+        ////                    .Token(ParserTokenType.Period, ".")
+        ////                    .Token(ParserTokenType.Object, "fileSearch")
+        ////                    .Token(ParserTokenType.Whitespace, " ")
+        ////                    .Token(ParserTokenType.PropertyName, "id")
+        ////                    .Token(ParserTokenType.Equals, "=")
+        ////                    .Token(ParserTokenType.PropertyValue, "fsC")
+        ////                    .Token(ParserTokenType.Whitespace, " ")
+        ////                    .Token(ParserTokenType.PropertyName, "component")
+        ////                    .Token(ParserTokenType.Equals, "=")
+        ////                    .Token(ParserTokenType.PropertyValue, "c00d5a59-1bd1-4f6b-9b2b-27e0ae64020b")
+        ////                    .Token(ParserTokenType.Whitespace, "\r\n")
+        ////                    )
+        ////                .Statement(
+        ////                    StatementType.Ignorable,
+        ////                    Token(ParserTokenType.Whitespace, "\r\n")
+        ////                    )
+        ////                .Statement(
+        ////                    StatementType.Object,
+        ////                    Token(ParserTokenType.NamespacePrefix, "msi")
+        ////                    .Token(ParserTokenType.Period, ".")
+        ////                    .Token(ParserTokenType.Object, "fileSearch")
+        ////                    .Token(ParserTokenType.Whitespace, " ")
+        ////                    .Token(ParserTokenType.PropertyName, "id")
+        ////                    .Token(ParserTokenType.Equals, "=")
+        ////                    .Token(ParserTokenType.PropertyValue, "fsRK")
+        ////                    .Token(ParserTokenType.Whitespace, " ")
+        ////                    .Token(ParserTokenType.PropertyName, "registry")
+        ////                    .Token(ParserTokenType.Equals, "=")
+        ////                    .Token(ParserTokenType.PropertyValue, "HKLM\\Search\\Registry\\Key\\")
+        ////                    )
+        ////                );
+        ////        }
 
 
         private static StatementListBuilder<StatementType, ParserTokenType> Statement(StatementType type, TokenListBuilder<ParserTokenType> tokens)

--- a/src/tools/swix/unittests/swcoreTests/packages.config
+++ b/src/tools/swix/unittests/swcoreTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="1.9.2" targetFramework="net40" />
+</packages>

--- a/src/tools/swix/unittests/swcoreTests/swcoreTests.csproj
+++ b/src/tools/swix/unittests/swcoreTests/swcoreTests.csproj
@@ -18,15 +18,11 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\..\bin\xUnit\xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\..\bin\xUnit\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -45,6 +41,12 @@
       <Project>{724901A4-16FF-4759-87A8-FDF85F2C3304}</Project>
       <Name>swcore</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -53,6 +53,7 @@
     <OutputPath_x64>$(BaseOutputPath)x64\</OutputPath_x64>
     <OutputPath_arm>$(BaseOutputPath)arm\</OutputPath_arm>
     <BuiltIncludePath>$(WIX_BUILDROOT)$(WixFlavor)\inc\</BuiltIncludePath>
+    <SwixTargetsPath>$(OutputPath_x86)SimplifiedWiX.targets</SwixTargetsPath>
     <WixToolPath>$(OutputPath_x86)</WixToolPath>
     <WixTargetsPath>$(OutputPath_x86)wix.targets</WixTargetsPath>
     <WixTargets200xPath>$(OutputPath_x86)wix200x.targets</WixTargets200xPath>

--- a/tools/WixBuild.swixproj.props
+++ b/tools/WixBuild.swixproj.props
@@ -19,7 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageSearchPaths Include="$(OriginalOutputPath)" />
+    <PackageSearchPaths Include="$(OutputPath_x86)" />
+    <PackageSearchPaths Include="$(OutputPath_x64)" />
   </ItemGroup>
 
 </Project>

--- a/tools/WixBuild.swixproj.props
+++ b/tools/WixBuild.swixproj.props
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="WixBuild.swixproj.props" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <OriginalOutputPath>$(OutputPath)</OriginalOutputPath>
+    <PackageArchitecture>neutral</PackageArchitecture>
+    <!--<PackageLanguages>neutral</PackageLanguages>-->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);version=$(FullBuildVersionString)</PackagePreprocessorDefinitions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageSearchPaths Include="$(OriginalOutputPath)" />
+  </ItemGroup>
+
+</Project>

--- a/tools/WixBuild.swixproj.targets
+++ b/tools/WixBuild.swixproj.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="WixBuild.swixproj.targets" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$(SwixTargetsPath)" />
+</Project>


### PR DESCRIPTION
This change adds very raw support for NuGet packages to Simplified WiX and support for using Simplified WiX in the WiX Build process. All of that support allows us to create a WixToolset.Tools.swr to create the nuget package for the WiX v4.0 project.  Publishing the built nuget package will be a later change.
