### PR TITLE
Fix Browser Shutdown Issue

### DIFF
--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -197,10 +197,7 @@ LExit:
             {
                 CfgAdminUninitialize(bdlDatabaseList.rgDatabases[i].cdb);
             }
-            else
-            {
-                CfgUninitialize(bdlDatabaseList.rgDatabases[i].cdb);
-            }
+            // Don't free local database here - we only have one open, it must be freed after all remotes, and is specifically freed below this loop
         }
 
         ReleaseDB(bdlDatabaseList.rgDatabases + i);


### PR DESCRIPTION
Local database handle must be uninitialized only after all remotes are shut down. The code now is shutting it down twice, once as part of the loop where we uninitialize remotes, and again below the loop. It should be shut down only after all remotes are shut down.
