### PR TITLE
Replace devenv /setup call with fast extension update mechanism.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: Add TouchFile custom action.
+
 ## WixBuild: Version 4.0.2102.0
 
 * RobMen: Merge recent changes through WiX v3.9.901.0

--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: Replace devenv /setup call with fast extension update mechanism.
+
 * RobMen: Add TouchFile custom action.
 
 ## WixBuild: Version 4.0.2102.0

--- a/src/Setup/VotiveMsi/2012.wxs
+++ b/src/Setup/VotiveMsi/2012.wxs
@@ -20,17 +20,16 @@
         <PropertyRef Id="VS2012_ROOT_FOLDER" />
         <PropertyRef Id="VS2012_SCHEMAS_DIR" />
 
-        <CustomActionRef Id="VS2012Setup" />
-        <UI>
-            <ProgressText Action="VS2012Setup" Template="[1]">Updating Visual Studio 2012 registration</ProgressText>
-        </UI>
-
-      <ComponentGroup Id="Votive2012Components">
+        <ComponentGroup Id="Votive2012Components">
             <ComponentGroupRef Id="Votive2010BinaryComponents"/>
             <ComponentGroupRef Id="Votive2012ExtensionComponents"/>
             <ComponentGroupRef Id="Votive2012ItemTemplateComponents" />
             <ComponentGroupRef Id="Votive2012ProjectTemplateComponents" />
         </ComponentGroup>
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS2012_EXTENSIONS_DIR" />
 
         <ComponentGroup Id="Votive$(var.VsVersion)ExtensionComponents" Directory="VsExtensions$(var.VsVersion)WixVersionFolder">
             <Component>
@@ -39,13 +38,16 @@
 
             <Component>
                 <File Id="Votive$(var.VsVersion).pkgdef" Source="votive2010.pkgdef"/>
+                <util:TouchFile OnInstall="yes" OnReinstall="yes" OnUninstall="yes" Path="[VS2012_EXTENSIONS_DIR]extensions.configurationchanged" />
             </Component>
 
             <Component>
                 <File Id="wix$(var.VsVersion).ico" Name="wix.ico" Source="Votive\Icons\ProjectFile.ico"/>
             </Component>
         </ComponentGroup>
+    </Fragment>
 
+    <Fragment>
         <ComponentGroup Id="Votive$(var.VsVersion)ItemTemplateComponents" Directory="VsItemTemplatesWix$(var.VsVersion)Folder">
             <Component>
                 <File Id="BlankFile$(var.VsVersion).zip" Source="templates\BlankFile.zip" />
@@ -60,7 +62,9 @@
                 <File Id="TextFile$(var.VsVersion).zip" Source="templates\TextFile.zip" />
             </Component>
         </ComponentGroup>
+    </Fragment>
 
+    <Fragment>
         <ComponentGroup Id="Votive$(var.VsVersion)ProjectTemplateComponents" Directory="VsProjectTemplatesWix$(var.VsVersion)Folder">
             <Component>
                 <File Id="WixLibrary$(var.VsVersion).zip" Source="templates\WixLibrary.zip" />

--- a/src/Setup/VotiveMsi/2013.wxs
+++ b/src/Setup/VotiveMsi/2013.wxs
@@ -20,11 +20,6 @@
         <PropertyRef Id="VS2013_ROOT_FOLDER" />
         <PropertyRef Id="VS2013_SCHEMAS_DIR" />
 
-        <CustomActionRef Id="VS2013Setup" />
-        <UI>
-            <ProgressText Action="VS2013Setup" Template="[1]">Updating Visual Studio 2013 registration</ProgressText>
-        </UI>
-
         <ComponentGroup Id="Votive2013Components">
             <ComponentGroupRef Id="Votive2010BinaryComponents"/>
             <ComponentGroupRef Id="Votive2013ExtensionComponents"/>
@@ -34,6 +29,8 @@
     </Fragment>
 
     <Fragment>
+        <PropertyRef Id="VS2013_EXTENSIONS_DIR" />
+
         <ComponentGroup Id="Votive$(var.VsVersion)ExtensionComponents" Directory="VsExtensions$(var.VsVersion)MicrosoftWix">
             <Component>
                 <File Id="extension$(var.VsVersion).vsixmanifest" Source="extension.vsixmanifest"/>
@@ -41,6 +38,7 @@
 
             <Component>
                 <File Id="Votive$(var.VsVersion).pkgdef" Source="votive2010.pkgdef"/>
+                <util:TouchFile OnInstall="yes" OnReinstall="yes" OnUninstall="yes" Path="[VS2013_EXTENSIONS_DIR]extensions.configurationchanged" />
             </Component>
 
             <Component>

--- a/src/Setup/VotiveMsi/FileAssociations.wxs
+++ b/src/Setup/VotiveMsi/FileAssociations.wxs
@@ -76,4 +76,32 @@
             </Component>
         </ComponentGroup>
     </Fragment>
+
+    <Fragment>
+        <Property Id="LATEST_DEVENV_EXE" Secure="yes" />
+        <Property Id="LATEST_DEVENV_EXE_COMMAND" Secure="yes" />
+
+        <PropertyRef Id="VS2010DEVENV" />
+        <PropertyRef Id="VS2012DEVENV" />
+        <PropertyRef Id="VS2013DEVENV" />
+
+        <CustomAction Id="CA_SetLatestDevenv_2010" Property="LATEST_DEVENV_EXE" Value="[VS2010DEVENV]"/>
+        <CustomAction Id="CA_SetLatestDevenv_2012" Property="LATEST_DEVENV_EXE" Value="[VS2012DEVENV]" />
+        <CustomAction Id="CA_SetLatestDevenv_2013" Property="LATEST_DEVENV_EXE" Value="[VS2013DEVENV]" />
+
+        <CustomAction Id="CA_SetLatestDevenvCommand_2010" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2010"/>
+        <CustomAction Id="CA_SetLatestDevenvCommand_2012" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2012"/>
+        <CustomAction Id="CA_SetLatestDevenvCommand_2013" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2013"/>
+
+        <!-- Install Sequences -->
+        <InstallExecuteSequence>
+            <Custom Action="CA_SetLatestDevenv_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenv_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenv_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
+
+            <Custom Action="CA_SetLatestDevenvCommand_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenvCommand_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenvCommand_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
+        </InstallExecuteSequence>
+    </Fragment>
 </Wix>

--- a/src/Setup/VotiveMsi/VotiveMsi.wxs
+++ b/src/Setup/VotiveMsi/VotiveMsi.wxs
@@ -58,32 +58,4 @@
             <?endif?>
         </Feature>
     </Product>
-
-    <Fragment>
-        <Property Id="LATEST_DEVENV_EXE" Secure="yes" />
-        <Property Id="LATEST_DEVENV_EXE_COMMAND" Secure="yes" />
-
-        <PropertyRef Id="VS2010DEVENV" />
-        <PropertyRef Id="VS2012DEVENV" />
-        <PropertyRef Id="VS2013DEVENV" />
-
-        <CustomAction Id="CA_SetLatestDevenv_2010" Property="LATEST_DEVENV_EXE" Value="[VS2010DEVENV]"/>
-        <CustomAction Id="CA_SetLatestDevenv_2012" Property="LATEST_DEVENV_EXE" Value="[VS2012DEVENV]" />
-        <CustomAction Id="CA_SetLatestDevenv_2013" Property="LATEST_DEVENV_EXE" Value="[VS2013DEVENV]" />
-
-        <CustomAction Id="CA_SetLatestDevenvCommand_2010" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2010"/>
-        <CustomAction Id="CA_SetLatestDevenvCommand_2012" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2012"/>
-        <CustomAction Id="CA_SetLatestDevenvCommand_2013" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2013"/>
-
-        <!-- Install Sequences -->
-        <InstallExecuteSequence>
-            <Custom Action="CA_SetLatestDevenv_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenv_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenv_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
-
-            <Custom Action="CA_SetLatestDevenvCommand_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenvCommand_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenvCommand_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
-        </InstallExecuteSequence>
-    </Fragment>
 </Wix>

--- a/src/ext/UtilExtension/wixext/Data/tables.xml
+++ b/src/ext/UtilExtension/wixext/Data/tables.xml
@@ -168,7 +168,17 @@
         <columnDefinition name="RebootMessage" type="string" length="255" nullable="yes"
                 category="text" description="Message to show to users when rebooting if failure action is REBOOT."/>
     </tableDefinition>
-    <tableDefinition name="User" createSymbols="yes">
+  <tableDefinition name="WixTouchFile" createSymbols="yes">
+    <columnDefinition name="WixTouchFile" type="string" length="72" primaryKey="yes" modularize="column"
+            category="identifier" description="Identifier for the WixTouchFile row in the package."/>
+    <columnDefinition name="Component_" type="string" length="72" modularize="column"
+            keyTable="Component" keyColumn="1" category="identifier" description="Foreign key into the Component table used to determine install state"/>
+    <columnDefinition name="Path" type="string" length="255" modularize="property"
+            category="formatted" description="Formatted column that resolves to the path to touch."/>
+    <columnDefinition name="Attributes" type="number" length="2"
+            minValue="1" maxValue="63" description="1 == Touch only when the associated component is being installed, 2 == Touch only when the associated component is being repaired , 4 == Touch only when the associated component is being removed, 16 = path is in 64-bit location, 32 = touching the file is vital."/>
+  </tableDefinition>
+  <tableDefinition name="User" createSymbols="yes">
         <columnDefinition name="User" type="string" length="72" primaryKey="yes" modularize="column"
                 category="identifier" description="Primary key, non-localized token"/>
         <columnDefinition name="Component_" type="string" length="72" nullable="yes" modularize="column"

--- a/src/ext/UtilExtension/wixext/Xsd/util.xsd
+++ b/src/ext/UtilExtension/wixext/Xsd/util.xsd
@@ -1197,6 +1197,46 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <xs:element name="TouchFile">
+    <xs:annotation>
+      <xs:documentation>Updates the last modified date/time of a file.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Component" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier for the touch file operation. If the identifier is not specified it will be generated.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Path" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path of the file to update. This value is formatted.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnInstall" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>Specifies whether or not the modified time of the file should be updated on install. If the OnInstall, OnReinstall and OnUninstall attributes are all absent the default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnReinstall" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>Specifies whether or not the modified time of the file should be updated on reinstall. If the OnInstall, OnReinstall and OnUninstall attributes are all absent the default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnUninstall" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>Specifies whether or not the modified time of the file should be updated on uninstall. If the OnInstall, OnReinstall and OnUninstall attributes are all absent the default is 'no'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Nonvital" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>Indicates the installation will not fail if the modified time of the file cannot be updated. The default is 'no'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="User">
     <xs:annotation>
       <xs:documentation>User for all kinds of things.  When it is not nested under a component it is included in the MSI so it can be referenced by other elements such as the User attribute in the AppPool element.  When it is nested under a Component element, the User will be created on install and can also be used for reference.</xs:documentation>

--- a/src/ext/UtilExtension/wixlib/UtilExtension_Platform.wxi
+++ b/src/ext/UtilExtension/wixlib/UtilExtension_Platform.wxi
@@ -144,6 +144,18 @@
   </Fragment>
 
   <Fragment>
+    <CustomAction Id="WixTouchFileDuringInstall" BinaryKey="WixCA$(var.Suffix)" DllEntry="WixTouchFileDuringInstall" Execute="immediate" Return="check" SuppressModularization="yes" />
+    <CustomAction Id="WixTouchFileDuringUninstall" BinaryKey="WixCA$(var.Suffix)" DllEntry="WixTouchFileDuringUninstall" Execute="immediate" Return="check" SuppressModularization="yes" />
+    <CustomAction Id="WixExecuteTouchFile" BinaryKey="WixCA$(var.Suffix)" DllEntry="WixExecuteTouchFile" Execute="deferred" Impersonate="no" Return="check" SuppressModularization="yes" />
+    <CustomAction Id="WixRollbackTouchFile" BinaryKey="WixCA$(var.Suffix)" DllEntry="WixExecuteTouchFile" Execute="rollback" Impersonate="no" Return="check" SuppressModularization="yes" />
+
+    <InstallExecuteSequence>
+      <Custom Action="WixTouchFileDuringUninstall" Before="RemoveFiles" Overridable="yes" />
+      <Custom Action="WixTouchFileDuringInstall" After="InstallFiles" Overridable="yes" />
+    </InstallExecuteSequence>
+  </Fragment>
+
+  <Fragment>
     <UIRef Id="XmlFileErrorsText" />
 
     <CustomAction Id="SchedXmlFile$(var.Suffix)" BinaryKey="WixCA$(var.Suffix)" DllEntry="SchedXmlFile" Execute="immediate" Return="check" SuppressModularization="yes" />

--- a/src/ext/ca/wixca/dll/TouchFile.cpp
+++ b/src/ext/ca/wixca/dll/TouchFile.cpp
@@ -1,0 +1,318 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="TouchFile.cpp" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+//    TouchFile custom action
+// </summary>
+//-------------------------------------------------------------------------------------------------
+#include "precomp.h"
+
+LPCWSTR vcsTouchFileQuery = L"SELECT `WixTouchFile`, `Component_`, `Path`, `Attributes` FROM `WixTouchFile`";
+enum TOUCH_FILE_QUERY { tfqId = 1, tfqComponent, tfqPath, tfqTouchFileAttributes };
+
+enum TOUCH_FILE_ATTRIBUTE
+{
+    TOUCH_FILE_ATTRIBUTE_ON_INSTALL = 0x01,
+    TOUCH_FILE_ATTRIBUTE_ON_REINSTALL = 0x02,
+    TOUCH_FILE_ATTRIBUTE_ON_UNINSTALL = 0x04,
+    TOUCH_FILE_ATTRIBUTE_64BIT = 0x10,
+    TOUCH_FILE_ATTRIBUTE_VITAL = 0x20
+};
+
+
+static BOOL SetExistingFileModifiedTime(
+    __in_z LPCWSTR wzId,
+    __in_z LPCWSTR wzPath,
+    __in BOOL f64Bit,
+    __in FILETIME* pftModified
+    )
+{
+    HRESULT hr = S_OK;
+    BOOL fReenableFileSystemRedirection = FALSE;
+
+    if (f64Bit)
+    {
+        hr = WcaDisableWow64FSRedirection();
+        ExitOnFailure2(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
+
+        fReenableFileSystemRedirection = TRUE;
+    }
+
+    hr = FileSetTime(wzPath, NULL, NULL, pftModified);
+
+LExit:
+    if (fReenableFileSystemRedirection)
+    {
+        WcaRevertWow64FSRedirection();
+    }
+
+    return SUCCEEDED(hr);
+}
+
+
+static HRESULT AddDataToCustomActionData(
+    __deref_inout_z LPWSTR* psczCustomActionData,
+    __in_z LPCWSTR wzId,
+    __in_z LPCWSTR wzPath,
+    __in int iTouchFileAttributes,
+    __in FILETIME ftModified
+    )
+{
+    HRESULT hr = S_OK;
+
+    hr = WcaWriteStringToCaData(wzId, psczCustomActionData);
+    ExitOnFailure(hr, "Failed to add touch file identity to custom action data.");
+
+    hr = WcaWriteStringToCaData(wzPath, psczCustomActionData);
+    ExitOnFailure(hr, "Failed to add touch file path to custom action data.");
+
+    hr = WcaWriteIntegerToCaData(iTouchFileAttributes, psczCustomActionData);
+    ExitOnFailure(hr, "Failed to add touch file attributes to custom action data.");
+
+    hr = WcaWriteIntegerToCaData(ftModified.dwHighDateTime, psczCustomActionData);
+    ExitOnFailure(hr, "Failed to add touch file high date/time to custom action data.");
+
+    hr = WcaWriteIntegerToCaData(ftModified.dwLowDateTime, psczCustomActionData);
+    ExitOnFailure(hr, "Failed to add touch file low date/time to custom action data.");
+
+LExit:
+    return hr;
+}
+
+
+static BOOL TryGetExistingFileModifiedTime(
+    __in_z LPCWSTR wzId,
+    __in_z LPCWSTR wzPath,
+    __in BOOL f64Bit,
+    __inout FILETIME* pftModified
+    )
+{
+    HRESULT hr = S_OK;
+    BOOL fReenableFileSystemRedirection = FALSE;
+
+    if (f64Bit)
+    {
+        hr = WcaDisableWow64FSRedirection();
+        ExitOnFailure2(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
+
+        fReenableFileSystemRedirection = TRUE;
+    }
+
+    hr = FileGetTime(wzPath, NULL, NULL, pftModified);
+    if (E_PATHNOTFOUND == hr || E_FILENOTFOUND == hr)
+    {
+        // If the file doesn't exist yet there is nothing to rollback (i.e. file will probably be removed during rollback), so
+        // keep the error code but don't log anything.
+    }
+    else if (FAILED(hr))
+    {
+        WcaLog(LOGMSG_STANDARD, "Cannot access modified timestamp for file: '%ls' due to error: 0x%x. Continuing with out rollback for: %ls", wzPath, hr, wzId);
+    }
+
+LExit:
+    if (fReenableFileSystemRedirection)
+    {
+        WcaRevertWow64FSRedirection();
+    }
+
+    return SUCCEEDED(hr);
+}
+
+
+static HRESULT ProcessTouchFileTable(
+    __in BOOL fInstalling
+    )
+{
+    HRESULT hr = S_OK;
+
+    FILETIME ftModified = {};
+
+    PMSIHANDLE hView;
+    PMSIHANDLE hRec;
+
+    LPWSTR sczId = NULL;
+    LPWSTR sczComponent = NULL;
+    int iTouchFileAttributes = 0;
+    LPWSTR sczPath = NULL;
+
+    FILETIME ftRollbackModified = {};
+    LPWSTR sczRollbackData = NULL;
+    LPWSTR sczExecuteData = NULL;
+
+    if (S_OK != WcaTableExists(L"WixTouchFile"))
+    {
+        ExitFunction();
+    }
+
+    ::GetSystemTimeAsFileTime(&ftModified);
+
+    hr = WcaOpenExecuteView(vcsTouchFileQuery, &hView);
+    ExitOnFailure(hr, "Failed to open view on WixTouchFile table");
+
+    while (S_OK == (hr = WcaFetchRecord(hView, &hRec)))
+    {
+        hr = WcaGetRecordString(hRec, tfqId, &sczId);
+        ExitOnFailure(hr, "Failed to get touch file identity.");
+
+        hr = WcaGetRecordString(hRec, tfqComponent, &sczComponent);
+        ExitOnFailure1(hr, "Failed to get touch file component for: %ls", sczId);
+
+        hr = WcaGetRecordInteger(hRec, tfqTouchFileAttributes, &iTouchFileAttributes);
+        ExitOnFailure1(hr, "Failed to get touch file attributes for: %ls", sczId);
+
+        WCA_TODO todo = WcaGetComponentToDo(sczComponent);
+
+        BOOL fOnInstall = fInstalling && WCA_TODO_INSTALL == todo && (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_ON_INSTALL);
+        BOOL fOnReinstall = fInstalling && WCA_TODO_REINSTALL == todo && (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_ON_REINSTALL);
+        BOOL fOnUninstall = !fInstalling && WCA_TODO_UNINSTALL == todo && (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_ON_UNINSTALL);
+
+        if (fOnInstall || fOnReinstall || fOnUninstall)
+        {
+            hr = WcaGetRecordFormattedString(hRec, tfqPath, &sczPath);
+            ExitOnFailure1(hr, "Failed to get touch file path for: %ls", sczId);
+
+            if (TryGetExistingFileModifiedTime(sczId, sczPath, (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_64BIT), &ftRollbackModified))
+            {
+                hr = AddDataToCustomActionData(&sczRollbackData, sczId, sczPath, iTouchFileAttributes, ftRollbackModified);
+                ExitOnFailure1(hr, "Failed to add to rollback custom action data for: %ls", sczId);
+            }
+
+            hr = AddDataToCustomActionData(&sczExecuteData, sczId, sczPath, iTouchFileAttributes, ftModified);
+            ExitOnFailure1(hr, "Failed to add to execute custom action data for: %ls", sczId);
+        }
+    }
+
+    if (E_NOMOREITEMS == hr)
+    {
+        hr = S_OK;
+    }
+    ExitOnFailure(hr, "Failure occured while processing WixTouchFile table");
+
+    if (sczRollbackData)
+    {
+        hr = WcaDoDeferredAction(L"WixRollbackTouchFile", sczRollbackData, 0);
+        ExitOnFailure(hr, "Failed to schedule WixRollbackTouchFile");
+    }
+
+    if (sczExecuteData)
+    {
+        hr = WcaDoDeferredAction(L"WixExecuteTouchFile", sczExecuteData, 0);
+        ExitOnFailure(hr, "Failed to schedule WixExecuteTouchFile");
+    }
+
+LExit:
+    ReleaseStr(sczExecuteData);
+    ReleaseStr(sczRollbackData);
+    ReleaseStr(sczPath);
+    ReleaseStr(sczComponent);
+    ReleaseStr(sczId);
+
+    return hr;
+}
+
+
+extern "C" UINT WINAPI WixTouchFileDuringInstall(
+    __in MSIHANDLE hInstall
+    )
+{
+    //AssertSz(FALSE, "debug WixTouchFileDuringInstall");
+
+    HRESULT hr = S_OK;
+
+    hr = WcaInitialize(hInstall, "WixTouchFileDuringInstall");
+    ExitOnFailure(hr, "Failed to initialize WixTouchFileDuringInstall.");
+
+    hr = ProcessTouchFileTable(TRUE);
+
+LExit:
+    DWORD er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}
+
+
+extern "C" UINT WINAPI WixTouchFileDuringUninstall(
+    __in MSIHANDLE hInstall
+    )
+{
+    //AssertSz(FALSE, "debug WixTouchFileDuringUninstall");
+
+    HRESULT hr = S_OK;
+
+    hr = WcaInitialize(hInstall, "WixTouchFileDuringUninstall");
+    ExitOnFailure(hr, "Failed to initialize WixTouchFileDuringUninstall.");
+
+    hr = ProcessTouchFileTable(FALSE);
+
+LExit:
+    DWORD er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}
+
+
+extern "C" UINT WINAPI WixExecuteTouchFile(
+    __in MSIHANDLE hInstall
+    )
+{
+    HRESULT hr = S_OK;
+
+    LPWSTR sczData = NULL;
+    LPWSTR pwz = NULL;
+
+    LPWSTR sczId = NULL;
+    LPWSTR sczPath = NULL;
+    int iTouchFileAttributes = 0;
+    FILETIME ftModified = {};
+
+    hr = WcaInitialize(hInstall, "WixExecuteTouchFile");
+    ExitOnFailure(hr, "Failed to initialize WixExecuteTouchFile.");
+
+    hr = WcaGetProperty(L"CustomActionData", &sczData);
+    ExitOnFailure(hr, "Failed to get custom action data for WixExecuteTouchFile.");
+
+    pwz = sczData;
+
+    while (pwz && *pwz)
+    {
+        hr = WcaReadStringFromCaData(&pwz, &sczId);
+        ExitOnFailure(hr, "Failed to get touch file identity from custom action data.");
+
+        hr = WcaReadStringFromCaData(&pwz, &sczPath);
+        ExitOnFailure1(hr, "Failed to get touch file path from custom action data for: %ls", sczId);
+
+        hr = WcaReadIntegerFromCaData(&pwz, &iTouchFileAttributes);
+        ExitOnFailure1(hr, "Failed to get touch file attributes from custom action data for: %ls", sczId);
+
+        hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int*>(&ftModified.dwHighDateTime));
+        ExitOnFailure1(hr, "Failed to get touch file high date/time from custom action data for: %ls", sczId);
+
+        hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int*>(&ftModified.dwLowDateTime));
+        ExitOnFailure1(hr, "Failed to get touch file low date/time from custom action data for: %ls", sczId);
+
+        hr = SetExistingFileModifiedTime(sczId, sczPath, (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_64BIT), &ftModified);
+        if (FAILED(hr))
+        {
+            if (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_VITAL)
+            {
+                ExitOnFailure2(hr, "Failed to touch file: '%ls' for: %ls", &sczPath, sczId);
+            }
+            else
+            {
+                WcaLog(LOGMSG_STANDARD, "Could not to touch non-vital file: '%ls' for: %ls with error: 0x%x. Continuing...", sczPath, sczId, hr);
+                hr = S_OK;
+            }
+        }
+    }
+
+LExit:
+    ReleaseStr(sczPath);
+    ReleaseStr(sczId);
+    ReleaseStr(sczData);
+
+    DWORD er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}

--- a/src/ext/ca/wixca/dll/wixca.def
+++ b/src/ext/ca/wixca/dll/wixca.def
@@ -49,6 +49,10 @@ EXPORTS
 ; test.cpp
     WixFailWhenDeferred
     WixWaitForEvent
+; TouchFile.cpp
+    WixTouchFileDuringInstall
+    WixTouchFileDuringUninstall
+    WixExecuteTouchFile
 ; exitearlywithsuccess.cpp
     WixExitEarlyWithSuccess
 ; xmlfile.cpp

--- a/src/ext/ca/wixca/dll/wixca.vcxproj
+++ b/src/ext/ca/wixca/dll/wixca.vcxproj
@@ -48,7 +48,6 @@
       <Platform>ARM</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0D1A6856-D89F-4CC4-B3E9-B1DCFB2852F6}</ProjectGuid>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -56,14 +55,11 @@
     <ProjectModuleDefinitionFile>wixca.def</ProjectModuleDefinitionFile>
     <ProjectModuleDefinitionFile Condition=" '$(Platform)'=='x64' ">wixca_x64.def</ProjectModuleDefinitionFile>
   </PropertyGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />
-
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc;$(WixRoot)src\libs\wcautil;..\..\inc</ProjectAdditionalIncludeDirectories>
     <ProjectAdditionalLinkLibraries>msi.lib;dutil.lib;wcautil.lib;shlwapi.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
-
   <ItemGroup>
     <ClCompile Include="cacleanup.cpp" />
     <ClCompile Include="CheckReboot.cpp" />
@@ -78,6 +74,7 @@
     <ClCompile Include="serviceconfig.cpp" />
     <ClCompile Include="shellexecca.cpp" />
     <ClCompile Include="test.cpp" />
+    <ClCompile Include="TouchFile.cpp" />
     <ClCompile Include="wixca.cpp" />
     <ClCompile Include="XmlFile.cpp" />
     <ClCompile Include="XmlConfig.cpp" />
@@ -93,6 +90,5 @@
   <ItemGroup>
     <ResourceCompile Include="wixca.rc" />
   </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -1505,7 +1505,7 @@ extern "C" HRESULT DAPI FileGetTime(
     HRESULT hr = S_OK;
     HANDLE hFile = NULL;
 
-    hFile = ::CreateFileW(wzFile, FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+    hFile = ::CreateFileW(wzFile, FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
     ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
 
     if (!::GetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime))
@@ -1531,7 +1531,7 @@ extern "C" HRESULT DAPI FileSetTime(
     HRESULT hr = S_OK;
     HANDLE hFile = NULL;
 
-    hFile = ::CreateFileW(wzFile, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+    hFile = ::CreateFileW(wzFile, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
     ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
 
     if (!::SetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime))


### PR DESCRIPTION
The devenv /setup call when installing the WiX toolset can take minutes
to complete. Fortunately the VSIX installation method introduced
another way to complete the registration of extensions. All that is
necessary is to touch the "extensions.configurationchanged" file.
