### PR TITLE
Feature #4400: Store UDM Manifests as blobs instead of strings

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* MikeGC: Feature #4400: Store UDM Manifests as blobs instead of strings
+
 * MikeGC: Bug #4435: Sync requests must be deduped to avoid the possibility of building up too many sync requests for the same location
 
 * MikeGC: Feature #4355: Settings engine doesn't handle files that are always locked for write (such as database files) very well

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -934,7 +934,7 @@ extern "C" HRESULT CFGAPI CfgSetBlob(
     }
 
     hr = ValueSetBlob(pbBuffer, cbBuffer, FALSE, NULL, pcdb->sczGuid, &cvValue);
-    ExitOnFailure(hr, "Failed to set delete value in memory");
+    ExitOnFailure(hr, "Failed to set blob value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
     ExitOnFailure1(hr, "Failed to set blob: %ls", wzName);

--- a/src/SettingsEngine/lib/cfgleg.cpp
+++ b/src/SettingsEngine/lib/cfgleg.cpp
@@ -85,7 +85,7 @@ HRESULT CfgLegacyImportProductFromXMLFile(
     hr = ProductGetLegacyManifestValueName(product.sczProductId, &sczManifestValueName);
     ExitOnFailure(hr, "Failed to get legacy manifest value name");
 
-    hr = ValueSetString(sczContent, FALSE, NULL, pcdb->sczGuid, &cvValue);
+    hr = ValueSetBlob(reinterpret_cast<BYTE *>(sczContent), lstrlenW(sczContent) * sizeof(WCHAR), FALSE, NULL, pcdb->sczGuid, &cvValue);
     ExitOnFailure(hr, "Failed to set manifest contents as string value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwCfgAppID, sczManifestValueName, &cvValue, TRUE);

--- a/src/SettingsEngine/lib/value.cpp
+++ b/src/SettingsEngine/lib/value.cpp
@@ -429,7 +429,7 @@ HRESULT ValueWrite(
         {
             ExitOnFailure1(hr, "Failed to check if value name is legacy manifest path: %ls", wzName);
 
-            if (VALUE_STRING == pcvValue->cvType)
+            if (VALUE_BLOB == pcvValue->cvType)
             {
                 hr = LogStringLine(REPORT_STANDARD, "Received new manifest for product %ls, %ls, %ls", sczProductName, wzLegacyVersion, wzLegacyPublicKey);
                 ExitOnFailure(hr, "Failed to log line");


### PR DESCRIPTION
Doing this has 2 benefits:

1) Makes the database file smaller
2) Allows users to export a manifest they're using as a file for inspection / debugging
