### PR TITLE
WIXBUG:1705 - Include AssemblyFileVersion in MsiAssemblyName table.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:1705 - Include AssemblyFileVersion in MsiAssemblyName table.
+
 * FireGiant: WIXFEAT:4258 - complete introduction of access modifiers for identifiers.
 
 * RobMen: Replace devenv /setup call with fast extension update mechanism.

--- a/src/tools/WixTasks/Light.cs
+++ b/src/tools/WixTasks/Light.cs
@@ -57,7 +57,6 @@ namespace WixToolset.Build.Tasks
         private ITaskItem wixProjectFile;
         private bool pedantic;
         private bool reuseCabinetCache;
-        private bool setMsiAssemblyNameFileVersion;
         private bool suppressAclReset;
         private bool suppressAssemblies;
         private bool suppressDefaultAdminSequenceActions;
@@ -259,13 +258,6 @@ namespace WixToolset.Build.Tasks
         {
             get { return this.reuseCabinetCache; }
             set { this.reuseCabinetCache = value; }
-        }
-
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        public bool SetMsiAssemblyNameFileVersion
-        {
-            get { return this.setMsiAssemblyNameFileVersion; }
-            set { this.setMsiAssemblyNameFileVersion = value; }
         }
 
         public bool SuppressAclReset
@@ -471,7 +463,6 @@ namespace WixToolset.Build.Tasks
             commandLineBuilder.AppendIfTrue("-dut", this.DropUnrealTables);
             commandLineBuilder.AppendIfTrue("-eav", this.ExactAssemblyVersions);
             commandLineBuilder.AppendExtensions(this.Extensions, this.ExtensionDirectory, this.referencePaths);
-            commandLineBuilder.AppendIfTrue("-fv", this.SetMsiAssemblyNameFileVersion);
             commandLineBuilder.AppendArrayIfNotNull("-ice:", this.Ices);
             commandLineBuilder.AppendArrayIfNotNull("-loc ", this.LocalizationFiles);
             commandLineBuilder.AppendIfTrue("-notidy", this.LeaveTemporaryFiles);

--- a/src/tools/WixTasks/Pyro.cs
+++ b/src/tools/WixTasks/Pyro.cs
@@ -17,8 +17,6 @@ namespace WixToolset.Build.Tasks
     using System.Collections.Generic;
     using System.IO;
     using Microsoft.Build.Framework;
-    using Microsoft.Build.Utilities;
-    using WixToolset.Build.Tasks;
 
     /// <summary>
     /// An MSBuild task to run the WiX patch builder.
@@ -34,7 +32,6 @@ namespace WixToolset.Build.Tasks
         public bool LeaveTemporaryFiles { get; set; }
         public string[] ReferencePaths { get; set; }
         public bool ReuseCabinetCache { get; set; }
-        public bool SetMsiAssemblyNameFileVersion { get; set; }
         public bool SuppressAssemblies { get; set; }
         public bool SuppressFiles { get; set; }
         public bool SuppressFileHashAndInfo { get; set; }
@@ -130,7 +127,6 @@ namespace WixToolset.Build.Tasks
             commandLineBuilder.AppendSwitchIfNotNull("-cc ", this.CabinetCachePath);
             commandLineBuilder.AppendIfTrue("-delta", this.BinaryDeltaPatch);
             commandLineBuilder.AppendExtensions(this.Extensions, this.ExtensionDirectory, this.ReferencePaths);
-            commandLineBuilder.AppendIfTrue("-fv", this.SetMsiAssemblyNameFileVersion);
             commandLineBuilder.AppendIfTrue("-notidy", this.LeaveTemporaryFiles);
             commandLineBuilder.AppendIfTrue("-reusecab", this.ReuseCabinetCache);
             commandLineBuilder.AppendIfTrue("-sa", this.SuppressAssemblies);

--- a/src/tools/WixTasks/wix.targets
+++ b/src/tools/WixTasks/wix.targets
@@ -1042,7 +1042,6 @@
       ReferencePaths="$(ReferencePaths)"
       ReuseCabinetCache="$(ReuseCabinetCache)"
       RunAsSeparateProcess="$(RunWixToolsOutOfProc)"
-      SetMsiAssemblyNameFileVersion="$(SetMsiAssemblyNameFileVersion)"
       SuppressAclReset="$(SuppressAclReset)"
       SuppressAllWarnings="$(LinkerSuppressAllWarnings)"
       SuppressAssemblies="$(SuppressAssemblies)"

--- a/src/tools/light/LightCommandLine.cs
+++ b/src/tools/light/LightCommandLine.cs
@@ -50,8 +50,6 @@ namespace WixToolset.Tools
 
         public bool SuppressValidation { get; private set; }
 
-        public bool SetMsiAssemblyNameFileVersion { get; private set; }
-
         public string OutputsFile { get; private set; }
 
         public string BuiltOutputsFile { get; private set; }
@@ -287,10 +285,6 @@ namespace WixToolset.Tools
                     else if (parameter.Equals("eav", StringComparison.Ordinal))
                     {
                         this.ExactAssemblyVersions = true;
-                    }
-                    else if (parameter.Equals("fv", StringComparison.Ordinal))
-                    {
-                        this.SetMsiAssemblyNameFileVersion = true;
                     }
                     else if (parameter.StartsWith("ice:", StringComparison.Ordinal))
                     {

--- a/src/tools/light/LightStrings.resx
+++ b/src/tools/light/LightStrings.resx
@@ -129,8 +129,6 @@
    -dcl:level set default cabinet compression level
               (low, medium, high, none, mszip; mszip default)
    -eav       exact assembly versions (breaks .NET 1.1 RTM compatibility)
-   -fv        add a 'fileVersion' entry to the MsiAssemblyName table
-              (rarely needed)
    -ice:&lt;ICE&gt;   run a specific internal consistency evaluator (ICE)
    -pdbout &lt;output.wixpdb&gt;  save the WixPdb to a specific file
               (default: same name as output with wixpdb extension)

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -187,7 +187,6 @@ namespace WixToolset.Tools
             binder.ExactAssemblyVersions = this.commandLine.ExactAssemblyVersions;
             binder.Ices.AddRange(this.commandLine.Ices);
             binder.SuppressIces.AddRange(this.commandLine.SuppressIces);
-            binder.SetMsiAssemblyNameFileVersion = this.commandLine.SetMsiAssemblyNameFileVersion;
             binder.SuppressAclReset = this.commandLine.SuppressAclReset;
             binder.SuppressLayout = this.commandLine.SuppressLayout;
             binder.SuppressValidation = this.commandLine.SuppressValidation;

--- a/src/tools/pyro/PyroCommandLine.cs
+++ b/src/tools/pyro/PyroCommandLine.cs
@@ -29,8 +29,6 @@ namespace WixToolset.Tools
             this.Extensions = new List<string>();
         }
 
-        public bool SetMsiAssemblyNameFileVersion { get; private set; }
-
         public bool Delta { get; private set; }
 
         public bool ShowLogo { get; private set; }
@@ -129,10 +127,6 @@ namespace WixToolset.Tools
 
                         this.Extensions.Add(args[i]);
                     }
-                    else if ("fv" == parameter)
-                    {
-                        this.SetMsiAssemblyNameFileVersion = true;
-                    }
                     else if ("nologo" == parameter)
                     {
                         this.ShowLogo = false;
@@ -181,7 +175,7 @@ namespace WixToolset.Tools
                             break;
                         }
 
-                        baseline= args[i];
+                        baseline = args[i];
 
                         transformPath = CommandLine.GetFile(parameter, args, ++i);
 

--- a/src/tools/pyro/PyroStrings.resx
+++ b/src/tools/pyro/PyroStrings.resx
@@ -133,7 +133,6 @@
    -cc <path> path to cache built cabinets
    -delta     create binary delta patch (instead of whole file patch)
    -ext <extension>  extension assembly or "class, assembly"
-   -fv        update 'fileVersion' entries in the MsiAssemblyName table
    -nologo    skip printing logo information
    -notidy    do not delete temporary files (useful for debugging)
    -o[ut]     specify output file

--- a/src/tools/pyro/pyro.cs
+++ b/src/tools/pyro/pyro.cs
@@ -14,10 +14,7 @@
 namespace WixToolset.Tools
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices;
@@ -168,7 +165,6 @@ namespace WixToolset.Tools
             //binder.CabbingThreadCount = this.commandLine.CabbingThreadCount;
             //binder.DefaultCompressionLevel = this.commandLine.DefaultCompressionLevel;
             //binder.ExactAssemblyVersions = this.commandLine.ExactAssemblyVersions;
-            binder.SetMsiAssemblyNameFileVersion = this.commandLine.SetMsiAssemblyNameFileVersion;
             binder.SuppressAclReset = this.commandLine.SuppressAclReset;
             //binder.SuppressLayout = this.commandLine.SuppressLayout;
             binder.SuppressValidation = true;

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -201,12 +201,6 @@ namespace WixToolset
         public List<string> SuppressIces { get; set; }
 
         /// <summary>
-        /// Gets and sets the option to set the file version in the MsiAssemblyName table.
-        /// </summary>
-        /// <value>The option to set the file version in the MsiAssemblyName table.</value>
-        public bool SetMsiAssemblyNameFileVersion { get; set; }
-
-        /// <summary>
         /// Gets and sets the option to suppress resetting ACLs by the binder.
         /// </summary>
         /// <value>The option to suppress resetting ACLs by the binder.</value>
@@ -6034,8 +6028,8 @@ namespace WixToolset
                 fileRow.FileSize = Convert.ToInt32(fileStream.Length, CultureInfo.InvariantCulture);
             }
 
-            string version;
-            string language;
+            string version = null;
+            string language = null;
             try
             {
                 Installer.GetFileVersion(fileInfo.FullName, out version, out language);
@@ -6221,16 +6215,12 @@ namespace WixToolset
                 Table assemblyNameTable = output.EnsureTable(this.core.TableDefinitions["MsiAssemblyName"]);
                 if (assemblyNameValues.ContainsKey("name"))
                 {
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "name", assemblyNameValues["name"], infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "name", assemblyNameValues["name"], infoCache, modularizationGuid);
                 }
 
-                string fileVersion = null;
-                if (this.SetMsiAssemblyNameFileVersion)
+                if (!String.IsNullOrEmpty(version))
                 {
-                    string ignored;
-
-                    Installer.GetFileVersion(fileInfo.FullName, out fileVersion, out ignored);
-                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "fileVersion", fileVersion, infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "fileVersion", version, infoCache, modularizationGuid);
                 }
 
                 if (assemblyNameValues.ContainsKey("version"))
@@ -6239,12 +6229,13 @@ namespace WixToolset
 
                     if (!this.ExactAssemblyVersions)
                     {
-                        // there is a bug in fusion that requires the assembly's "version" attribute
+                        // There is a bug in fusion that requires the assembly's "version" attribute
                         // to be equal to or longer than the "fileVersion" in length when its present;
-                        // the workaround is to prepend zeroes to the last version number in the assembly version
-                        if (this.SetMsiAssemblyNameFileVersion && null != fileVersion && fileVersion.Length > assemblyVersion.Length)
+                        // the workaround is to prepend zeroes to the last version number in the assembly
+                        // version.
+                        if (null != version && version.Length > assemblyVersion.Length)
                         {
-                            string padding = new string('0', fileVersion.Length - assemblyVersion.Length);
+                            string padding = new string('0', version.Length - assemblyVersion.Length);
                             string[] assemblyVersionNumbers = assemblyVersion.Split('.');
 
                             if (assemblyVersionNumbers.Length > 0)
@@ -6255,27 +6246,27 @@ namespace WixToolset
                         }
                     }
 
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "version", assemblyVersion, infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "version", assemblyVersion, infoCache, modularizationGuid);
                 }
 
                 if (assemblyNameValues.ContainsKey("culture"))
                 {
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "culture", assemblyNameValues["culture"], infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "culture", assemblyNameValues["culture"], infoCache, modularizationGuid);
                 }
 
                 if (assemblyNameValues.ContainsKey("publicKeyToken"))
                 {
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "publicKeyToken", assemblyNameValues["publicKeyToken"], infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "publicKeyToken", assemblyNameValues["publicKeyToken"], infoCache, modularizationGuid);
                 }
 
-                if (null != fileRow.ProcessorArchitecture && 0 < fileRow.ProcessorArchitecture.Length)
+                if (!String.IsNullOrEmpty(fileRow.ProcessorArchitecture))
                 {
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "processorArchitecture", fileRow.ProcessorArchitecture, infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "processorArchitecture", fileRow.ProcessorArchitecture, infoCache, modularizationGuid);
                 }
 
                 if (assemblyNameValues.ContainsKey("processorArchitecture"))
                 {
-                    SetMsiAssemblyName(output, assemblyNameTable, fileRow, "processorArchitecture", assemblyNameValues["processorArchitecture"], infoCache, modularizationGuid);
+                    this.SetMsiAssemblyName(output, assemblyNameTable, fileRow, "processorArchitecture", assemblyNameValues["processorArchitecture"], infoCache, modularizationGuid);
                 }
 
                 // add the assembly name to the information cache


### PR DESCRIPTION
After discussing with CLR team, including the AssemblyFileVersion when
installing into the GAC makes a lot of sense to them. Historically the
documentation did not highlight including the AssemblyFileVersion but
most (all?) Microsoft already products seem to inclue file version.
