### PR TITLE
Store tools in "bin" folder in NuGet package for consistency with MSI.

### DIFF
--- a/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
+++ b/src/Setup/Nuget/WixToolset.Tools/WixToolset.Tools.swr
@@ -12,7 +12,7 @@ nuget.metadata developmentDependency=true
 folder build\
   file WixToolset.Tools.props source=redirect.wix.nuget.props
 
-folder tools\
+folder tools\bin\
   file candle.exe
   file candle.exe.config
   file dark.exe

--- a/src/tools/WixTasks/redirect.wix.nuget.props
+++ b/src/tools/WixTasks/redirect.wix.nuget.props
@@ -9,6 +9,6 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <WixTargetsPath>$(MSBuildThisFileDirectory)..\tools\wix.targets</WixTargetsPath>
+    <WixTargetsPath>$(MSBuildThisFileDirectory)..\tools\bin\wix.targets</WixTargetsPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The MSI based packages install the WiX toolset in a "bin" folder. The
NuGet package were placing the files in the root of the tools folder.
These inconsistencies made it more difficult to switch from installed
WiX to NuGet WiX since many target files expected the "bin" folder.
