### PR TITLE
Remove deprecated commandline switches.

### DIFF
--- a/src/tools/candle/CandleCommandLine.cs
+++ b/src/tools/candle/CandleCommandLine.cs
@@ -147,13 +147,8 @@ namespace WixToolset.Tools
                     {
                         this.ShowPedanticMessages = true;
                     }
-                    else if ("platform" == parameter || "arch" == parameter)
+                    else if ("arch" == parameter)
                     {
-                        if ("platform" == parameter)
-                        {
-                            Messaging.Instance.OnMessage(WixWarnings.DeprecatedCommandLineSwitch("platform", "arch"));
-                        }
-
                         if (!CommandLine.IsValidArg(args, ++i))
                         {
                             Messaging.Instance.OnMessage(WixErrors.InvalidPlatformParameter(parameter, String.Empty));
@@ -186,11 +181,6 @@ namespace WixToolset.Tools
                         string file = parameter.Substring(1);
                         this.PreprocessFile = String.IsNullOrEmpty(file) ? "con:" : file;
                     }
-                    else if ("swall" == parameter)
-                    {
-                        Messaging.Instance.OnMessage(WixWarnings.DeprecatedCommandLineSwitch("swall", "sw"));
-                        Messaging.Instance.SuppressAllWarnings = true;
-                    }
                     else if (parameter.StartsWith("sw", StringComparison.Ordinal))
                     {
                         string paramArg = parameter.Substring(2);
@@ -219,11 +209,6 @@ namespace WixToolset.Tools
                         {
                             Messaging.Instance.OnMessage(WixErrors.IllegalSuppressWarningId(paramArg));
                         }
-                    }
-                    else if ("wxall" == parameter)
-                    {
-                        Messaging.Instance.OnMessage(WixWarnings.DeprecatedCommandLineSwitch("wxall", "wx"));
-                        Messaging.Instance.WarningsAsError = true;
                     }
                     else if (parameter.StartsWith("wx", StringComparison.Ordinal))
                     {

--- a/src/tools/candle/CandleStrings.resx
+++ b/src/tools/candle/CandleStrings.resx
@@ -124,16 +124,14 @@
     <value> usage:  candle.exe [-?] [-nologo] [-out outputFile] sourceFile [sourceFile ...] [@responseFile]
 
    -arch      set architecture defaults for package, components, etc.
-              values: x86, x64, or ia64 (default: x86)
+              values: x86, x64, ia64 or arm (default: x86)
    -d&lt;name&gt;[=&lt;value&gt;]  define a parameter for the preprocessor
    -ext &lt;extension&gt;  extension assembly or "class, assembly"
-   -fips      enables FIPS compliant algorithms
    -I&lt;dir&gt;    add to include search path
    -nologo    skip printing candle logo information
    -o[ut]     specify output file (default: write to current directory)
    -p&lt;file&gt;   preprocess to a file (or stdout if no file supplied)
    -pedantic  show pedantic messages
-   -platform  (deprecated alias for -arch)
    -sw[N]     suppress all warnings or a specific message ID
               (example: -sw1009 -sw1103)
    -v         verbose output

--- a/src/tools/light/LightStrings.resx
+++ b/src/tools/light/LightStrings.resx
@@ -161,9 +161,6 @@
    -xo        output wixout format instead of MSI format
    -? | -help this help information</value>
   </data>
-  <data name="EXP_BindFileOptionNotApplicable" xml:space="preserve">
-    <value>The -bf (bind files) option is only applicable with the -xo option.</value>
-  </data>
   <data name="EXP_CannotLinkObjFilesWithOutpuFile" xml:space="preserve">
     <value>Cannot link object files (.wixobj) files with an output file (.wixout)</value>
   </data>


### PR DESCRIPTION
Pretty straight forward. These are already deprecated in wix3.
