### PR TITLE
Add dropbox support, fix LAN locking issue, make MonUtil support removab...

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+* MikeGC: Feature #4352: Settings Engine now has primitive cloud support (tested with dropbox, should work with other similar products)
+
+* MikeGC: Bug #4401: MonUtil can now monitor removable drives (and allow them to be unplugged)
+
+* MikeGC: Bug #4405: LAN Database no longer has annoying locking issue where one client's connection failure causes everyone to fail to sync for a lengthy period of time
+
 * MikeGC: Bug #4345: Make IniUtil tolerate ini files that have '[' or ']' in the name of a value
 
 * MikeGC: Fix bug in settings browser that can in certain situations result in an inability to look at history of a conflicting value, and other minor bugfixes

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -1487,13 +1487,19 @@ LRESULT CALLBACK BrowseWindow::WndProc(
         fCsEntered = TRUE;
         if (SUCCEEDED(UXDATABASE(dwIndex).hrSyncResult) && NULL != UXDATABASE(dwIndex).pcplConflictProductList)
         {
-            hr = TrayShowBalloon(L"Sync Conflicts", L"Sync conflicts occurred. Click here to open main browser window, and resolve them.", NIIF_WARNING);
-            ExitOnFailure(hr, "Failed to show tray message");
+            hrTemp = TrayShowBalloon(L"Sync Conflicts", L"Sync conflicts occurred. Click here to open main browser window, and resolve them.", NIIF_WARNING);
+            if (FAILED(hrTemp))
+            {
+                LogStringLine(REPORT_STANDARD, "Failed to show tray balloon");
+            }
         }
         else
         {
-            hr = TrayHideBalloon();
-            ExitOnFailure(hr, "Failed to hide tray message");
+            hrTemp = TrayHideBalloon();
+            if (FAILED(hrTemp))
+            {
+                LogStringLine(REPORT_STANDARD, "Failed to hide tray balloon");
+            }
         }
 
         hr = pUX->RefreshSingleDatabaseConflictList(dwIndex);

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -135,6 +135,7 @@ extern "C" HRESULT CFGAPI CfgUninitialize(
         pcdb->dwAppID = DWORD_MAX;
         pcdb->fProductSet = FALSE;
         ReleaseNullStr(pcdb->sczGuid);
+        ReleaseNullStr(pcdb->sczDbCopiedPath);
         ReleaseNullStr(pcdb->sczDbDir);
         ReleaseNullStr(pcdb->sczStreamsDir);
 
@@ -160,7 +161,7 @@ extern "C" HRESULT CFGAPI CfgUninitialize(
 
         if (pcdb->hToken)
         {
-            ::CloseHandle(pcdb->hToken);
+            ReleaseHandle(pcdb->hToken);
         }
 
         LogUninitialize(TRUE);

--- a/src/SettingsEngine/lib/cfgrmote.cpp
+++ b/src/SettingsEngine/lib/cfgrmote.cpp
@@ -259,6 +259,7 @@ extern "C" HRESULT CFGAPI CfgRemoteDisconnect(
     ReleaseStr(pcdb->sczOriginalDbPath);
     ReleaseStr(pcdb->sczOriginalDbDir);
     ReleaseStr(pcdb->sczDbPath);
+    ReleaseStr(pcdb->sczDbCopiedPath);
     ReleaseStr(pcdb->sczDbDir);
     ReleaseStr(pcdb->sczStreamsDir);
 
@@ -358,19 +359,10 @@ static HRESULT RemoteDatabaseInitialize(
     hr = PathGetDirectory(pcdb->sczDbPath, &pcdb->sczDbDir);
     ExitOnFailure(hr, "Failed to copy remote database directory");
 
-    hr = PathConcat(pcdb->sczDbDir, L"LAST_REAL_CHANGE", &pcdb->sczDbChangesPath);
-    ExitOnFailure(hr, "Failed to get db changes path");
-
     if (fCreate)
     {
         hr = DirEnsureExists(pcdb->sczDbDir, NULL);
         ExitOnFailure(hr, "Failed to ensure remote database directory exists after UNC conversion");
-
-        if (!FileExistsEx(pcdb->sczDbChangesPath, NULL))
-        {
-            hr = FileWrite(pcdb->sczDbChangesPath, FILE_ATTRIBUTE_HIDDEN, NULL, 0, NULL);
-            ExitOnFailure1(hr, "Failed to write new db changes file: %ls", pcdb->sczDbChangesPath);
-        }
     }
 
     // Setup expected schema in memory

--- a/src/SettingsEngine/lib/handle.h
+++ b/src/SettingsEngine/lib/handle.h
@@ -43,7 +43,9 @@ struct CFGDB_STRUCT
     LPWSTR sczOriginalDbPath; // The original path to the DB (before converting mounted drives to UNC paths)
     LPWSTR sczOriginalDbDir; // The original path to the DB (before converting mounted drives to UNC paths)
     LPWSTR sczDbPath; // The full path to the database file that was opened
-    LPWSTR sczDbChangesPath; // The full path to the hidden file next to a database which tracks when the last real change to it was
+    // The modified time of the remote db at the moment we copied it. Before we copy it back, we verify nobody else has changed it.
+    FILETIME ftBeforeModify;
+    LPWSTR sczDbCopiedPath; // The full path to the database file that was copied locally (used when remote databases are opened)
     LPWSTR sczDbDir; // The directory this DB was opened or created in
     LPWSTR sczStreamsDir; // The directory where external streams for this database should be stored
     SCE_DATABASE *psceDb;

--- a/src/SettingsEngine/lib/legsync.cpp
+++ b/src/SettingsEngine/lib/legsync.cpp
@@ -809,7 +809,7 @@ static HRESULT DeleteEmptyDirectoryChildren(
 
     do
     {
-        // Safety / silence OACR
+        // Safety / silence code analysis tools
         wfd.cFileName[MAX_PATH - 1] = L'\0';
 
         // Don't use "." or ".."
@@ -1060,7 +1060,7 @@ static HRESULT ReadDirWriteLegacyDbHelp(
 
     do
     {
-        // Safety / silence OACR
+        // Safety / silence code analysis tools
         wfd.cFileName[MAX_PATH - 1] = L'\0';
 
         // Don't use "." or ".."

--- a/src/SettingsEngine/lib/stream.cpp
+++ b/src/SettingsEngine/lib/stream.cpp
@@ -280,6 +280,11 @@ HRESULT StreamCopy(
     ExitOnFailure(hr, "Failed to get stream file path");
 
     hr = FileEnsureCopy(sczStreamPathFrom, sczStreamPathTo, FALSE);
+    if (E_FILENOTFOUND == hr || E_PATHNOTFOUND == hr)
+    {
+        LogStringLine(REPORT_STANDARD, "Stream %ls was missing. If syncing to a cloud-managed directory, this is normal, and autosync (when the file is downloaded to the machine) will automatically fix the situation.", sczStreamPathFrom);
+        ExitFunction1(hr = HRESULT_FROM_WIN32(PEERDIST_ERROR_MISSING_DATA));
+    }
     ExitOnFailure2(hr, "Failed to copy file from %ls to %ls", sczStreamPathFrom, sczStreamPathTo);
 
     hr = SceSetColumnDword(sceRowInsert, BINARY_COMPRESSION, static_cast<DWORD>(cfCompressionFormat));

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -1370,12 +1370,14 @@ extern "C" HRESULT DAPI FileCreateTempW(
     int i = 0;
 
     if (!::GetTempPathW(cchTempPath, wzTempPath))
+    {
         ExitOnLastError(hr, "failed to get temp path");
+    }
 
     for (i = 0; i < 1000 && INVALID_HANDLE_VALUE == hTempFile; ++i)
     {
         hr = StrAllocFormatted(&pwzTempFile, L"%s%s%05d.%s", wzTempPath, wzPrefix, i, wzExtension);
-        ExitOnFailure(hr, "failed to allocate memory for log file");
+        ExitOnFailure(hr, "failed to allocate memory for temp filename");
 
         hTempFile = ::CreateFileW(pwzTempFile, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
         if (INVALID_HANDLE_VALUE == hTempFile)


### PR DESCRIPTION
The main point of this change is to add support for primitive cloud support by syncing over dropbox (or onedrive, etc.).

Along the way, we had to make settings engine monitor all remotes again (not just network remotes) - this is necessary to add dropbox support, but in order not to regress the USB drive scenario, required MonUtil to support monitoring removable drives (and still allow them to be removed).

We also get rid of the silly "last real change" file next to remotes, which was sort of a hack around SQL CE's stupid behavior (it would always modify the database even if you open it just for reading), and which was not a valid solution for the dropbox scenario. Now we copy the DB locally, work on it, then re-upload to temp file in remote directory, then move back to original remote database path as an atomic operation.

A side effect of that "copy locally" part of the change is that now a client syncing to a network remote then loses its connection while doing so, no longer leaves the main database locked (which previously preventing all clients from syncing).

tl;dr - we can now sync over dropbox, and fix a couple of bugs along the way.
