### PR TITLE
Delete settings engine streams safely

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* MikeGC: Bug #4495: Delete settings engine streams safely (only delete after committing the database)
+
 * RobMen: Merge recent changes through WiX v3.9.526.0
 
 * MikeGC: Feature #4352: Settings Engine now has primitive cloud support (tested with dropbox, should work with other similar products)

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -91,6 +91,11 @@ int WINAPI wWinMain(
 
     (void)HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
 
+    if (!IsLogInitialized())
+    {
+        LogInitialize(NULL);
+    }
+
     hr = ProcessCommandLine(lpCmdLine, &commandLineRequest);
     ExitOnFailure(hr, "Failed to process command line");
 

--- a/src/SettingsEngine/lib/cfgadmin.cpp
+++ b/src/SettingsEngine/lib/cfgadmin.cpp
@@ -23,7 +23,6 @@ extern "C" HRESULT CfgAdminInitialize(
     )
 {
     HRESULT hr = S_OK;
-    LPWSTR sczDbDir = NULL;
     LPWSTR sczDbFilePath = NULL;
     CFGDB_STRUCT *pcdb;
 
@@ -81,7 +80,6 @@ extern "C" HRESULT CfgAdminInitialize(
     }
 
 LExit:
-    ReleaseStr(sczDbDir);
     ReleaseStr(sczDbFilePath);
 
     return hr;

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -47,7 +47,10 @@ extern "C" HRESULT CFGAPI CfgInitialize(
         ExitOnNull(vpfBackgroundStatus, hr, E_INVALIDARG, "Background status function pointer must not be NULL");
         ExitOnNull(vpfConflictsFound, hr, E_INVALIDARG, "Conflicts found function pointer must not be NULL");
 
-        LogInitialize(NULL);
+        if (!IsLogInitialized())
+        {
+            LogInitialize(NULL);
+        }
 
         hr = LogOpen(NULL, L"CfgAPI", NULL, L".log", FALSE, TRUE, NULL);
         ExitOnFailure(hr, "Failed to initialize log");
@@ -138,6 +141,7 @@ extern "C" HRESULT CFGAPI CfgUninitialize(
         ReleaseNullStr(pcdb->sczDbCopiedPath);
         ReleaseNullStr(pcdb->sczDbDir);
         ReleaseNullStr(pcdb->sczStreamsDir);
+        ReleaseNullStrArray(pcdb->rgsczStreamsToDelete, pcdb->cStreamsToDelete);
 
         if (s_fXmlInitialized)
         {
@@ -159,10 +163,7 @@ extern "C" HRESULT CFGAPI CfgUninitialize(
             vfComInitialized = FALSE;
         }
 
-        if (pcdb->hToken)
-        {
-            ReleaseHandle(pcdb->hToken);
-        }
+        ReleaseHandle(pcdb->hToken);
 
         LogUninitialize(TRUE);
 

--- a/src/SettingsEngine/lib/cfgrmote.cpp
+++ b/src/SettingsEngine/lib/cfgrmote.cpp
@@ -262,6 +262,7 @@ extern "C" HRESULT CFGAPI CfgRemoteDisconnect(
     ReleaseStr(pcdb->sczDbCopiedPath);
     ReleaseStr(pcdb->sczDbDir);
     ReleaseStr(pcdb->sczStreamsDir);
+    ReleaseNullStrArray(pcdb->rgsczStreamsToDelete, pcdb->cStreamsToDelete);
 
     hr = SceCloseDatabase(pcdb->psceDb);
     ExitOnFailure(hr, "Failed to close remote database");

--- a/src/SettingsEngine/lib/handle.h
+++ b/src/SettingsEngine/lib/handle.h
@@ -87,6 +87,11 @@ struct CFGDB_STRUCT
 
     CFGDB_STRUCT **rgpcdbOpenDatabases;
     DWORD cOpenDatabases;
+
+    // Defer all stream deletes to when the database is closed - deleting a stream before database changes are committed is dangerous in case of rollback,
+    // and remotes don't *really* commit until database is recopied
+    LPWSTR *rgsczStreamsToDelete;
+    DWORD cStreamsToDelete;
 };
 
 HRESULT HandleLock(


### PR DESCRIPTION
Only delete settings engine streams after database commits.

Fix a few other minor bugs along the way that probably aren't worth their own pull request (UI thread issues that could rarely occur, minor correctness things, and ensure logutil is initialized before we could ever call ExitOnFailure).
