### PR TITLE
Fix #4395 by replacing incorrectly removed AssemblyDefaultHeatExtension.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: Fix #4395 by replacing incorrectly removed AssemblyDefaultHeatExtension attribute from VSHeatExtension.
+
 * MikeGC: Bug #4345: Make IniUtil tolerate ini files that have '[' or ']' in the name of a value
 
 * MikeGC: Fix bug in settings browser that can in certain situations result in an inability to look at history of a conflicting value, and other minor bugfixes

--- a/src/ext/VSExtension/wixext/AssemblyInfo.cs
+++ b/src/ext/VSExtension/wixext/AssemblyInfo.cs
@@ -11,7 +11,11 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
+using WixToolset.Extensions;
+using WixToolset.Tools;
+
 [assembly: AssemblyTitle("WiX Toolset VS Extension")]
 [assembly: AssemblyDescription("WiX Toolset Visual Studio Extension")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
+[assembly: AssemblyDefaultHeatExtension(typeof(VSHeatExtension))]


### PR DESCRIPTION
Simple fix to replace attribute that was incorrectly removed during clean up of most extension code.
