### PR TITLE
Feature #3635: Write errors to StdErr

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BMurri: Feature #3635: Write errors to StdErr
+
 ## WixBuild: Version 4.0.2102.0
 
 * RobMen: Merge recent changes through WiX v3.9.901.0

--- a/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
+++ b/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
@@ -76,17 +76,17 @@ namespace WixToolset.Dtf.Tools.MakeSfxCA
             }
             catch (ArgumentException ex)
             {
-                Console.WriteLine("Error: Invalid argument: " + ex.Message);
+                Console.Error.WriteLine("Error: Invalid argument: " + ex.Message);
                 return 1;
             }
             catch (FileNotFoundException ex)
             {
-                Console.WriteLine("Error: Cannot find file: " + ex.Message);
+                Console.Error.WriteLine("Error: Cannot find file: " + ex.Message);
                 return 1;
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Error: Unexpected error: " + ex);
+                Console.Error.WriteLine("Error: Unexpected error: " + ex);
                 return 1;
             }
         }

--- a/src/ext/lux/lux/lux.cs
+++ b/src/ext/lux/lux/lux.cs
@@ -48,20 +48,10 @@ namespace WixToolset.Lux
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("LUX", "lux.exe").Display += Lux.DisplayMessage;
+            Messaging.Instance.InitializeAppName("LUX", "lux.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Lux lux = new Lux();
             return lux.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/ext/lux/nit/nit.cs
+++ b/src/ext/lux/nit/nit.cs
@@ -46,20 +46,10 @@ namespace WixToolset.Lux
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("NIT", "nit.exe").Display += Nit.DisplayMessage;
+            Messaging.Instance.InitializeAppName("NIT", "nit.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Nit nit = new Nit();
             return nit.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/WixUnit/WixUnit.cs
+++ b/src/tools/WixUnit/WixUnit.cs
@@ -292,7 +292,7 @@ namespace WixToolset.Unit
                         Console.WriteLine();
                         Console.WriteLine("Re-run the failed tests with the -rf option");
                         Console.WriteLine();
-                        Console.WriteLine("Failed {0} out of {1} unit test{2} ({3} seconds).", this.failedUnitTests.Count, this.totalUnitTests, (1 != this.completedUnitTests ? "s" : ""), elapsedTime);
+                        Console.Error.WriteLine("Failed {0} out of {1} unit test{2} ({3} seconds).", this.failedUnitTests.Count, this.totalUnitTests, (1 != this.completedUnitTests ? "s" : ""), elapsedTime);
 
                         using (XmlWriter writer = XmlWriter.Create(this.failedTestsFile))
                         {

--- a/src/tools/candle/candle.cs
+++ b/src/tools/candle/candle.cs
@@ -42,20 +42,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("CNDL", "candle.exe").Display += Candle.DisplayMessage;
+            Messaging.Instance.InitializeAppName("CNDL", "candle.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Candle candle = new Candle();
             return candle.Execute(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         private int Execute(string[] args)

--- a/src/tools/dark/dark.cs
+++ b/src/tools/dark/dark.cs
@@ -66,20 +66,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("DARK", "dark.exe").Display += Dark.DisplayMessage;
+            Messaging.Instance.InitializeAppName("DARK", "dark.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Dark dark = new Dark();
             return dark.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>
@@ -258,7 +248,7 @@ namespace WixToolset.Tools
                     {
                         if (!decompiler.DeleteTempFiles())
                         {
-                            Console.WriteLine(DarkStrings.WAR_FailedToDeleteTempDir, decompiler.TempFilesLocation);
+                            Console.Error.WriteLine(DarkStrings.WAR_FailedToDeleteTempDir, decompiler.TempFilesLocation);
                         }
                     }
                     else
@@ -273,7 +263,7 @@ namespace WixToolset.Tools
                     {
                         if (!unbinder.DeleteTempFiles())
                         {
-                            Console.WriteLine(DarkStrings.WAR_FailedToDeleteTempDir, unbinder.TempFilesLocation);
+                            Console.Error.WriteLine(DarkStrings.WAR_FailedToDeleteTempDir, unbinder.TempFilesLocation);
                         }
                     }
                     else

--- a/src/tools/heat/heat.cs
+++ b/src/tools/heat/heat.cs
@@ -63,20 +63,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("HEAT", "heat.exe").Display += Heat.DisplayMessage;
+            Messaging.Instance.InitializeAppName("HEAT", "heat.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Heat heat = new Heat();
             return heat.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/insignia/insignia.cs
+++ b/src/tools/insignia/insignia.cs
@@ -58,20 +58,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("INSG", "Insignia.exe").Display += Insignia.DisplayMessage;
+            Messaging.Instance.InitializeAppName("INSG", "Insignia.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Insignia insignia = new Insignia();
             return insignia.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -40,20 +40,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("LGHT", "light.exe").Display += Light.DisplayMessage;
+            Messaging.Instance.InitializeAppName("LGHT", "light.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Light light = new Light();
             return light.Execute(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/lit/lit.cs
+++ b/src/tools/lit/lit.cs
@@ -35,20 +35,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("LIT", "lit.exe").Display += Lit.DisplayMessage;
+            Messaging.Instance.InitializeAppName("LIT", "lit.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Lit lit = new Lit();
             return lit.Execute(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         private int Execute(string[] args)

--- a/src/tools/melt/melt.cs
+++ b/src/tools/melt/melt.cs
@@ -69,20 +69,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("MELT", "melt.exe").Display += Melt.DisplayMessage;
+            Messaging.Instance.InitializeAppName("MELT", "melt.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Melt melt = new Melt();
             return melt.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>
@@ -242,7 +232,7 @@ namespace WixToolset.Tools
                     {
                         if (!decompiler.DeleteTempFiles())
                         {
-                            Console.WriteLine(MeltStrings.WAR_FailedToDeleteTempDir, decompiler.TempFilesLocation);
+                            Console.Error.WriteLine(MeltStrings.WAR_FailedToDeleteTempDir, decompiler.TempFilesLocation);
                         }
                     }
                     else
@@ -257,7 +247,7 @@ namespace WixToolset.Tools
                     {
                         if (!unbinder.DeleteTempFiles())
                         {
-                            Console.WriteLine(MeltStrings.WAR_FailedToDeleteTempDir, unbinder.TempFilesLocation);
+                            Console.Error.WriteLine(MeltStrings.WAR_FailedToDeleteTempDir, unbinder.TempFilesLocation);
                         }
                     }
                     else

--- a/src/tools/pyro/pyro.cs
+++ b/src/tools/pyro/pyro.cs
@@ -41,20 +41,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("PYRO", "pyro.exe").Display += Pyro.DisplayMessage;
+            Messaging.Instance.InitializeAppName("PYRO", "pyro.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Pyro pyro = new Pyro();
             return pyro.Execute(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/retina/retina.cs
+++ b/src/tools/retina/retina.cs
@@ -54,20 +54,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("RETI", "retina.exe").Display += Retina.DisplayMessage;
+            Messaging.Instance.InitializeAppName("RETI", "retina.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Retina retina = new Retina();
             return retina.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>

--- a/src/tools/shine/CommandLine.cs
+++ b/src/tools/shine/CommandLine.cs
@@ -186,7 +186,7 @@ namespace WixToolset.Shine
                             break;
 
                         default:
-                            Console.WriteLine("Unknown command line parameter: {0}", arg);
+                            Console.Error.WriteLine("Unknown command line parameter: {0}", arg);
                             cmdLine.ShowHelp = true;
                             break;
                     }
@@ -197,7 +197,7 @@ namespace WixToolset.Shine
                 }
                 else
                 {
-                    Console.WriteLine("Unknown command line parameter: {0}", arg);
+                    Console.Error.WriteLine("Unknown command line parameter: {0}", arg);
                     cmdLine.ShowHelp = true;
                 }
             }

--- a/src/tools/shine/shine.cs
+++ b/src/tools/shine/shine.cs
@@ -51,7 +51,7 @@ namespace WixToolset.Shine
 
             if (String.IsNullOrEmpty(cmdLine.Dgml))
             {
-                Console.WriteLine("Displaying graph to console is not supported yet. Use the -dgml switch.");
+                Console.Error.WriteLine("Displaying graph to console is not supported yet. Use the -dgml switch.");
             }
             else
             {

--- a/src/tools/smoke/smoke.cs
+++ b/src/tools/smoke/smoke.cs
@@ -70,20 +70,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("SMOK", "smoke.exe").Display += Smoke.DisplayMessage;
+            Messaging.Instance.InitializeAppName("SMOK", "smoke.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Smoke smoke = new Smoke();
             return smoke.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>
@@ -215,7 +205,7 @@ namespace WixToolset.Tools
                         {
                             if (!validator.DeleteTempFiles())
                             {
-                                Console.WriteLine(SmokeStrings.WAR_FailedToDeleteTempDir, validator.TempFilesLocation);
+                                Console.Error.WriteLine(SmokeStrings.WAR_FailedToDeleteTempDir, validator.TempFilesLocation);
                             }
                         }
                         else

--- a/src/tools/swix/swc/Messaging.cs
+++ b/src/tools/swix/swc/Messaging.cs
@@ -94,10 +94,22 @@ namespace WixToolset.Simplified
             }
 
             string messageType = e.Message.Type.ToString().ToLowerInvariant();
-            Console.WriteLine(String.IsNullOrEmpty(fileName) ?
-                              "{1} {2}{3:0000}: {4}" :
-                              "{0} : {1} {2}{3:0000}: {4}",
-                              fileName, messageType, "SWIX", e.Message.Id, e.Message.Message);
+            System.IO.TextWriter stream = null;
+            switch (e.Message.Type)
+            {
+            case CompilerMessage.CompilerMessageType.Error:
+            case CompilerMessage.CompilerMessageType.Warning:
+                stream = Console.Error;
+                break;
+            default:
+                stream = Console.Out;
+                break;
+            }
+
+            stream.WriteLine(String.IsNullOrEmpty(fileName) ?
+                             "{1} {2}{3:0000}: {4}" :
+                             "{0} : {1} {2}{3:0000}: {4}",
+                             fileName, messageType, "SWIX", e.Message.Id, e.Message.Message);
 
             if (e.Message.Type == CompilerMessage.CompilerMessageType.Error)
             {

--- a/src/tools/torch/torch.cs
+++ b/src/tools/torch/torch.cs
@@ -72,20 +72,10 @@ namespace WixToolset.Tools
         public static int Main(string[] args)
         {
             AppCommon.PrepareConsoleForLocalization();
-            Messaging.Instance.InitializeAppName("TRCH", "torch.exe").Display += Torch.DisplayMessage;
+            Messaging.Instance.InitializeAppName("TRCH", "torch.exe").Display += AppCommon.ConsoleDisplayMessage;
 
             Torch torch = new Torch();
             return torch.Run(args);
-        }
-
-        /// <summary>
-        /// Handler for display message events.
-        /// </summary>
-        /// <param name="sender">Sender of message.</param>
-        /// <param name="e">Event arguments containing message to display.</param>
-        private static void DisplayMessage(object sender, DisplayEventArgs e)
-        {
-            Console.WriteLine(e.Message);
         }
 
         /// <summary>
@@ -370,7 +360,7 @@ namespace WixToolset.Tools
                     {
                         if (!binder.DeleteTempFiles())
                         {
-                            Console.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, binder.TempFilesLocation);
+                            Console.Error.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, binder.TempFilesLocation);
                         }
                     }
                     else
@@ -385,7 +375,7 @@ namespace WixToolset.Tools
                     {
                         if (!unbinder.DeleteTempFiles())
                         {
-                            Console.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, binder.TempFilesLocation);
+                            Console.Error.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, binder.TempFilesLocation);
                         }
                     }
                     else
@@ -408,7 +398,7 @@ namespace WixToolset.Tools
                         }
                         catch
                         {
-                            Console.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, tempFileCollection.BasePath);
+                            Console.Error.WriteLine(TorchStrings.WAR_FailedToDeleteTempDir, tempFileCollection.BasePath);
                         }
                     }
                     else

--- a/src/tools/wix/AppCommon.cs
+++ b/src/tools/wix/AppCommon.cs
@@ -86,6 +86,25 @@ namespace WixToolset
         }
 
         /// <summary>
+        /// Handler for display message events.
+        /// </summary>
+        /// <param name="sender">Sender of message.</param>
+        /// <param name="e">Event arguments containing message to display.</param>
+        public static void ConsoleDisplayMessage(object sender, DisplayEventArgs e)
+        {
+            switch (e.Level)
+            {
+            case MessageLevel.Warning:
+            case MessageLevel.Error:
+                Console.Error.WriteLine(e.Message);
+                break;
+            default:
+                Console.WriteLine(e.Message);
+                break;
+            }
+        }
+
+        /// <summary>
         /// Creates and returns the string for CreatingApplication field (MSI Summary Information Stream).
         /// </summary>
         /// <remarks>It reads the AssemblyProductAttribute and AssemblyVersionAttribute of executing assembly

--- a/src/tools/wix/ConsoleMessageHandler.cs
+++ b/src/tools/wix/ConsoleMessageHandler.cs
@@ -64,7 +64,16 @@ namespace WixToolset
 #if DEBUG
                 Debugger.Log((int)mea.Level, this.shortAppName, string.Concat(message, "\n"));
 #endif
-                Console.WriteLine(message);
+                switch (mea.Level)
+                {
+                case MessageLevel.Warning:
+                case MessageLevel.Error:
+                    Console.Error.WriteLine(message);
+                    break;
+                default:
+                    Console.WriteLine(message);
+                    break;
+                }
             }
         }
 

--- a/src/tools/wix/Msi/Database.cs
+++ b/src/tools/wix/Msi/Database.cs
@@ -264,7 +264,7 @@ namespace WixToolset.Msi
                         break;
                     }
 
-                    Console.WriteLine(String.Format("Failed to create the database. Info: {0}. Retrying ({1} of {2})", String.Join(", ", exception.ErrorInfo), i, retryLimit));
+                    Console.Error.WriteLine(String.Format("Failed to create the database. Info: {0}. Retrying ({1} of {2})", String.Join(", ", exception.ErrorInfo), i, retryLimit));
                     Thread.Sleep(retryWait);
                 }
             }

--- a/src/tools/wixcop/Inspector.cs
+++ b/src/tools/wixcop/Inspector.cs
@@ -1079,13 +1079,13 @@ namespace Microsoft.Tools.WindowsInstaller.Tools
 
             if (null != node)
             {
-                Console.WriteLine("{0}({1}) : {2} WXCP{3:0000} : {4} ({5})", this.sourceFile, ((IXmlLineInfo)node).LineNumber, warningError, (int)inspectorTestType, String.Format(CultureInfo.CurrentCulture, message, args), inspectorTestType.ToString());
+                Console.Error.WriteLine("{0}({1}) : {2} WXCP{3:0000} : {4} ({5})", this.sourceFile, ((IXmlLineInfo)node).LineNumber, warningError, (int)inspectorTestType, String.Format(CultureInfo.CurrentCulture, message, args), inspectorTestType.ToString());
             }
             else
             {
                 string source = (null == this.sourceFile ? "wixcop.exe" : this.sourceFile);
 
-                Console.WriteLine("{0} : {1} WXCP{2:0000} : {3} ({4})", source, warningError, (int)inspectorTestType, String.Format(CultureInfo.CurrentCulture, message, args), inspectorTestType.ToString());
+                Console.Error.WriteLine("{0} : {1} WXCP{2:0000} : {3} ({4})", source, warningError, (int)inspectorTestType, String.Format(CultureInfo.CurrentCulture, message, args), inspectorTestType.ToString());
             }
 
             return true;

--- a/src/tools/wixcop/WixCop.cs
+++ b/src/tools/wixcop/WixCop.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Tools.WindowsInstaller.Tools
                 {
                     if (!this.searchPatternResults.ContainsKey(searchPattern))
                     {
-                        Console.WriteLine("Could not find file \"{0}\"", searchPattern);
+                        Console.Error.WriteLine("Could not find file \"{0}\"", searchPattern);
                         errors++;
                     }
                 }
@@ -206,7 +206,7 @@ namespace Microsoft.Tools.WindowsInstaller.Tools
             }
             catch (Exception e)
             {
-                Console.WriteLine("wixcop.exe : fatal error WXCP0001 : {0}\r\n\n\nStack Trace:\r\n{1}", e.Message, e.StackTrace);
+                Console.Error.WriteLine("wixcop.exe : fatal error WXCP0001 : {0}\r\n\n\nStack Trace:\r\n{1}", e.Message, e.StackTrace);
 
                 return 1;
             }


### PR DESCRIPTION
Implements feature [3635](http://wixtoolset.org/issues/3635/). In general, errors and warnings are pushed to the stderr stream, all remaining output remains on stdout. This is a v4 only feature, it should NOT be ported back to v3.
