### PR TITLE
Settings Engine Compatibility With App Database Files

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* MikeGC: Feature #4355: Settings engine doesn't handle files that are always locked for write (such as database files) very well
+
 * SeanHall: WIXFEAT:4413 - Merge OnApplyNumberOfPhases into OnApplyBegin.
 
 ## WixBuild: Version 4.0.2115.0

--- a/src/SettingsEngine/lib/drdfault.cpp
+++ b/src/SettingsEngine/lib/drdfault.cpp
@@ -28,6 +28,7 @@ HRESULT DirDefaultReadFile(
     SCE_ROW_HANDLE sceValueRow = NULL;
     BOOL fRet = FALSE;
     BOOL fIgnore = FALSE;
+    BOOL fShareWriteOnRead = FALSE;
     BYTE *pbBuffer = NULL;
     DWORD cbBuffer = 0;
     BOOL fRefreshTimestamp = FALSE;
@@ -38,7 +39,7 @@ HRESULT DirDefaultReadFile(
     hr = MapFileToCfgName(wzName, wzSubPath, &sczValueName);
     ExitOnFailure2(hr, "Failed to get cfg name for file at name %ls, subpath %ls", wzName, wzSubPath);
 
-    hr = FilterCheckValue(&pSyncProductSession->product, sczValueName, &fIgnore);
+    hr = FilterCheckValue(&pSyncProductSession->product, sczValueName, &fIgnore, &fShareWriteOnRead);
     ExitOnFailure1(hr, "Failed to check if cfg blob value should be ignored: %ls", sczValueName);
 
     if (fIgnore)
@@ -94,8 +95,19 @@ HRESULT DirDefaultReadFile(
         }
     }
 
-    hr = FileRead(&pbBuffer, &cbBuffer, wzFilePath);
-    ExitOnFailure1(hr, "Failed to read file into memory: %ls", wzFilePath);
+    // Only share write if we were explicitly told to by the UDM (typically for an app that holds its file open for write
+    // for the lifetime of the app, such as for a database file). If we were not told to, we're syncing a potentially corrupt file
+    // (one in the middle of being written), and so a sharing violation to abort (and later retry) is a good thing.
+    if (fShareWriteOnRead)
+    {
+        hr = FileReadEx(&pbBuffer, &cbBuffer, wzFilePath, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE);
+        ExitOnFailure1(hr, "Failed to read file into memory (with write sharing): %ls", wzFilePath);
+    }
+    else
+    {
+        hr = FileReadEx(&pbBuffer, &cbBuffer, wzFilePath, FILE_SHARE_DELETE | FILE_SHARE_READ);
+        ExitOnFailure1(hr, "Failed to read file into memory: %ls", wzFilePath);
+    }
 
     if (fRefreshTimestamp)
     {
@@ -146,6 +158,8 @@ HRESULT DirDefaultWriteFile(
     DWORD cbBuffer = 0;
     int iTimestampCompare = 0;
     BOOL fRet = FALSE;
+    BOOL fIgnore = FALSE;
+    BOOL fSharingViolation = FALSE;
     BOOL fFileExists = FALSE;
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hFileDelete = INVALID_HANDLE_VALUE; // A separate handle specifically for opening the file for "delete on close" behavior
@@ -168,9 +182,12 @@ HRESULT DirDefaultWriteFile(
 
     *pfHandled = TRUE;
 
-    // If it's not a valid cfg type for a file, or the file doesn't exist and we're intending to delete it, just exit with no error
+    hr = FilterCheckValue(pProduct, wzName, &fIgnore, NULL);
+    ExitOnFailure1(hr, "Failed to check if cfg value should be ignored: %ls", wzName);
+
+    // If it's ignored, or not a valid cfg type for a file, or the file doesn't exist and we're intending to delete it, just exit with no error
     // This doesn't need to be transactional because if a new file was written right after this, autosync will pick it up
-    if ((VALUE_BLOB != pcvValue->cvType && VALUE_DELETED != pcvValue->cvType) || (!FileExistsEx(sczPath, NULL) && VALUE_DELETED == pcvValue->cvType))
+    if (fIgnore || (VALUE_BLOB != pcvValue->cvType && VALUE_DELETED != pcvValue->cvType) || (!FileExistsEx(sczPath, NULL) && VALUE_DELETED == pcvValue->cvType))
     {
         ExitFunction1(hr = S_OK);
     }
@@ -198,22 +215,34 @@ HRESULT DirDefaultWriteFile(
     // This does carry with it a slight risk that an app could read the file while we're writing it or be denied permission to write to it
     // but this is brief, and it is not expected that we should need to write data to the local machine from another machine for an app while the app is writing data locally
     hFile = ::CreateFileW(sczPath, GENERIC_WRITE, FILE_SHARE_DELETE, NULL, OPEN_ALWAYS, 0, NULL);
-    if (INVALID_HANDLE_VALUE == hFile && ERROR_ACCESS_DENIED == ::GetLastError())
+    if (INVALID_HANDLE_VALUE == hFile)
     {
-        hr = UtilConvertToVirtualStorePath(sczPath, &sczVirtualStorePath);
-        ExitOnFailure1(hr, "Failed to convert file path to virtualstore path: %ls", sczPath);
+        if (ERROR_ACCESS_DENIED == ::GetLastError())
+        {
+            hr = UtilConvertToVirtualStorePath(sczPath, &sczVirtualStorePath);
+            ExitOnFailure1(hr, "Failed to convert file path to virtualstore path: %ls", sczPath);
 
-        // Switch path for the rest of the file to the virtualstore path
-        ReleaseStr(sczPath);
-        sczPath = sczVirtualStorePath;
-        ReleaseNullStr(sczVirtualStorePath);
+            // Switch path for the rest of the file to the virtualstore path
+            ReleaseStr(sczPath);
+            sczPath = sczVirtualStorePath;
+            ReleaseNullStr(sczVirtualStorePath);
 
-        hFile = ::CreateFileW(sczPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL);
+            hFile = ::CreateFileW(sczPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL);
+            ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open virtualstore file for write: %ls", sczPath);
+        }
+        else if (ERROR_SHARING_VIOLATION == ::GetLastError())
+        {
+            // If there is a sharing violation, it's not an error if the file is actually unchanged, so do our best to tolerate it
+            fSharingViolation = TRUE;
+        }
+        else
+        {
+            ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file for write: %ls", sczPath);
+        }
     }
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file for write: %ls", sczPath);
     fFileExists = ::GetLastError() == ERROR_ALREADY_EXISTS;
 
-    if (fFileExists)
+    if (fFileExists || fSharingViolation)
     {
         // If the file exists, check if it has the same timestamp - if it does, don't write it, or if it has newer timestamp, break out so we can re-do the whole sync
         hr = FileGetTime(sczPath, NULL, NULL, &ftDisk);
@@ -238,6 +267,14 @@ HRESULT DirDefaultWriteFile(
             ExitOnFailure1(hr, "Found newer file on disk at path %ls while trying to write file from DB, file must have changed during sync, aborting", sczPath);
         }
 
+        // If there is a sharing violation but we actually want to write the file, we won't be able to do so, so it becomes an error at this point
+        if (fSharingViolation)
+        {
+            hr = HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION);
+            ExitOnFailure1(hr, "Sharing violation while writing file %ls - file is apparently in the process of being written - this should be resolved on next autosync.", sczPath);
+        }
+
+        // Clear out any existing content we are about to overwrite
         fRet = ::SetEndOfFile(hFile);
         if (!fRet)
         {

--- a/src/SettingsEngine/lib/drdfault.cpp
+++ b/src/SettingsEngine/lib/drdfault.cpp
@@ -242,9 +242,10 @@ HRESULT DirDefaultWriteFile(
     }
     fFileExists = ::GetLastError() == ERROR_ALREADY_EXISTS;
 
-    if (fFileExists || fSharingViolation)
+    // If the file exists, and settings engine expects one to exist, check if it has the same timestamp
+    // if it does, no need to write it, or if it has newer timestamp, break out so we can re-do the whole sync
+    if (VALUE_BLOB == pcvValue->cvType && (fFileExists || fSharingViolation))
     {
-        // If the file exists, check if it has the same timestamp - if it does, don't write it, or if it has newer timestamp, break out so we can re-do the whole sync
         hr = FileGetTime(sczPath, NULL, NULL, &ftDisk);
         ExitOnFailure1(hr, "Failed to get time of file: %ls", sczPath);
 

--- a/src/SettingsEngine/lib/filter.cpp
+++ b/src/SettingsEngine/lib/filter.cpp
@@ -15,23 +15,38 @@
 
 HRESULT FilterCheckValue(
     __in LEGACY_PRODUCT *pProduct,
-    __in LPWSTR wzName,
-    __out BOOL *pfIgnore
+    __in_z LPCWSTR wzName,
+    __out_opt BOOL *pfIgnore,
+    __out_opt BOOL *pfShareWriteOnRead
     )
 {
     HRESULT hr = S_OK;
 
-    *pfIgnore = FALSE;
+    if (pfIgnore)
+    {
+        *pfIgnore = FALSE;
+    }
+    if (pfShareWriteOnRead)
+    {
+        *pfShareWriteOnRead = FALSE;
+    }
 
     for (DWORD i = 0; i < pProduct->cFilters; ++i)
     {
-        // If it matches an exact name ignore, this is it (no checking further filters)
+        // If it matches an exact named filter, this is it (no checking further filters)
         if (NULL != pProduct->rgFilters[i].sczExactName && CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, pProduct->rgFilters[i].sczExactName, -1, wzName, -1))
         {
-            *pfIgnore = pProduct->rgFilters[i].fIgnore;
+            if (pfIgnore)
+            {
+                *pfIgnore = pProduct->rgFilters[i].fIgnore;
+            }
+            if (pfShareWriteOnRead)
+            {
+                *pfShareWriteOnRead = pProduct->rgFilters[i].fShareWriteOnRead;
+            }
             ExitFunction1(hr = S_OK);
         }
-        // If it matches a prefix, ignore it
+        // If it matches a prefix, filter it
         else if (NULL != pProduct->rgFilters[i].sczPrefix || NULL != pProduct->rgFilters[i].sczPostfix)
         {
             if (NULL != pProduct->rgFilters[i].sczPrefix && 
@@ -47,7 +62,14 @@ HRESULT FilterCheckValue(
                 continue;
             }
 
-            *pfIgnore = pProduct->rgFilters[i].fIgnore;
+            if (pfIgnore)
+            {
+                *pfIgnore = pProduct->rgFilters[i].fIgnore;
+            }
+            if (pfShareWriteOnRead)
+            {
+                *pfShareWriteOnRead = pProduct->rgFilters[i].fShareWriteOnRead;
+            }
             // Not an exact match, so keep checking further filters to allow one to override another
         }
     }

--- a/src/SettingsEngine/lib/filter.h
+++ b/src/SettingsEngine/lib/filter.h
@@ -20,8 +20,9 @@ extern "C" {
 
 HRESULT FilterCheckValue(
     __in LEGACY_PRODUCT *pProduct,
-    __in LPWSTR wzName,
-    __out BOOL *pfIgnore
+    __in_z LPCWSTR wzName,
+    __out_opt BOOL *pfIgnore,
+    __out_opt BOOL *pfShareWriteOnRead
     );
 
 #ifdef __cplusplus

--- a/src/SettingsEngine/lib/inifile.cpp
+++ b/src/SettingsEngine/lib/inifile.cpp
@@ -67,7 +67,7 @@ HRESULT IniFileRead(
         hr = MapFileToCfgName(pIniFile->sczNamespace, rgIniValues[i].wzName, &sczFullValueName);
         ExitOnFailure2(hr, "Failed ot map INI value name: %ls, %ls", pIniFile->sczNamespace, rgIniValues[i].wzName);
 
-        hr = FilterCheckValue(&pSyncProductSession->product, sczFullValueName, &fIgnore);
+        hr = FilterCheckValue(&pSyncProductSession->product, sczFullValueName, &fIgnore, NULL);
         ExitOnFailure1(hr, "Failed to check if ini value should be ignored: %ls", sczFullValueName);
 
         if (fIgnore)

--- a/src/SettingsEngine/lib/legsync.cpp
+++ b/src/SettingsEngine/lib/legsync.cpp
@@ -557,7 +557,7 @@ static HRESULT ProductDbToMachine(
         hr = SceGetColumnString(sceRow, VALUE_COMMON_NAME, &sczName);
         ExitOnFailure(hr, "Failed to get name from row while querying VALUE_INDEX_TABLE table");
 
-        hr = FilterCheckValue(&pSyncProductSession->product, sczName, &fIgnore);
+        hr = FilterCheckValue(&pSyncProductSession->product, sczName, &fIgnore, NULL);
         ExitOnFailure1(hr, "Failed to check if cfg setting should be ignored: %ls", sczName);
 
         if (!fIgnore)

--- a/src/SettingsEngine/lib/manifest.h
+++ b/src/SettingsEngine/lib/manifest.h
@@ -125,8 +125,8 @@ struct LEGACY_VALUE_FILTER
     LPWSTR sczPrefix;
     LPWSTR sczPostfix;
 
-    // TODO: switch this to an enum to support per-machine, ignored, and normal settings
     BOOL fIgnore;
+    BOOL fShareWriteOnRead;
 };
 
 struct LEGACY_PRODUCT

--- a/src/SettingsEngine/lib/parse.cpp
+++ b/src/SettingsEngine/lib/parse.cpp
@@ -1102,7 +1102,16 @@ HRESULT ParseFilter(
         ExitOnFailure(hr, "Failed to resize filter array");
         ++pProduct->cFilters;
 
-        if (0 == lstrcmpW(bstrElement, L"Ignore"))
+        if (0 == lstrcmpW(bstrElement, L"Normal"))
+        {
+            hr = XmlGetYesNoAttribute(pixnNode, L"ShareWrite", &pProduct->rgFilters[pProduct->cFilters-1].fShareWriteOnRead);
+            if (E_NOTFOUND == hr)
+            {
+                hr = S_OK;
+            }
+            ExitOnFailure(hr, "Failed to get Normal/@ShareWrite attribute");
+        }
+        else if (0 == lstrcmpW(bstrElement, L"Ignore"))
         {
             pProduct->rgFilters[pProduct->cFilters-1].fIgnore = TRUE;
         }

--- a/src/SettingsEngine/lib/rgdfault.cpp
+++ b/src/SettingsEngine/lib/rgdfault.cpp
@@ -55,7 +55,7 @@ extern "C" HRESULT RegDefaultReadValue(
     hr = MapRegValueToCfgName(wzNamespace, wzRegKey, wzValueName, &sczCfgValueName);
     ExitOnFailure3(hr, "Failed to format default legacy value name from namespace: %ls, key: %ls, valuename: %ls", wzNamespace, wzRegKey, wzValueName);
 
-    hr = FilterCheckValue(&pSyncProductSession->product, sczCfgValueName, &fIgnore);
+    hr = FilterCheckValue(&pSyncProductSession->product, sczCfgValueName, &fIgnore, NULL);
     ExitOnFailure1(hr, "Failed to check if cfg value should be ignored: %ls", sczCfgValueName);
 
     if (fIgnore)

--- a/src/SettingsEngine/manifests/SpaceChem.udm
+++ b/src/SettingsEngine/manifests/SpaceChem.udm
@@ -13,6 +13,7 @@
             <!-- TODO: suppport some settings from this INI file, like "enableReporting" and "disableFBOs" -->
             <Ignore Name="Data:\Config.ini"/>
             <Ignore Postfix=".zicrash"/>
+            <Normal Name="Data:\.locals" ShareWrite="yes"/>
         </Filter>
 
         <DisplayName LCID="1033">SpaceChem</DisplayName>

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -800,6 +800,20 @@ extern "C" HRESULT DAPI FileRead(
     return hr;
 }
 
+/*******************************************************************
+ FileRead - read a file into memory with specified share mode
+
+********************************************************************/
+extern "C" HRESULT DAPI FileReadEx(
+    __deref_out_bcount_full(*pcbDest) LPBYTE* ppbDest,
+    __out DWORD* pcbDest,
+    __in_z LPCWSTR wzSrcPath,
+    __in DWORD dwShareMode
+    )
+{
+    HRESULT hr = FileReadPartialEx(ppbDest, pcbDest, wzSrcPath, FALSE, 0, 0xFFFFFFFF, FALSE, dwShareMode);
+    return hr;
+}
 
 /*******************************************************************
  FileReadUntil - read a file into memory with a maximum size
@@ -831,6 +845,24 @@ extern "C" HRESULT DAPI FileReadPartial(
     __in BOOL fPartialOK
     )
 {
+    return FileReadPartialEx(ppbDest, pcbDest, wzSrcPath, fSeek, cbStartPosition, cbMaxRead, fPartialOK, FILE_SHARE_READ | FILE_SHARE_DELETE);
+}
+
+/*******************************************************************
+ FileReadPartial - read a portion of a file into memory
+                   (with specified share mode)
+********************************************************************/
+extern "C" HRESULT DAPI FileReadPartialEx(
+    __deref_out_bcount_full(*pcbDest) LPBYTE* ppbDest,
+    __out_range(<=, cbMaxRead) DWORD* pcbDest,
+    __in_z LPCWSTR wzSrcPath,
+    __in BOOL fSeek,
+    __in DWORD cbStartPosition,
+    __in DWORD cbMaxRead,
+    __in BOOL fPartialOK,
+    __in DWORD dwShareMode
+    )
+{
     HRESULT hr = S_OK;
 
     UINT er = ERROR_SUCCESS;
@@ -844,7 +876,7 @@ extern "C" HRESULT DAPI FileReadPartial(
     ExitOnNull(wzSrcPath, hr, E_INVALIDARG, "Invalid argument wzSrcPath");
     ExitOnNull(*wzSrcPath, hr, E_INVALIDARG, "*wzSrcPath is null");
 
-    hFile = ::CreateFileW(wzSrcPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+    hFile = ::CreateFileW(wzSrcPath, GENERIC_READ, dwShareMode, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
         er = ::GetLastError();

--- a/src/libs/dutil/inc/fileutil.h
+++ b/src/libs/dutil/inc/fileutil.h
@@ -109,6 +109,12 @@ HRESULT DAPI FileRead(
     __out DWORD* pcbDest,
     __in_z LPCWSTR wzSrcPath
     );
+HRESULT DAPI FileReadEx(
+    __deref_out_bcount_full(*pcbDest) LPBYTE* ppbDest,
+    __out DWORD* pcbDest,
+    __in_z LPCWSTR wzSrcPath,
+    __in DWORD dwShareMode
+    );
 HRESULT DAPI FileReadUntil(
     __deref_out_bcount_full(*pcbDest) LPBYTE* ppbDest,
     __out_range(<=, cbMaxRead) DWORD* pcbDest,
@@ -123,6 +129,16 @@ HRESULT DAPI FileReadPartial(
     __in DWORD cbStartPosition,
     __in DWORD cbMaxRead,
     __in BOOL fPartialOK
+    );
+HRESULT DAPI FileReadPartialEx(
+    __deref_out_bcount_full(*pcbDest) LPBYTE* ppbDest,
+    __out_range(<=, cbMaxRead) DWORD* pcbDest,
+    __in_z LPCWSTR wzSrcPath,
+    __in BOOL fSeek,
+    __in DWORD cbStartPosition,
+    __in DWORD cbMaxRead,
+    __in BOOL fPartialOK,
+    __in DWORD dwShareMode
     );
 HRESULT DAPI FileWrite(
     __in_z LPCWSTR pwzFileName,


### PR DESCRIPTION
I somehow scrounged up a bit of time to do some settings engine work.

Feature #4355: Settings engine doesn't handle files that are always locked for write (such as database files) very well

When writing a file back out to disk, if we can't get a file write lock, that isn't necessarily a failure - first check if we actually had something different to write, and if not, there is nothing to do.

Also when reading a file from disk, we typically don't want FILE_SHARE_WRITE share mode (because it means we're probably reading a file mid-write, which is essentially backing up a corrupt version of the file), but there are a few apps that we do want to enable this share mode for, such as apps that work with a settings DB, and leave it open for the lifetime of the app. In this case, the manifest now allows opting in to this behavior in the filter section (so it can be done for certain file extensions, all files in certain subdirectories, or just some particular file).
