### PR TITLE
WIXBUG:4317 - Integrate preprocessor AutoVersion function lost in merges.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4317 - Integrate preprocessor AutoVersion function lost in merges.
+
 * RobMen: WIXBUG:1705 - Include AssemblyFileVersion in MsiAssemblyName table.
 
 * FireGiant: WIXFEAT:4258 - complete introduction of access modifiers for identifiers.

--- a/src/tools/wix/PreprocessorCore.cs
+++ b/src/tools/wix/PreprocessorCore.cs
@@ -14,11 +14,9 @@
 namespace WixToolset
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
-    using System.Xml;
     using System.Xml.Linq;
     using WixToolset.Data;
     using WixToolset.Extensibility;
@@ -335,7 +333,20 @@ namespace WixToolset
                 case "fun":
                     switch (function)
                     {
-                        // Add any core defined functions here
+                        case "AutoVersion":
+                            // Make sure the base version is specified
+                            if (args.Length == 0 || String.IsNullOrEmpty(args[0]))
+                            {
+                                throw new WixException(WixErrors.InvalidPreprocessorFunctionAutoVersion(sourceLineNumbers));
+                            }
+
+                            // Build = days since 1/1/2000; Revision = seconds since midnight / 2
+                            DateTime now = DateTime.UtcNow;
+                            TimeSpan build = now - new DateTime(2000, 1, 1);
+                            TimeSpan revision = now - new DateTime(now.Year, now.Month, now.Day);
+
+                            return String.Join(".", args[0], (int)build.TotalDays, (int)(revision.TotalSeconds / 2));
+
                         default:
                             return null;
                     }

--- a/test/src/UnitTests/wix/WixUnitTest.csproj
+++ b/test/src/UnitTests/wix/WixUnitTest.csproj
@@ -32,6 +32,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="packages.config" />
+    <Content Include="testdata\func_autoversion.wxs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/src/UnitTests/wix/testdata/func_autoversion.wxs
+++ b/test/src/UnitTests/wix/testdata/func_autoversion.wxs
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<?define ProductMajorVersion="1"?>
+<?define ProductMinorVersion="2"?>
+<?define ProductVersion="$(fun.AutoVersion($(var.ProductMajorVersion).$(var.ProductMinorVersion)))"?>
+
+<Foo Bar="$(var.ProductVersion)" />


### PR DESCRIPTION
Somewhere in all the merges from wix3 branch the preprocessor AutoVersion function was lost.
