### PR TITLE
Define variadic macros for use throughout the code base

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: Redefine Exit\* macros as variadic macros
+
 * MikeGC: Feature #4400: Store UDM Manifests as blobs instead of strings
 
 * MikeGC: Bug #4435: Sync requests must be deduped to avoid the possibility of building up too many sync requests for the same location

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -265,10 +265,10 @@ HRESULT ProcessCommandLine(
                 ++i;
 
                 hr = MemEnsureArraySize((LPVOID *)&pCommandLineRequest->rgsczLegacyManifests, pCommandLineRequest->cLegacyManifests + 1, sizeof(LPWSTR), 10);
-                ExitOnFailure1(hr, "Failed to resize legacy manifest array to size %u", pCommandLineRequest->cLegacyManifests + 1);
+                ExitOnFailure(hr, "Failed to resize legacy manifest array to size %u", pCommandLineRequest->cLegacyManifests + 1);
 
                 hr = PathExpand(&pCommandLineRequest->rgsczLegacyManifests[pCommandLineRequest->cLegacyManifests], argv[i], PATH_EXPAND_FULLPATH);
-                ExitOnFailure1(hr, "Failed to expand legacy manifest path %ls", argv[i]);
+                ExitOnFailure(hr, "Failed to expand legacy manifest path %ls", argv[i]);
 
                 ++(pCommandLineRequest->cLegacyManifests);
             }
@@ -887,7 +887,7 @@ static HRESULT CheckProductInstalledState(
         }
 
         hr = CfgIsProductRegistered(pcdLocalHandle, wzProductName, wzVersion, wzPublicKey, *prgfInstalled + i);
-        ExitOnFailure3(hr, "Failed to check if product is registered: %ls, %ls, %ls", wzProductName, wzVersion, (NULL == wzPublicKey) ? L"NULL" : wzPublicKey);
+        ExitOnFailure(hr, "Failed to check if product is registered: %ls, %ls, %ls", wzProductName, wzVersion, (NULL == wzPublicKey) ? L"NULL" : wzPublicKey);
     }
 
 LExit:

--- a/src/SettingsEngine/browse/message.cpp
+++ b/src/SettingsEngine/browse/message.cpp
@@ -32,12 +32,12 @@ HRESULT SendDwordString(
     if (NULL != wzString1)
     {
         hr = StrAllocString(&pDwordString->sczString1, wzString1, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string1: %ls", wzString1);
+        ExitOnFailure(hr, "Failed to allocate copy of string1: %ls", wzString1);
     }
 
     if (!::PostThreadMessageW(dwThreadId, dwMessageId, dwDatabaseIndex, reinterpret_cast<LPARAM>(pDwordString)))
     {
-        ExitWithLastError1(hr, "Failed to send message %u to worker thread", dwMessageId);
+        ExitWithLastError(hr, "Failed to send message %u to worker thread", dwMessageId);
     }
 
     pDwordString = NULL;
@@ -66,12 +66,12 @@ HRESULT SendQwordString(
     if (NULL != wzString1)
     {
         hr = StrAllocString(&pQwordString->sczString1, wzString1, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string1: %ls", wzString1);
+        ExitOnFailure(hr, "Failed to allocate copy of string1: %ls", wzString1);
     }
 
     if (!::PostThreadMessageW(dwThreadId, dwMessageId, dwDatabaseIndex, reinterpret_cast<LPARAM>(pQwordString)))
     {
-        ExitWithLastError1(hr, "Failed to send message %u to worker thread", dwMessageId);
+        ExitWithLastError(hr, "Failed to send message %u to worker thread", dwMessageId);
     }
 
     pQwordString = NULL;
@@ -98,18 +98,18 @@ HRESULT SendStringPair(
     if (NULL != wzString1)
     {
         hr = StrAllocString(&pStringPair->sczString1, wzString1, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string1: %ls", wzString1);
+        ExitOnFailure(hr, "Failed to allocate copy of string1: %ls", wzString1);
     }
 
     if (NULL != wzString2)
     {
         hr = StrAllocString(&pStringPair->sczString2, wzString2, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string2: %ls", wzString2);
+        ExitOnFailure(hr, "Failed to allocate copy of string2: %ls", wzString2);
     }
 
     if (!::PostThreadMessageW(dwThreadId, dwMessageId, dwDatabaseIndex, reinterpret_cast<LPARAM>(pStringPair)))
     {
-        ExitWithLastError1(hr, "Failed to send message %u to worker thread", dwMessageId);
+        ExitWithLastError(hr, "Failed to send message %u to worker thread", dwMessageId);
     }
 
     pStringPair = NULL;
@@ -137,24 +137,24 @@ HRESULT SendStringTriplet(
     if (NULL != wzString1)
     {
         hr = StrAllocString(&pStringTriplet->sczString1, wzString1, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string1: %ls", wzString1);
+        ExitOnFailure(hr, "Failed to allocate copy of string1: %ls", wzString1);
     }
 
     if (NULL != wzString2)
     {
         hr = StrAllocString(&pStringTriplet->sczString2, wzString2, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string2: %ls", wzString2);
+        ExitOnFailure(hr, "Failed to allocate copy of string2: %ls", wzString2);
     }
 
     if (NULL != wzString3)
     {
         hr = StrAllocString(&pStringTriplet->sczString3, wzString3, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string3: %ls", wzString3);
+        ExitOnFailure(hr, "Failed to allocate copy of string3: %ls", wzString3);
     }
 
     if (!::PostThreadMessageW(dwThreadId, dwMessageId, dwDatabaseIndex, reinterpret_cast<LPARAM>(pStringTriplet)))
     {
-        ExitWithLastError1(hr, "Failed to send message %u to worker thread", dwMessageId);
+        ExitWithLastError(hr, "Failed to send message %u to worker thread", dwMessageId);
     }
 
     pStringTriplet = NULL;
@@ -185,19 +185,19 @@ HRESULT SendBackgroundStatusCallback(
     if (NULL != wzString1)
     {
         hr = StrAllocString(&pBackgroundStatusCallback->sczString1, wzString1, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string1: %ls", wzString1);
+        ExitOnFailure(hr, "Failed to allocate copy of string1: %ls", wzString1);
     }
 
     if (NULL != wzString2)
     {
         hr = StrAllocString(&pBackgroundStatusCallback->sczString2, wzString2, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string2: %ls", wzString2);
+        ExitOnFailure(hr, "Failed to allocate copy of string2: %ls", wzString2);
     }
 
     if (NULL != wzString3)
     {
         hr = StrAllocString(&pBackgroundStatusCallback->sczString3, wzString3, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of string3: %ls", wzString3);
+        ExitOnFailure(hr, "Failed to allocate copy of string3: %ls", wzString3);
     }
 
     if (!::PostThreadMessageW(dwThreadId, WM_BROWSE_BACKGROUND_STATUS_CALLBACK, reinterpret_cast<WPARAM>(pBackgroundStatusCallback), 0))

--- a/src/SettingsEngine/browse/precomp.h
+++ b/src/SettingsEngine/browse/precomp.h
@@ -14,9 +14,9 @@
 #pragma once
 
 #define ExitTrace LogErrorString
-#define ExitTrace1 LogErrorString
-#define ExitTrace2 LogErrorString
-#define ExitTrace3 LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
 
 #include <windows.h>
 #include <windowsx.h>

--- a/src/SettingsEngine/browse/ui.cpp
+++ b/src/SettingsEngine/browse/ui.cpp
@@ -187,19 +187,19 @@ HRESULT UISetListViewText(
     for (DWORD i = 1; i < uNumColumns; ++i)
     {
         hr = UIListViewSetItemText(hwnd, dwTopIndex, i, L"");
-        ExitOnFailure1(hr, "Failed to clear text on sub item %u", i);
+        ExitOnFailure(hr, "Failed to clear text on sub item %u", i);
     }
 
     // Now do so for all remaining rows of the listview that are visible
     for (DWORD i = dwTopIndex + 1; i < dwNumRows; ++i)
     {
         hr = UIListViewSetItem(hwnd, i, L"", 0, DWORD_MAX);
-        ExitOnFailure1(hr, "Failed to set row %u first column", i);
+        ExitOnFailure(hr, "Failed to set row %u first column", i);
 
         for (DWORD j = 1; j < uNumColumns; ++j)
         {
             hr = UIListViewSetItemText(hwnd, i, j, L"");
-            ExitOnFailure1(hr, "Failed to clear text on sub item %u", j);
+            ExitOnFailure(hr, "Failed to clear text on sub item %u", j);
         }
     }
 
@@ -687,7 +687,7 @@ HRESULT UISetValueConflictsFromListView(
             if (0 > lvItem.lParam || pcpProductConflict->cValues <= static_cast<DWORD>(lvItem.lParam))
             {
                 hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid param %d stored in listview!", lvItem.lParam);
+                ExitOnFailure(hr, "Invalid param %d stored in listview!", lvItem.lParam);
             }
 
             pcpProductConflict->rgrcValueChoices[lvItem.lParam] = rcChoice;
@@ -735,7 +735,7 @@ HRESULT UISetProductConflictsFromListView(
             if (0 > lvItem.lParam || cProductCount <= static_cast<DWORD>(lvItem.lParam))
             {
                 hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid param %d stored in listview!", lvItem.lParam);
+                ExitOnFailure(hr, "Invalid param %d stored in listview!", lvItem.lParam);
             }
 
             for (DWORD j = 0; j < pcplProductConflictList[lvItem.lParam].cValues; ++j)
@@ -940,7 +940,7 @@ HRESULT UIListViewSetItemText(
 
     if (-1 == ::SendMessageW(hwnd, LVM_SETITEMTEXTW, static_cast<LPARAM>(dwIndex), reinterpret_cast<LPARAM>(&lvi)))
     {
-        ExitWithLastError2(hr, "Failed to set field in listview - row %u, column %u", dwIndex, dwColumnIndex);
+        ExitWithLastError(hr, "Failed to set field in listview - row %u, column %u", dwIndex, dwColumnIndex);
     }
 
 LExit:
@@ -967,7 +967,7 @@ HRESULT UIListViewSetItem(
 
     if (-1 == ::SendMessageW(hwnd, LVM_SETITEMW, static_cast<LPARAM>(dwIndex), reinterpret_cast<LPARAM>(&lvi)))
     {
-        ExitWithLastError1(hr, "Failed to set first column item in listview - row %u", dwIndex);
+        ExitWithLastError(hr, "Failed to set first column item in listview - row %u", dwIndex);
     }
 
 LExit:

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -1298,19 +1298,19 @@ LRESULT CALLBACK BrowseWindow::WndProc(
             for (DWORD i = 0; i < UXDATABASE(dwIndex).dwDatabaseListCount; ++i)
             {
                 hr = CfgEnumReadString(UXDATABASE(dwIndex).cehDatabaseList, i, ENUM_DATA_FRIENDLY_NAME, &wzText);
-                ExitOnFailure1(hr, "Failed to read friendly name from database enumeration at index: %u", i);
+                ExitOnFailure(hr, "Failed to read friendly name from database enumeration at index: %u", i);
 
                 hr = StrAllocString(&UXDATABASE(rgdwDwords[i]).sczName, wzText, 0);
                 ExitOnFailure(hr, "Failed to copy friendly name to database array");
 
                 hr = CfgEnumReadString(UXDATABASE(dwIndex).cehDatabaseList, i, ENUM_DATA_PATH, &wzText);
-                ExitOnFailure1(hr, "Failed to read path from database enumeration at index: %u", i);
+                ExitOnFailure(hr, "Failed to read path from database enumeration at index: %u", i);
 
                 hr = StrAllocString(&UXDATABASE(rgdwDwords[i]).sczPath, wzText, 0);
                 ExitOnFailure(hr, "Failed to copy path to database array");
 
                 hr = CfgEnumReadBool(UXDATABASE(dwIndex).cehDatabaseList, i, ENUM_DATA_SYNC_BY_DEFAULT, &UXDATABASE(rgdwDwords[i]).fSyncByDefault);
-                ExitOnFailure1(hr, "Failed to read sync by default flag from database enumeration at index: %u", i);
+                ExitOnFailure(hr, "Failed to read sync by default flag from database enumeration at index: %u", i);
 
                 UXDATABASE(rgdwDwords[i]).fChecked = UXDATABASE(rgdwDwords[i]).fSyncByDefault;
                 UXDATABASE(rgdwDwords[i]).fRemember = TRUE;
@@ -1318,7 +1318,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
 
                 if (!::PostThreadMessageW(pUX->m_dwWorkThreadId, WM_BROWSE_OPEN_REMOTE, static_cast<LPARAM>(rgdwDwords[i]), 0))
                 {
-                    ExitWithLastError1(hr, "Failed to send message to worker thread to open remote database (index %u)", rgdwDwords[i]);
+                    ExitWithLastError(hr, "Failed to send message to worker thread to open remote database (index %u)", rgdwDwords[i]);
                 }
             }
 
@@ -1520,13 +1520,13 @@ LRESULT CALLBACK BrowseWindow::WndProc(
 
         // And for the database we synced with
         hr = pUX->EnumerateProducts(dwIndex);
-        ExitOnFailure1(hr, "Failed to enumerate products in remote database index:%u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate products in remote database index:%u", dwIndex);
 
         hr = pUX->EnumerateValues(dwIndex);
-        ExitOnFailure1(hr, "Failed to enumerate values in remote database index:%u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate values in remote database index:%u", dwIndex);
 
         hr = pUX->EnumerateValueHistory(dwIndex);
-        ExitOnFailure1(hr, "Failed to enumerate value history in remote database index:%u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate value history in remote database index:%u", dwIndex);
 
         ExitFunction();
 
@@ -1709,7 +1709,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
                 ListView_GetItem(::GetDlgItem(pUX->m_hWnd, BROWSE_CONTROL_PRODUCT_LIST_VIEW), &lvItem);
 
                 hr = pUX->SetSelectedProduct(lvItem.lParam);
-                ExitOnFailure1(hr, "Failed to set selected product to index: %u", lpnmitem->lParam);
+                ExitOnFailure(hr, "Failed to set selected product to index: %u", lpnmitem->lParam);
                 break;
             default:
                 break;
@@ -1777,7 +1777,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
                 {
                 case NM_DBLCLK:
                     hr = pUX->SetDatabaseIndex(dwIndex);
-                    ExitOnFailure1(hr, "Failed to set database index to: %u", dwIndex);
+                    ExitOnFailure(hr, "Failed to set database index to: %u", dwIndex);
 
                     pUX->m_dwOtherDatabaseIndex = pUX->m_dwDatabaseIndex;
 
@@ -1790,7 +1790,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
                     ListView_GetItem(::GetDlgItem(pUX->m_hWnd, BROWSE_CONTROL_OTHERDATABASES_VIEW), &lvItem);
 
                     hr = pUX->SetDatabaseIndex(dwIndex);
-                    ExitOnFailure1(hr, "Failed to set database index to: %u", static_cast<DWORD>(lvItem.lParam));
+                    ExitOnFailure(hr, "Failed to set database index to: %u", static_cast<DWORD>(lvItem.lParam));
 
                     pUX->m_dwOtherDatabaseIndex = pUX->m_dwDatabaseIndex;
                     break;
@@ -2466,7 +2466,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
 
                 if (!::PostThreadMessageW(pUX->m_dwWorkThreadId, WM_BROWSE_OPEN_REMOTE, static_cast<LPARAM>(pUX->m_dwOtherDatabaseIndex), 0))
                 {
-                    ExitWithLastError3(hr, "Failed to send message to worker thread to reconnect to remote database (index %u, name %ls, path %ls)", pUX->m_dwOtherDatabaseIndex, CURRENTUXDATABASE.sczName, CURRENTUXDATABASE.sczPath);
+                    ExitWithLastError(hr, "Failed to send message to worker thread to reconnect to remote database (index %u, name %ls, path %ls)", pUX->m_dwOtherDatabaseIndex, CURRENTUXDATABASE.sczName, CURRENTUXDATABASE.sczPath);
                 }
 
                 hr = pUX->SetPreviousScreen();
@@ -2485,7 +2485,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
 
                 if (!::PostThreadMessageW(pUX->m_dwWorkThreadId, WM_BROWSE_DISCONNECT, static_cast<LPARAM>(pUX->m_dwOtherDatabaseIndex), 0))
                 {
-                    ExitWithLastError3(hr, "Failed to send message to worker thread to disconnect remote database (index %u, name %ls, path %ls)", pUX->m_dwOtherDatabaseIndex, CURRENTUXDATABASE.sczName, CURRENTUXDATABASE.sczPath);
+                    ExitWithLastError(hr, "Failed to send message to worker thread to disconnect remote database (index %u, name %ls, path %ls)", pUX->m_dwOtherDatabaseIndex, CURRENTUXDATABASE.sczName, CURRENTUXDATABASE.sczPath);
                 }
 
                 hr = pUX->SetPreviousScreen();
@@ -2594,7 +2594,7 @@ HRESULT BrowseWindow::SetTab(
     else if (BROWSE_TAB_OTHERDATABASES == tab)
     {
         hr = SetDatabaseIndex(m_dwOtherDatabaseIndex);
-        ExitOnFailure1(hr, "Failed to set database index to %u", m_dwOtherDatabaseIndex);
+        ExitOnFailure(hr, "Failed to set database index to %u", m_dwOtherDatabaseIndex);
 
         hr = SetOtherDatabasesState(m_otherDatabasesState);
         ExitOnFailure(hr, "Failed while switching 'other databases' state");
@@ -2617,7 +2617,7 @@ HRESULT BrowseWindow::SetMainState(
     DWORD dwNewPageId = 0;
     DWORD dwOldPageId = 0;
 
-    Trace2(REPORT_STANDARD, "BrowseWindow::SetMainState() changing from state %d to %d", m_mainState, state);
+    Trace(REPORT_STANDARD, "BrowseWindow::SetMainState() changing from state %d to %d", m_mainState, state);
 
     if (state != m_mainState)
     {
@@ -2677,7 +2677,7 @@ HRESULT BrowseWindow::SetOtherDatabasesState(
     DWORD dwNewPageId = 0;
     DWORD dwOldPageId = 0;
 
-    Trace2(REPORT_STANDARD, "BrowseWindow::SetOtherDatabasesState() changing from state %d to %d", m_otherDatabasesState, state);
+    Trace(REPORT_STANDARD, "BrowseWindow::SetOtherDatabasesState() changing from state %d to %d", m_otherDatabasesState, state);
 
     if (state != m_otherDatabasesState)
     {

--- a/src/SettingsEngine/lib/backgrnd.cpp
+++ b/src/SettingsEngine/lib/backgrnd.cpp
@@ -351,7 +351,7 @@ HRESULT BackgroundMarkRemoteChanged(
 
         if (!::PostThreadMessageW(pcdbRemote->pcdbLocal->dwBackgroundThreadId, BACKGROUND_THREAD_SYNC_FROM_REMOTE, reinterpret_cast<WPARAM>(sczDirectory), static_cast<LPARAM>(FALSE)))
         {
-            ExitWithLastError1(hr, "Failed to send message to background thread to sync from remote at directory %ls", sczDirectory);
+            ExitWithLastError(hr, "Failed to send message to background thread to sync from remote at directory %ls", sczDirectory);
         }
         sczDirectory = NULL;
     }
@@ -565,7 +565,7 @@ static DWORD WINAPI BackgroundThread(
                 // Intentionally don't log here, because MonUtil will occasionally send false positive "ping" notifications
 
                 hr = PropagateRemotes(pcdb, sczString1, static_cast<BOOL>(msg.lParam));
-                ExitOnFailure2(hr, "Failed to propagate remotes with from value of %ls, fCheckDbTimestamp=%ls", sczString1, static_cast<BOOL>(msg.lParam) ? L"TRUE" : L"FALSE");
+                ExitOnFailure(hr, "Failed to propagate remotes with from value of %ls, fCheckDbTimestamp=%ls", sczString1, static_cast<BOOL>(msg.lParam) ? L"TRUE" : L"FALSE");
                 break;
 
             case BACKGROUND_THREAD_UPDATE_PRODUCT:
@@ -707,7 +707,7 @@ static HRESULT BeginMonitoring(
     hr = SceGetFirstRow(pcdb->psceDb, PRODUCT_INDEX_TABLE, &sceRow);
     while (E_NOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to get row from table: %u", PRODUCT_INDEX_TABLE);
+        ExitOnFailure(hr, "Failed to get row from table: %u", PRODUCT_INDEX_TABLE);
 
         hr = SceGetColumnBool(sceRow, PRODUCT_IS_LEGACY, &fIsLegacy);
         ExitOnFailure(hr, "Failed to check if product is legacy");
@@ -780,7 +780,7 @@ static HRESULT BeginMonitoringProduct(
     ExitOnFailure(hr, "Failed to set product in legacy sync session");
 
     hr = AddProductToMonitorList(pcdb, &pSyncSession->syncProductSession.product, sczName, pContext);
-    ExitOnFailure1(hr, "Failed to add product %ls to monitor list", sczName);
+    ExitOnFailure(hr, "Failed to add product %ls to monitor list", sczName);
 
     pcdb->vpfBackgroundStatus(S_OK, BACKGROUND_STATUS_SYNCING_PRODUCT, sczName, wzLegacyVersion, wzLegacyPublicKey, pcdb->pvCallbackContext);
     fSyncingProduct = TRUE;
@@ -792,7 +792,7 @@ static HRESULT BeginMonitoringProduct(
     if (pSyncSession->syncProductSession.fRegistered && !pSyncSession->syncProductSession.fNewlyRegistered)
     {
         hr = LegacySyncPullDeletedValues(pcdb, &pSyncSession->syncProductSession);
-        ExitOnFailure1(hr, "Failed to check for deleted registry values for product %u", dwAppID);
+        ExitOnFailure(hr, "Failed to check for deleted registry values for product %u", dwAppID);
     }
 
     hr = LegacySyncFinalizeProduct(pcdb, pSyncSession);
@@ -883,7 +883,7 @@ static void MonDirectoryCallback(
     {
         if (!::PostThreadMessageW(pContext->dwBackgroundThreadId, BACKGROUND_THREAD_ERROR_MONITORING, static_cast<WPARAM>(hrResult), reinterpret_cast<LPARAM>(pSyncRequest)))
         {
-            ExitWithLastError1(hr, "Failed to send message to worker thread to notify MonUtil cannot watch directory %ls", wzPath);
+            ExitWithLastError(hr, "Failed to send message to worker thread to notify MonUtil cannot watch directory %ls", wzPath);
         }
     }
     else
@@ -932,7 +932,7 @@ static void MonRegKeyCallback(
     {
         if (!::PostThreadMessageW(pContext->dwBackgroundThreadId, BACKGROUND_THREAD_DETECT, static_cast<WPARAM>(hrResult), 0))
         {
-            ExitWithLastError1(hr, "Failed to send message to worker thread to notify MonUtil to re-detect", wzSubKey);
+            ExitWithLastError(hr, "Failed to send message to worker thread to notify MonUtil to re-detect", wzSubKey);
         }
         ExitFunction1(hr = S_OK);
     }
@@ -951,7 +951,7 @@ static void MonRegKeyCallback(
     {
         if (!::PostThreadMessageW(pContext->dwBackgroundThreadId, BACKGROUND_THREAD_ERROR_MONITORING, static_cast<WPARAM>(hrResult), reinterpret_cast<LPARAM>(pSyncRequest)))
         {
-            ExitWithLastError1(hr, "Failed to send message to worker thread to notify MonUtil cannot watch subkey %ls", wzSubKey);
+            ExitWithLastError(hr, "Failed to send message to worker thread to notify MonUtil cannot watch subkey %ls", wzSubKey);
         }
     }
     else
@@ -1049,14 +1049,14 @@ static HRESULT HandleSyncRequest(
     if (pMonitorItem->fRemote)
     {
         hr = StrAllocString(&sczTemp, pSyncRequest->sczPath, 0);
-        ExitOnFailure1(hr, "Failed to copy sync request string %ls", pSyncRequest->sczPath);
+        ExitOnFailure(hr, "Failed to copy sync request string %ls", pSyncRequest->sczPath);
 
         // If we previously failed to connect to this remote and now we can again, don't check timestamp, because we need to both push and pull changes
         fCheckDbTimestamp = !fReconnected;
 
         if (!::PostThreadMessageW(pcdb->dwBackgroundThreadId, BACKGROUND_THREAD_SYNC_FROM_REMOTE, reinterpret_cast<WPARAM>(sczTemp), static_cast<LPARAM>(fCheckDbTimestamp)))
         {
-            ExitWithLastError1(hr, "Failed to send message to background thread to sync from remote %ls", sczTemp);
+            ExitWithLastError(hr, "Failed to send message to background thread to sync from remote %ls", sczTemp);
         }
         sczTemp = NULL;
     }
@@ -1134,7 +1134,7 @@ static HRESULT HandleDriveStatusUpdate(
                 // we should check that the DB guid matches expected value!
                 if (!::PostThreadMessageW(pcdb->dwBackgroundThreadId, BACKGROUND_THREAD_SYNC_FROM_REMOTE, reinterpret_cast<WPARAM>(sczDirectory), static_cast<LPARAM>(FALSE)))
                 {
-                    ExitWithLastError1(hr, "Failed to send message to background thread to sync from remote %ls", sczDirectory);
+                    ExitWithLastError(hr, "Failed to send message to background thread to sync from remote %ls", sczDirectory);
                 }
                 sczDirectory = NULL;
             }
@@ -1268,7 +1268,7 @@ static HRESULT FindSyncRequest(
     if (DWORD_MAX == *pdwIndex)
     {
         hr = E_NOTFOUND;
-        ExitOnFailure2(hr, "Monitor of type %u for path %ls wasn't found", pSyncRequest->type, pSyncRequest->sczPath);
+        ExitOnFailure(hr, "Monitor of type %u for path %ls wasn't found", pSyncRequest->type, pSyncRequest->sczPath);
     }
 
 LExit:
@@ -1317,7 +1317,7 @@ static HRESULT AddProductToMonitorList(
             }
 
             hr = MemEnsureArraySize(reinterpret_cast<void **>(&pContext->rgMonitorItems), pContext->cMonitorItems + 1, sizeof(MONITOR_ITEM), BACKGROUND_ARRAY_GROWTH);
-            ExitOnFailure1(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
+            ExitOnFailure(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
             ++pContext->cMonitorItems;
 
             pItem = pContext->rgMonitorItems + pContext->cMonitorItems - 1;
@@ -1346,7 +1346,7 @@ static HRESULT AddProductToMonitorList(
         if (NULL != pProduct->rgFiles[i].sczExpandedPath)
         {
             hr = PathGetDirectory(pProduct->rgFiles[i].sczExpandedPath, &sczDirectory);
-            ExitOnFailure1(hr, "Failed to get directory portion of path %ls", pProduct->rgFiles[i].sczExpandedPath);
+            ExitOnFailure(hr, "Failed to get directory portion of path %ls", pProduct->rgFiles[i].sczExpandedPath);
 
             BOOL fRecursive = (LEGACY_FILE_PLAIN == pProduct->rgFiles[i].legacyFileType) ? FALSE : TRUE;
 
@@ -1372,7 +1372,7 @@ static HRESULT AddProductToMonitorList(
                 }
 
                 hr = MemEnsureArraySize(reinterpret_cast<void **>(&pContext->rgMonitorItems), pContext->cMonitorItems + 1, sizeof(MONITOR_ITEM), BACKGROUND_ARRAY_GROWTH);
-                ExitOnFailure1(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
+                ExitOnFailure(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
                 ++pContext->cMonitorItems;
 
                 pItem = pContext->rgMonitorItems + pContext->cMonitorItems - 1;
@@ -1475,10 +1475,10 @@ static HRESULT UpdateProductInMonitorList(
     dwOriginalAppIDLocal = pcdb->dwAppID;
 
     hr = ProductFindRow(pcdb, PRODUCT_INDEX_TABLE, wzProductName, wzLegacyVersion, wzLegacyPublicKey, &sceRow);
-    ExitOnFailure1(hr, "Failed to find row for legacy product %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to find row for legacy product %ls", wzProductName);
 
     hr = BeginMonitoringProduct(pcdb, sceRow, &syncSession, pContext);
-    ExitOnFailure1(hr, "Failed to begin monitoring product %ls while updating product in monitor list", wzProductName);
+    ExitOnFailure(hr, "Failed to begin monitoring product %ls while updating product in monitor list", wzProductName);
 
     hr = BackgroundSyncRemotes(pcdb);
     ExitOnFailure(hr, "Failed to send message to background thread to sync to remotes");
@@ -1512,13 +1512,13 @@ static HRESULT AddRemoteToMonitorList(
     BOOL fLocked = FALSE;
 
     hr = PathGetDirectory(wzPath, &sczDirectory);
-    ExitOnFailure1(hr, "Failed to get directory portion of remote path %ls", wzPath);
+    ExitOnFailure(hr, "Failed to get directory portion of remote path %ls", wzPath);
 
     // If this directory is already watched by some other product, add our product ID to the appID list for that monitor
     if (!FindDirectoryMonitorIndex(pContext, sczDirectory, FALSE, &dwIndex))
     {
         hr = MemEnsureArraySize(reinterpret_cast<void **>(&pContext->rgMonitorItems), pContext->cMonitorItems + 1, sizeof(MONITOR_ITEM), BACKGROUND_ARRAY_GROWTH);
-        ExitOnFailure1(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
+        ExitOnFailure(hr, "Failed to increase space after %u monitor items", pContext->cMonitorItems);
         ++pContext->cMonitorItems;
 
         pItem = pContext->rgMonitorItems + pContext->cMonitorItems - 1;
@@ -1537,10 +1537,10 @@ static HRESULT AddRemoteToMonitorList(
         dwOriginalAppIDLocal = pcdb->dwAppID;
 
         hr = MonAddDirectory(pContext->monitorHandle, pItem->sczPath, TRUE, REMOTEDB_SILENCE_PERIOD, NULL);
-        ExitOnFailure1(hr, "Failed to add directory %ls for monitoring", pItem->sczPath);
+        ExitOnFailure(hr, "Failed to add directory %ls for monitoring", pItem->sczPath);
 
         hr = SyncRemotes(pcdb, pItem->sczPath, FALSE);
-        ExitOnFailure1(hr, "Failed to sync remotes starting with the one under directory %ls", pItem->sczPath);
+        ExitOnFailure(hr, "Failed to sync remotes starting with the one under directory %ls", pItem->sczPath);
     }
     else
     {
@@ -1571,7 +1571,7 @@ static HRESULT RemoveRemoteFromMonitorList(
     LPWSTR sczDirectory = NULL;
 
     hr = PathGetDirectory(wzPath, &sczDirectory);
-    ExitOnFailure1(hr, "Failed to get directory portion of remote path %ls", wzPath);
+    ExitOnFailure(hr, "Failed to get directory portion of remote path %ls", wzPath);
 
     for (DWORD i = 0; i < pContext->cMonitorItems; ++i)
     {
@@ -1621,7 +1621,7 @@ static HRESULT PropagateRemotes(
     BOOL fLocked = FALSE;
 
     hr = HandleLock(pcdb);
-    ExitOnFailure1(hr, "Failed to lock handle while propagating remotes from %ls", wzFrom);
+    ExitOnFailure(hr, "Failed to lock handle while propagating remotes from %ls", wzFrom);
     fLocked = TRUE;
     dwOriginalAppIDLocal = pcdb->dwAppID;
 
@@ -1767,7 +1767,7 @@ static HRESULT SyncRemote(
     if (fCheckDbTimestamp)
     {
         hr = FileGetTime(pcdb->sczDbPath, NULL, NULL, &ftLastModified);
-        ExitOnFailure1(hr, "Failed to get file time of remote db: %ls", pcdb->sczDbPath);
+        ExitOnFailure(hr, "Failed to get file time of remote db: %ls", pcdb->sczDbPath);
 
         if (0 == ::CompareFileTime(&ftLastModified, &pcdb->ftLastModified))
         {

--- a/src/SettingsEngine/lib/cfgadmin.cpp
+++ b/src/SettingsEngine/lib/cfgadmin.cpp
@@ -150,13 +150,13 @@ extern "C" HRESULT CfgAdminRegisterProduct(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle while registering product per-machine");
@@ -236,13 +236,13 @@ extern "C" HRESULT CfgAdminUnregisterProduct(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle while unregistering product per-machine");
@@ -310,13 +310,13 @@ extern "C" HRESULT CfgAdminIsProductRegistered(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle while checking if product is registered per-machine");
@@ -328,7 +328,7 @@ extern "C" HRESULT CfgAdminIsProductRegistered(
         *pfRegistered = FALSE;
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure3(hr, "Failed to search for product in admin database with name: '%ls' version '%ls' public key '%ls'", wzProductName, wzVersion, sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to search for product in admin database with name: '%ls' version '%ls' public key '%ls'", wzProductName, wzVersion, sczLowPublicKey);
 
     *pfRegistered = TRUE;
 

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -249,13 +249,13 @@ extern "C" HRESULT CfgSetProduct(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version while setting product: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version while setting product: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle when setting produt");
@@ -319,7 +319,7 @@ extern "C" HRESULT CfgSetDword(
     ExitOnFailure(hr, "Failed to set dword value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set DWORD value: %u", dwValue);
+    ExitOnFailure(hr, "Failed to set DWORD value: %u", dwValue);
 
     if (!pcdb->fRemote)
     {
@@ -379,7 +379,7 @@ extern "C" HRESULT CfgGetDword(
     }
 
     hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwAppID, wzName, &sceRow);
-    ExitOnFailure2(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
+    ExitOnFailure(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
 
     hr = ValueRead(pcdb, sceRow, &cvValue);
     ExitOnFailure(hr, "Failed to retrieve deleted column");
@@ -392,7 +392,7 @@ extern "C" HRESULT CfgGetDword(
     if (VALUE_DWORD != cvValue.cvType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as dword, but it's of type: %d", cvValue.cvType);
+        ExitOnFailure(hr, "Tried to retrieve value as dword, but it's of type: %d", cvValue.cvType);
     }
 
     *pdwValue = cvValue.dword.dwValue;
@@ -448,7 +448,7 @@ extern "C" HRESULT CfgSetQword(
     ExitOnFailure(hr, "Failed to set qword value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set QWORD value: %I64u", qwValue);
+    ExitOnFailure(hr, "Failed to set QWORD value: %I64u", qwValue);
 
     if (!pcdb->fRemote)
     {
@@ -508,7 +508,7 @@ extern "C" HRESULT CfgGetQword(
     }
 
     hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwAppID, wzName, &sceRow);
-    ExitOnFailure2(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
+    ExitOnFailure(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
 
     hr = ValueRead(pcdb, sceRow, &cvValue);
     ExitOnFailure(hr, "Failed to retrieve deleted column");
@@ -521,7 +521,7 @@ extern "C" HRESULT CfgGetQword(
     if (VALUE_QWORD != cvValue.cvType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as dword, but it's of type: %d", cvValue.cvType);
+        ExitOnFailure(hr, "Tried to retrieve value as dword, but it's of type: %d", cvValue.cvType);
     }
 
     *pqwValue = cvValue.qword.qwValue;
@@ -580,7 +580,7 @@ extern "C" HRESULT CfgSetString(
     ExitOnFailure(hr, "Failed to set string value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure2(hr, "Failed to set string value '%ls' to '%ls'", wzName, wzValue);
+    ExitOnFailure(hr, "Failed to set string value '%ls' to '%ls'", wzName, wzValue);
 
     if (!pcdb->fRemote)
     {
@@ -640,7 +640,7 @@ extern "C" HRESULT CfgGetString(
     fLocked = TRUE;
 
     hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwAppID, wzName, &sceRow);
-    ExitOnFailure2(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
+    ExitOnFailure(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
 
     hr = ValueRead(pcdb, sceRow, &cvValue);
     ExitOnFailure(hr, "Failed to retrieve deleted column");
@@ -653,7 +653,7 @@ extern "C" HRESULT CfgGetString(
     if (VALUE_STRING != cvValue.cvType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as string, but it's of type: %d", cvValue.cvType);
+        ExitOnFailure(hr, "Tried to retrieve value as string, but it's of type: %d", cvValue.cvType);
     }
 
     ReleaseStr(*psczValue);
@@ -713,7 +713,7 @@ extern "C" HRESULT CFGAPI CfgSetBool(
     ExitOnFailure(hr, "Failed to set bool value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set BOOL value named: %ls", wzName);
+    ExitOnFailure(hr, "Failed to set BOOL value named: %ls", wzName);
 
     if (!pcdb->fRemote)
     {
@@ -773,7 +773,7 @@ extern "C" HRESULT CFGAPI CfgGetBool(
     fLocked = TRUE;
 
     hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwAppID, wzName, &sceRow);
-    ExitOnFailure2(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
+    ExitOnFailure(hr, "Failed to find config value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, wzName);
 
     hr = ValueRead(pcdb, sceRow, &cvValue);
     ExitOnFailure(hr, "Failed to retrieve deleted column");
@@ -786,7 +786,7 @@ extern "C" HRESULT CFGAPI CfgGetBool(
     if (VALUE_BOOL != cvValue.cvType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as bool, but it's of type: %d", cvValue.cvType);
+        ExitOnFailure(hr, "Tried to retrieve value as bool, but it's of type: %d", cvValue.cvType);
     }
 
     *pfValue = cvValue.boolean.fValue;
@@ -844,7 +844,7 @@ extern "C" HRESULT CfgDeleteValue(
     ExitOnFailure(hr, "Failed to set delete value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure1(hr, "Failed to delete value: %ls", wzName);
+    ExitOnFailure(hr, "Failed to delete value: %ls", wzName);
 
     if (!pcdb->fRemote)
     {
@@ -937,7 +937,7 @@ extern "C" HRESULT CFGAPI CfgSetBlob(
     ExitOnFailure(hr, "Failed to set blob value in memory");
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzName, &cvValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set blob: %ls", wzName);
+    ExitOnFailure(hr, "Failed to set blob: %ls", wzName);
 
     if (!pcdb->fRemote)
     {
@@ -1004,7 +1004,7 @@ extern "C" HRESULT CFGAPI CfgGetBlob(
     {
         ExitFunction();
     }
-    ExitOnFailure2(hr, "Failed to find blob named: %ls for AppID: %u", wzName, pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to find blob named: %ls for AppID: %u", wzName, pcdb->dwAppID);
 
     hr = ValueRead(pcdb, sceRow, &cvValue);
     ExitOnFailure(hr, "Failed to retrieve deleted column");
@@ -1017,17 +1017,17 @@ extern "C" HRESULT CFGAPI CfgGetBlob(
     if (VALUE_BLOB != cvValue.cvType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as blob, but it's of type: %d", cvValue.cvType);
+        ExitOnFailure(hr, "Tried to retrieve value as blob, but it's of type: %d", cvValue.cvType);
     }
 
     if (CFG_BLOB_DB_STREAM != cvValue.blob.cbType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "Tried to retrieve value as db stream blob, but it's of type: %d", cvValue.blob.cbType);
+        ExitOnFailure(hr, "Tried to retrieve value as db stream blob, but it's of type: %d", cvValue.blob.cbType);
     }
 
     hr = StreamRead(pcdb, cvValue.blob.dbstream.dwContentID, NULL, ppbBuffer, piBuffer);
-    ExitOnFailure2(hr, "Failed to get binary content of blob named: %ls, with content ID: %u", wzName, dwContentID);
+    ExitOnFailure(hr, "Failed to get binary content of blob named: %ls, with content ID: %u", wzName, dwContentID);
 
 LExit:
     ReleaseSceRow(sceRow);
@@ -1105,7 +1105,7 @@ extern "C" HRESULT CfgEnumerateProducts(
     hr = SceGetFirstRow(pcdb->psceDb, PRODUCT_INDEX_TABLE, &sceRow);
     while (E_NOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to get row from table: %u", PRODUCT_INDEX_TABLE);
+        ExitOnFailure(hr, "Failed to get row from table: %u", PRODUCT_INDEX_TABLE);
 
         if (pcesEnum->dwNumValues >= pcesEnum->dwMaxValues)
         {
@@ -1191,7 +1191,7 @@ extern "C" HRESULT CfgEnumPastValues(
     fLocked = TRUE;
 
     hr = EnumPastValues(pcdb, wzName, reinterpret_cast<CFG_ENUMERATION **>(ppvHandle), pcCount);
-    ExitOnFailure1(hr, "Failed to call internal enumerate past values function on value named: %ls", wzName);
+    ExitOnFailure(hr, "Failed to call internal enumerate past values function on value named: %ls", wzName);
 
 LExit:
     if (fLocked)
@@ -1248,7 +1248,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDataType(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1264,7 +1264,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDataType(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1280,7 +1280,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDataType(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1288,7 +1288,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDataType(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for datatype. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1314,7 +1314,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadString(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1336,7 +1336,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadString(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1358,7 +1358,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadString(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1381,7 +1381,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadString(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1400,14 +1400,14 @@ extern "C" HRESULT CFGAPI CfgEnumReadString(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
 
     default:
         hr = E_INVALIDARG;
-          ExitOnFailure2(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+          ExitOnFailure(hr, "Unsupported request for string. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1439,7 +1439,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDword(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1457,14 +1457,14 @@ extern "C" HRESULT CFGAPI CfgEnumReadDword(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
 
     case ENUMERATION_PRODUCTS:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
 
     case ENUMERATION_VALUE_HISTORY:
@@ -1480,7 +1480,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDword(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1488,7 +1488,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadDword(
 
     default:
         hr = E_INVALIDARG;
-          ExitOnFailure2(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+          ExitOnFailure(hr, "Unsupported request for dword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1514,7 +1514,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadQword(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1528,7 +1528,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadQword(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1542,7 +1542,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadQword(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1550,7 +1550,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadQword(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for qword. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1576,7 +1576,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1590,7 +1590,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1604,7 +1604,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1618,7 +1618,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1633,7 +1633,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1641,7 +1641,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBool(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for bool. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1667,7 +1667,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadHash(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1681,7 +1681,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadHash(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1695,14 +1695,14 @@ extern "C" HRESULT CFGAPI CfgEnumReadHash(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for hash. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1728,7 +1728,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadSystemTime(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     switch (pcesEnum->enumType)
@@ -1742,7 +1742,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadSystemTime(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1757,7 +1757,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadSystemTime(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1765,7 +1765,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadSystemTime(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for systemtime. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1797,7 +1797,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBinary(
     if (dwIndex >= pcesEnum->dwNumValues)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
     }
 
     hr = HandleLock(pcdb);
@@ -1811,12 +1811,12 @@ extern "C" HRESULT CFGAPI CfgEnumReadBinary(
         {
         case ENUM_DATA_BLOBCONTENT:
             hr = StreamRead(pcdb, pcesEnum->values.rgcValues[dwIndex].blob.dbstream.dwContentID, NULL, ppbBuffer, piBuffer);
-            ExitOnFailure1(hr, "Failed to get blob content with ID: %u", pcesEnum->values.rgcValues[dwIndex].blob.dbstream.dwContentID);
+            ExitOnFailure(hr, "Failed to get blob content with ID: %u", pcesEnum->values.rgcValues[dwIndex].blob.dbstream.dwContentID);
             break;
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
         break;
@@ -1826,12 +1826,12 @@ extern "C" HRESULT CFGAPI CfgEnumReadBinary(
         {
         case ENUM_DATA_BLOBCONTENT:
             hr = StreamRead(pcdb, pcesEnum->valueHistory.rgcValues[dwIndex].blob.dbstream.dwContentID, NULL, ppbBuffer, piBuffer);
-            ExitOnFailure1(hr, "Failed to get binary content with ID: %u", pcesEnum->valueHistory.rgcValues[dwIndex].blob.dbstream.dwContentID);
+            ExitOnFailure(hr, "Failed to get binary content with ID: %u", pcesEnum->valueHistory.rgcValues[dwIndex].blob.dbstream.dwContentID);
             break;
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+            ExitOnFailure(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
             break;
         }
 
@@ -1839,7 +1839,7 @@ extern "C" HRESULT CFGAPI CfgEnumReadBinary(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
+        ExitOnFailure(hr, "Unsupported request for blob. Enumeration type: %d, request type: %d", pcesEnum->enumType, cedData);
         break;
     }
 
@@ -1990,7 +1990,7 @@ extern "C" HRESULT CfgResolve(
         if (fLegacy)
         {
             hr = LegacySyncSetProduct(pcdb->pcdbLocal, &syncSession, rgcpProduct[dwProductIndex].sczProductName);
-            ExitOnFailure1(hr, "Failed to set legacy product: ", rgcpProduct[dwProductIndex].sczProductName);
+            ExitOnFailure(hr, "Failed to set legacy product: ", rgcpProduct[dwProductIndex].sczProductName);
         }
 
         for (dwValueIndex = 0; dwValueIndex < rgcpProduct[dwProductIndex].cValues; ++dwValueIndex)
@@ -2063,13 +2063,13 @@ extern "C" HRESULT CFGAPI CfgRegisterProduct(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle when registering product");
@@ -2112,13 +2112,13 @@ extern "C" HRESULT CFGAPI CfgUnregisterProduct(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle when unregistering product");
@@ -2162,13 +2162,13 @@ extern "C" HRESULT CFGAPI CfgIsProductRegistered(
     StrStringToLower(sczLowPublicKey);
 
     hr = ProductValidateName(wzProductName);
-    ExitOnFailure1(hr, "Failed to validate ProductName: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to validate ProductName: %ls", wzProductName);
 
     hr = ProductValidateVersion(wzVersion);
-    ExitOnFailure1(hr, "Failed to validate Version: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to validate Version: %ls", wzVersion);
 
     hr = ProductValidatePublicKey(sczLowPublicKey);
-    ExitOnFailure1(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
+    ExitOnFailure(hr, "Failed to validate Public Key: %ls", sczLowPublicKey);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle when checking if product is registered");

--- a/src/SettingsEngine/lib/cfgleg.cpp
+++ b/src/SettingsEngine/lib/cfgleg.cpp
@@ -69,10 +69,10 @@ HRESULT CfgLegacyImportProductFromXMLFile(
     ExitOnFailure(hr, "Failed to log line");
 
     hr = FileToString(wzXmlFilePath, &sczContent, NULL);
-    ExitOnFailure1(hr, "Failed to load string out of file contents from file at path: %ls", wzXmlFilePath);
+    ExitOnFailure(hr, "Failed to load string out of file contents from file at path: %ls", wzXmlFilePath);
 
     hr = ParseManifest(sczContent, &product);
-    ExitOnFailure1(hr, "Failed to parse XML manifest file from path: %ls", wzXmlFilePath);
+    ExitOnFailure(hr, "Failed to parse XML manifest file from path: %ls", wzXmlFilePath);
 
     hr = HandleLock(pcdb);
     ExitOnFailure(hr, "Failed to lock handle while importing legacy manifest");
@@ -92,7 +92,7 @@ HRESULT CfgLegacyImportProductFromXMLFile(
     ExitOnFailure(hr, "Failed to write manifest contents to database");
 
     hr = ProductSet(pcdb, product.sczProductId, wzLegacyVersion, wzLegacyPublicKey, FALSE, NULL);
-    ExitOnFailure1(hr, "Failed to set legacy product to product ID: %ls", product.sczProductId);
+    ExitOnFailure(hr, "Failed to set legacy product to product ID: %ls", product.sczProductId);
 
     hr = SceCommitTransaction(pcdb->psceDb);
     ExitOnFailure(hr, "Failed to commit transaction");

--- a/src/SettingsEngine/lib/cfgrmote.cpp
+++ b/src/SettingsEngine/lib/cfgrmote.cpp
@@ -39,11 +39,11 @@ extern "C" HRESULT CFGAPI CfgCreateRemoteDatabase(
     if (FileExistsEx(wzPath, NULL))
     {
         hr = HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS);
-        ExitOnFailure1(hr, "Tried to create remote database %ls, but it already exists!", wzPath);
+        ExitOnFailure(hr, "Tried to create remote database %ls, but it already exists!", wzPath);
     }
 
     hr = RemoteDatabaseInitialize(wzPath, TRUE, FALSE, FALSE, pcdHandle);
-    ExitOnFailure1(hr, "Failed to create remote database at path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to create remote database at path: %ls", wzPath);
 
 LExit:
     return hr;
@@ -62,11 +62,11 @@ extern "C" HRESULT CFGAPI CfgOpenRemoteDatabase(
     if (!FileExistsEx(wzPath, NULL))
     {
         hr = E_NOTFOUND;
-        ExitOnFailure1(hr, "Tried to open remote database %ls, but it doesn't exist!", wzPath);
+        ExitOnFailure(hr, "Tried to open remote database %ls, but it doesn't exist!", wzPath);
     }
 
     hr = RemoteDatabaseInitialize(wzPath, FALSE, FALSE, FALSE, pcdHandle);
-    ExitOnFailure1(hr, "Failed to open remote database at path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to open remote database at path: %ls", wzPath);
 
 LExit:
     return hr;
@@ -92,7 +92,7 @@ extern "C" HRESULT CFGAPI CfgRememberDatabase(
     hr = DatabaseListFind(pcdbLocal, wzFriendlyName, &sceRow);
     if (E_NOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to find database index row for friendly name '%ls'", wzFriendlyName);
+        ExitOnFailure(hr, "Failed to find database index row for friendly name '%ls'", wzFriendlyName);
 
         hr = SceBeginTransaction(pcdbLocal->psceDb);
         ExitOnFailure(hr, "Failed to begin transaction");
@@ -112,20 +112,20 @@ extern "C" HRESULT CFGAPI CfgRememberDatabase(
         {
             pcdbRemote->fSyncByDefault = fSyncByDefault;
             hr = BackgroundRemoveRemote(pcdbLocal, pcdbRemote->sczOriginalDbPath);
-            ExitOnFailure1(hr, "Failed to remove remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczOriginalDbPath);
+            ExitOnFailure(hr, "Failed to remove remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczOriginalDbPath);
         }
         else if (!pcdbRemote->fSyncByDefault && fSyncByDefault)
         {
             pcdbRemote->fSyncByDefault = fSyncByDefault;
             hr = BackgroundAddRemote(pcdbLocal, pcdbRemote->sczOriginalDbPath);
-            ExitOnFailure1(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczOriginalDbPath);
+            ExitOnFailure(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczOriginalDbPath);
         }
     }
     else
     {
         pcdbRemote->fSyncByDefault = fSyncByDefault;
         hr = DatabaseListInsert(pcdbLocal, wzFriendlyName, fSyncByDefault, pcdbRemote->sczOriginalDbPath);
-        ExitOnFailure1(hr, "Failed to remember database '%ls' in database list", wzFriendlyName);
+        ExitOnFailure(hr, "Failed to remember database '%ls' in database list", wzFriendlyName);
     }
 
     pcdbRemote->fSyncByDefault = fSyncByDefault;
@@ -162,16 +162,16 @@ extern "C" HRESULT CFGAPI CfgOpenKnownRemoteDatabase(
     fLocked = TRUE;
 
     hr = DatabaseListFind(pcdbLocal, wzFriendlyName, &sceRow);
-    ExitOnFailure1(hr, "Failed to find database index row for friendly name '%ls'", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to find database index row for friendly name '%ls'", wzFriendlyName);
 
     hr = SceGetColumnString(sceRow, DATABASE_INDEX_PATH, &sczPath);
-    ExitOnFailure1(hr, "Failed to get path from database list for database '%ls'", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to get path from database list for database '%ls'", wzFriendlyName);
 
     hr = SceGetColumnBool(sceRow, DATABASE_INDEX_SYNC_BY_DEFAULT, &fSyncByDefault);
     ExitOnFailure(hr, "Failed to get 'sync by default' column for existing database in list");
 
     hr = RemoteDatabaseInitialize(sczPath, FALSE, fSyncByDefault, TRUE, pcdHandle);
-    ExitOnFailure2(hr, "Failed to open known database '%ls' at path '%ls'", wzFriendlyName, sczPath);
+    ExitOnFailure(hr, "Failed to open known database '%ls' at path '%ls'", wzFriendlyName, sczPath);
 
 LExit:
     ReleaseSceRow(sceRow);
@@ -206,13 +206,13 @@ extern "C" HRESULT CFGAPI CfgForgetDatabase(
     if (pcdbRemote->fSyncByDefault)
     {
         hr = BackgroundRemoveRemote(pcdbLocal, pcdbRemote->sczDbPath);
-        ExitOnFailure1(hr, "Failed to remove remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczDbPath);
+        ExitOnFailure(hr, "Failed to remove remote path to background thread for automatic synchronization: %ls", pcdbRemote->sczDbPath);
 
         pcdbRemote->fSyncByDefault = FALSE;
     }
 
     hr = DatabaseListDelete(pcdbLocal, wzFriendlyName);
-    ExitOnFailure1(hr, "Failed to delete database '%ls' from database list", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to delete database '%ls' from database list", wzFriendlyName);
 
 LExit:
     if (fLocked)
@@ -322,10 +322,10 @@ static HRESULT RemoteDatabaseInitialize(
     pcdb->fRemote = TRUE;
 
     hr = StrAllocString(&pcdb->sczOriginalDbPath, wzPath, 0);
-    ExitOnFailure1(hr, "Failed to copy original path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to copy original path: %ls", wzPath);
 
     hr = PathGetDirectory(wzPath, &pcdb->sczOriginalDbDir);
-    ExitOnFailure1(hr, "Failed to get directory of original path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to get directory of original path: %ls", wzPath);
 
     if (wzPath[0] != L'\\' || wzPath[1] != L'\\')
     {
@@ -335,7 +335,7 @@ static HRESULT RemoteDatabaseInitialize(
             ReleaseNullStr(pcdb->sczDbPath);
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to convert remote path %ls to unc path", wzPath);
+        ExitOnFailure(hr, "Failed to convert remote path %ls to unc path", wzPath);
     }
     if (NULL == pcdb->sczDbPath)
     {
@@ -343,7 +343,7 @@ static HRESULT RemoteDatabaseInitialize(
         hr = S_OK;
 
         hr = StrAllocString(&pcdb->sczDbPath, wzPath, 0);
-        ExitOnFailure1(hr, "Failed to copy path request: %ls", wzPath);
+        ExitOnFailure(hr, "Failed to copy path request: %ls", wzPath);
     }
     else
     {
@@ -354,7 +354,7 @@ static HRESULT RemoteDatabaseInitialize(
     {
         // database file doesn't exist, error out
         hr = HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
-        ExitOnFailure1(hr, "Tried to open remote database that doesn't exist at path: %ls", pcdb->sczDbPath);
+        ExitOnFailure(hr, "Tried to open remote database that doesn't exist at path: %ls", pcdb->sczDbPath);
     }
 
     hr = PathGetDirectory(pcdb->sczDbPath, &pcdb->sczDbDir);
@@ -399,7 +399,7 @@ static HRESULT RemoteDatabaseInitialize(
     if (fSyncByDefault)
     {
         hr = BackgroundAddRemote(pcdbLocal, pcdb->sczOriginalDbPath);
-        ExitOnFailure1(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", pcdb->sczDbDir);
+        ExitOnFailure(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", pcdb->sczDbDir);
     }
     pcdb->pcdbLocal = pcdbLocal;
     pcdb->fSyncByDefault = fSyncByDefault;

--- a/src/SettingsEngine/lib/compress.cpp
+++ b/src/SettingsEngine/lib/compress.cpp
@@ -52,17 +52,17 @@ HRESULT CompressToCab(
     }
 
     hr = CabCBegin(PathFile(wzCabPath), wzTempDir, 1, 0, 0, compressionType, &hCab);
-    ExitOnFailure1(hr, "Failed to begin compressing stream into cab %ls", wzCabPath);
+    ExitOnFailure(hr, "Failed to begin compressing stream into cab %ls", wzCabPath);
     fFreeCab = TRUE;
 
     hr = FileWrite(wzTempFilePath, FILE_ATTRIBUTE_TEMPORARY, pbBuffer, cbBuffer, NULL);
-    ExitOnFailure1(hr, "Failed to write file out to path %ls", wzTempFilePath);
+    ExitOnFailure(hr, "Failed to write file out to path %ls", wzTempFilePath);
 
     hr = CabCAddFile(wzTempFilePath, wzCompressedTokenName, NULL, hCab);
-    ExitOnFailure2(hr, "Failed to add only file %ls to cab %ls", wzTempFilePath, wzCabPath);
+    ExitOnFailure(hr, "Failed to add only file %ls to cab %ls", wzTempFilePath, wzCabPath);
 
     hr = CabCFinish(hCab, NULL);
-    ExitOnFailure1(hr, "Failed to finish cab %ls", wzCabPath);
+    ExitOnFailure(hr, "Failed to finish cab %ls", wzCabPath);
     fFreeCab = FALSE;
 
     // Ignore failures
@@ -77,7 +77,7 @@ HRESULT CompressToCab(
     if (static_cast<LONGLONG>(DWORD_MAX) < llSize)
     {
         hr = E_FAIL;
-        ExitOnFailure1(hr, "CAB file bigger than DWORD can track: %ls", *psczPath);
+        ExitOnFailure(hr, "CAB file bigger than DWORD can track: %ls", *psczPath);
     }
 
     *pcbCompressedSize = static_cast<DWORD>(llSize);
@@ -110,13 +110,13 @@ HRESULT CompressFromCab(
     ExitOnFailure(hr, "Failed to get path to extracted cab file");
 
     hr = FileEnsureDelete(sczInputFile);
-    ExitOnFailure1(hr, "Failed to delete file: %ls", sczInputFile);
+    ExitOnFailure(hr, "Failed to delete file: %ls", sczInputFile);
 
     hr = CabExtract(wzPath, wzCompressedTokenName, wzTempDir, NULL, NULL, 0);
-    ExitOnFailure1(hr, "Failed to extract only file from cabinet: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to extract only file from cabinet: %ls", wzPath);
 
     hr = FileRead(ppbFileBuffer, pcbSize, sczInputFile);
-    ExitOnFailure1(hr, "Failed to read extracted file: %ls", sczInputFile);
+    ExitOnFailure(hr, "Failed to read extracted file: %ls", sczInputFile);
 
 LExit:
     if (sczInputFile)
@@ -161,7 +161,7 @@ HRESULT CompressWriteStream(
         // then rolling back the transaction or crashing or losing connection to remote)
         // we'll leave a stream behind that db doesn't know about, and is possibly incomplete. So just overwrite it.
         hr = FileEnsureMove(sczCabPath, sczStreamPath, TRUE, TRUE);
-        ExitOnFailure2(hr, "Failed to move file from cab path %ls to stream path %ls", sczCabPath, sczStreamPath);
+        ExitOnFailure(hr, "Failed to move file from cab path %ls to stream path %ls", sczCabPath, sczStreamPath);
 
         ReleaseNullStr(sczCabPath);
     }
@@ -170,7 +170,7 @@ HRESULT CompressWriteStream(
         *pcfCompressionFormat = COMPRESSION_NONE;
 
         hr = FileWrite(sczStreamPath, EXTERNAL_STREAM_FILE_FLAGS, pbBuffer, cbBuffer, NULL);
-        ExitOnFailure2(hr, "Failed to write file stream of size %u to disk at location: %ls", cbBuffer, sczStreamPath);
+        ExitOnFailure(hr, "Failed to write file stream of size %u to disk at location: %ls", cbBuffer, sczStreamPath);
     }
 
     if (sczCabPath)
@@ -213,29 +213,29 @@ HRESULT CompressReadStream(
     {
     case COMPRESSION_CAB:
         hr = CompressFromCab(sczStreamPath, &pbContent, &cbContent);
-        ExitOnFailure1(hr, "Failed to read cab stream on disk: %ls", sczStreamPath);
+        ExitOnFailure(hr, "Failed to read cab stream on disk: %ls", sczStreamPath);
         break;
 
     case COMPRESSION_NONE:
         hr = FileRead(&pbContent, &cbContent, sczStreamPath);
-        ExitOnFailure1(hr, "Failed to read uncompressed stream file: %ls", sczStreamPath);
+        ExitOnFailure(hr, "Failed to read uncompressed stream file: %ls", sczStreamPath);
         break;
 
     default:
         hr = E_FAIL;
-        ExitOnFailure1(hr, "Unrecognized compression option found while reading stream from disk: %u", cfCompressionFormat);
+        ExitOnFailure(hr, "Unrecognized compression option found while reading stream from disk: %u", cfCompressionFormat);
         break;
     }
 
     if (NULL != ppbFileBuffer)
     {
         hr = StreamValidateFileMatchesHash(pbContent, cbContent, pbHash, &fMatches);
-        ExitOnFailure1(hr, "Failed to check if file at path matches expected hash: %ls", sczStreamPath);
+        ExitOnFailure(hr, "Failed to check if file at path matches expected hash: %ls", sczStreamPath);
 
         if (!fMatches)
         {
             hr = E_FAIL;
-            ExitOnFailure1(hr, "Stream file on disk appears to be corrupted: %ls", sczStreamPath);
+            ExitOnFailure(hr, "Stream file on disk appears to be corrupted: %ls", sczStreamPath);
         }
     }
 

--- a/src/SettingsEngine/lib/database.cpp
+++ b/src/SettingsEngine/lib/database.cpp
@@ -39,7 +39,7 @@ HRESULT DatabaseGetUserDir(
     else
     {
         hr = PathGetKnownFolder(CSIDL_LOCAL_APPDATA, &sczPath);
-        ExitOnFailure1(hr, "Failed to get known folder with ID CSIDL_LOCAL_APPDATA", CSIDL_LOCAL_APPDATA);
+        ExitOnFailure(hr, "Failed to get known folder with ID CSIDL_LOCAL_APPDATA", CSIDL_LOCAL_APPDATA);
 
         hr = PathConcat(sczPath, L"Wix\\SettingsStore\\", psczDbFileDir);
         ExitOnFailure(hr, "Failed to concatenate settingsstore subpath to path");
@@ -318,7 +318,7 @@ HRESULT DatabaseGetAdminDir(
     else
     {
         hr = PathGetKnownFolder(CSIDL_WINDOWS, &sczPath);
-        ExitOnFailure1(hr, "Failed to get known folder with ID CSIDL_WINDOWS", CSIDL_WINDOWS);
+        ExitOnFailure(hr, "Failed to get known folder with ID CSIDL_WINDOWS", CSIDL_WINDOWS);
 
         hr = PathConcat(sczPath, L"Wix\\SettingsStore\\", psczDbFileDir);
         ExitOnFailure(hr, "Failed to concatenate settingsstore subpath to path");

--- a/src/SettingsEngine/lib/dblist.cpp
+++ b/src/SettingsEngine/lib/dblist.cpp
@@ -40,7 +40,7 @@ extern "C" HRESULT DatabaseListInsert(
     if (fSyncByDefault)
     {
         hr = BackgroundAddRemote(pcdb, wzPath);
-        ExitOnFailure1(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", wzPath);
+        ExitOnFailure(hr, "Failed to add remote path to background thread for automatic synchronization: %ls", wzPath);
     }
 
     hr = SceSetColumnString(sceRow, DATABASE_INDEX_PATH, wzPath);
@@ -76,7 +76,7 @@ HRESULT DatabaseListFind(
     ExitOnFailure(hr, "Failed to begin query into database index table");
 
     hr = SceSetQueryColumnString(sqhHandle, wzFriendlyName);
-    ExitOnFailure1(hr, "Failed to set query column name string to: %ls", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to set query column name string to: %ls", wzFriendlyName);
 
     hr = SceRunQueryExact(&sqhHandle, pSceRow);
     if (E_NOTFOUND == hr)
@@ -84,7 +84,7 @@ HRESULT DatabaseListFind(
         // Don't pollute our log with unnecessary messages
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to query for database '%ls' in database list", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to query for database '%ls' in database list", wzFriendlyName);
 
 LExit:
     ReleaseSceQuery(sqhHandle);
@@ -106,10 +106,10 @@ extern "C" HRESULT DatabaseListDelete(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to search for database '%ls' in database list", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to search for database '%ls' in database list", wzFriendlyName);
 
     hr = SceDeleteRow(&sceRow);
-    ExitOnFailure1(hr, "Failed to delete database '%ls' from database list", wzFriendlyName);
+    ExitOnFailure(hr, "Failed to delete database '%ls' from database list", wzFriendlyName);
 
 LExit:
     ReleaseSceRow(sceRow);

--- a/src/SettingsEngine/lib/detect.cpp
+++ b/src/SettingsEngine/lib/detect.cpp
@@ -89,10 +89,10 @@ HRESULT DetectUpdateCache(
                 ExitOnFailure(hr, "Failed to set manifest contents as string value in memory");
 
                 hr = ValueWrite(pcdb, pcdb->dwAppID, sczValueName, &cvValue, TRUE);
-                ExitOnFailure2(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzInstallLocationValue);
+                ExitOnFailure(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzInstallLocationValue);
 
                 hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczValueName);
-                ExitOnFailure1(hr, "Failed to add file to list of files seen: %ls", sczValueName);
+                ExitOnFailure(hr, "Failed to add file to list of files seen: %ls", sczValueName);
             }
             if (pDetect->rgDetects[i].arp.sczUninstallStringDirProperty && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzUninstallStringDirValue))
             {
@@ -106,10 +106,10 @@ HRESULT DetectUpdateCache(
                 ExitOnFailure(hr, "Failed to set manifest contents as string value in memory");
 
                 hr = ValueWrite(pcdb, pcdb->dwAppID, sczValueName, &cvValue, TRUE);
-                ExitOnFailure2(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzUninstallStringDirValue);
+                ExitOnFailure(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzUninstallStringDirValue);
 
                 hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczValueName);
-                ExitOnFailure1(hr, "Failed to add file to list of files seen: %ls", sczValueName);
+                ExitOnFailure(hr, "Failed to add file to list of files seen: %ls", sczValueName);
             }
             if (pDetect->rgDetects[i].arp.sczDisplayIconDirProperty && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzDisplayIconDirValue))
             {
@@ -123,10 +123,10 @@ HRESULT DetectUpdateCache(
                 ExitOnFailure(hr, "Failed to set manifest contents as string value in memory");
 
                 hr = ValueWrite(pcdb, pcdb->dwAppID, sczValueName, &cvValue, TRUE);
-                ExitOnFailure2(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzDisplayIconDirValue);
+                ExitOnFailure(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].arp.wzDisplayIconDirValue);
 
                 hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczValueName);
-                ExitOnFailure1(hr, "Failed to add file to list of files seen: %ls", sczValueName);
+                ExitOnFailure(hr, "Failed to add file to list of files seen: %ls", sczValueName);
             }
             break;
 
@@ -143,16 +143,16 @@ HRESULT DetectUpdateCache(
                 ExitOnFailure(hr, "Failed to set manifest contents as string value in memory");
 
                 hr = ValueWrite(pcdb, pcdb->dwAppID, sczValueName, &cvValue, TRUE);
-                ExitOnFailure2(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].exe.sczDetectedFileDir);
+                ExitOnFailure(hr, "Failed to set cached value named '%ls' to '%ls'", sczValueName, pDetect->rgDetects[i].exe.sczDetectedFileDir);
 
                 hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczValueName);
-                ExitOnFailure1(hr, "Failed to add file to list of files seen: %ls", sczValueName);
+                ExitOnFailure(hr, "Failed to add file to list of files seen: %ls", sczValueName);
             }
             break;
 
         default:
             hr = E_UNEXPECTED;
-            ExitOnFailure1(hr, "Unexpected detect type encountered while updating cache: %u", pDetect->rgDetects[i].ldtType);
+            ExitOnFailure(hr, "Unexpected detect type encountered while updating cache: %u", pDetect->rgDetects[i].ldtType);
             break;
         }
 
@@ -219,7 +219,7 @@ HRESULT DetectGetArpProducts(
     for (DWORD i = 0; i < pArpProducts->cProducts; ++i)
     {
         hr = DictAddValue(pArpProducts->shProductsFound, pArpProducts->rgProducts + i);
-        ExitOnFailure1(hr, "Failed to add to dictionary product named: %ls", pArpProducts->rgProducts[i].sczDisplayName);
+        ExitOnFailure(hr, "Failed to add to dictionary product named: %ls", pArpProducts->rgProducts[i].sczDisplayName);
     }
 
     hr = S_OK;
@@ -279,7 +279,7 @@ HRESULT DetectGetExeProducts(
     for (DWORD i = 0; i < pExeProducts->cProducts; ++i)
     {
         hr = DictAddValue(pExeProducts->shProductsFound, pExeProducts->rgProducts + i);
-        ExitOnFailure1(hr, "Failed to add to dictionary product with filename: %ls", pExeProducts->rgProducts[i].sczFilePath);
+        ExitOnFailure(hr, "Failed to add to dictionary product with filename: %ls", pExeProducts->rgProducts[i].sczFilePath);
     }
 
     hr = S_OK;
@@ -320,7 +320,7 @@ HRESULT DetectProduct(
                 }
                 else if (FAILED(hr))
                 {
-                    ExitOnFailure1(hr, "Failed to lookup display name %ls in arp dictionary", pDetect->rgDetects[i].arp.sczDisplayName);
+                    ExitOnFailure(hr, "Failed to lookup display name %ls in arp dictionary", pDetect->rgDetects[i].arp.sczDisplayName);
                 }
                 else
                 {
@@ -347,14 +347,14 @@ HRESULT DetectProduct(
                 if (NULL != pDetect->rgDetects[i].exe.wzFileDirValue)
                 {
                     hr = PathGetDirectory(pDetect->rgDetects[i].exe.wzFileDirValue, &pDetect->rgDetects[i].exe.sczDetectedFileDir);
-                    ExitOnFailure1(hr, "Failed to get directory from path: %ls", pDetect->rgDetects[i].exe.wzFileDirValue);
+                    ExitOnFailure(hr, "Failed to get directory from path: %ls", pDetect->rgDetects[i].exe.wzFileDirValue);
                 }
 
                 break;
 
             default:
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Unexpected detect type encountered: %d", pDetect->rgDetects[i].ldtType);
+                ExitOnFailure(hr, "Unexpected detect type encountered: %d", pDetect->rgDetects[i].ldtType);
                 break;
             }
 
@@ -375,21 +375,21 @@ HRESULT DetectProduct(
             case LEGACY_DETECT_TYPE_ARP:
                 // Read in any values from cache
                 hr = ReadCache(pcdb, pDetect->rgDetects[i].arp.sczInstallLocationProperty, pSyncProductSession->shDictValuesSeen, pDetect);
-                ExitOnFailure1(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczInstallLocationProperty);
+                ExitOnFailure(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczInstallLocationProperty);
 
                 hr = ReadCache(pcdb, pDetect->rgDetects[i].arp.sczUninstallStringDirProperty, pSyncProductSession->shDictValuesSeen, pDetect);
-                ExitOnFailure1(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczUninstallStringDirProperty);
+                ExitOnFailure(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczUninstallStringDirProperty);
 
                 hr = ReadCache(pcdb, pDetect->rgDetects[i].arp.sczDisplayIconDirProperty, pSyncProductSession->shDictValuesSeen, pDetect);
-                ExitOnFailure1(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczDisplayIconDirProperty);
+                ExitOnFailure(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].arp.sczDisplayIconDirProperty);
                 break;
             case LEGACY_DETECT_TYPE_EXE:
                 hr = ReadCache(pcdb, pDetect->rgDetects[i].exe.sczFileDirProperty, pSyncProductSession->shDictValuesSeen, pDetect);
-                ExitOnFailure1(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].exe.sczFileDirProperty);
+                ExitOnFailure(hr, "Failed to read cached value %ls", pDetect->rgDetects[i].exe.sczFileDirProperty);
                 break;
             default:
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Unexpected detect type encountered in 2nd loop: %d", pDetect->rgDetects[i].ldtType);
+                ExitOnFailure(hr, "Unexpected detect type encountered in 2nd loop: %d", pDetect->rgDetects[i].ldtType);
                 break;
             }
         }
@@ -397,7 +397,7 @@ HRESULT DetectProduct(
     else if (!fJustReadCache)
     {
         hr = DetectUpdateCache(pcdb, pSyncProductSession);
-        ExitOnFailure1(hr, "Failed to update cached detection results for AppID: %u", pcdb->dwAppID);
+        ExitOnFailure(hr, "Failed to update cached detection results for AppID: %u", pcdb->dwAppID);
     }
 
 LExit:
@@ -438,7 +438,7 @@ HRESULT DetectExpandDirectoryPath(
                 && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzInstallLocationValue))
             {
                 hr = StrAllocString(&sczPropertyValue, pDetect->rgDetects[i].arp.wzInstallLocationValue, 0);
-                ExitOnFailure1(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzInstallLocationValue);
+                ExitOnFailure(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzInstallLocationValue);
 
                 hr = PathConcat(sczPropertyValue, wzPathAfterColon, psczOutput);
                 ExitOnFailure(hr, "Failed to concatenate paths while expanding detected arp path");
@@ -449,7 +449,7 @@ HRESULT DetectExpandDirectoryPath(
                 && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzUninstallStringDirValue))
             {
                 hr = StrAllocString(&sczPropertyValue, pDetect->rgDetects[i].arp.wzUninstallStringDirValue, 0);
-                ExitOnFailure1(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzUninstallStringDirValue);
+                ExitOnFailure(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzUninstallStringDirValue);
 
                 hr = PathConcat(sczPropertyValue, wzPathAfterColon, psczOutput);
                 ExitOnFailure(hr, "Failed to concatenate paths while expanding detected arp path");
@@ -460,7 +460,7 @@ HRESULT DetectExpandDirectoryPath(
                 && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzInstallLocationValue))
             {
                 hr = StrAllocString(&sczPropertyValue, pDetect->rgDetects[i].arp.wzDisplayIconDirValue, 0);
-                ExitOnFailure1(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzDisplayIconDirValue);
+                ExitOnFailure(hr, "Failed to copy value of InstallLocation", pDetect->rgDetects[i].arp.wzDisplayIconDirValue);
 
                 hr = PathConcat(sczPropertyValue, wzPathAfterColon, psczOutput);
                 ExitOnFailure(hr, "Failed to concatenate paths while expanding detected arp path");
@@ -474,7 +474,7 @@ HRESULT DetectExpandDirectoryPath(
                 && 0 < lstrlenW(pDetect->rgDetects[i].arp.wzInstallLocationValue))
             {
                 hr = StrAllocString(&sczPropertyValue, pDetect->rgDetects[i].exe.wzFileDirValue, 0);
-                ExitOnFailure1(hr, "Failed to copy value of file dir", pDetect->rgDetects[i].exe.wzFileDirValue);
+                ExitOnFailure(hr, "Failed to copy value of file dir", pDetect->rgDetects[i].exe.wzFileDirValue);
 
                 hr = PathConcat(sczPropertyValue, wzPathAfterColon, psczOutput);
                 ExitOnFailure(hr, "Failed to concatenate paths while expanding detected exe path");
@@ -485,7 +485,7 @@ HRESULT DetectExpandDirectoryPath(
 
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "An invalid detect type %d was found while expanding legacy directory path", pDetect->rgDetects[i].ldtType);
+            ExitOnFailure(hr, "An invalid detect type %d was found while expanding legacy directory path", pDetect->rgDetects[i].ldtType);
             break;
         }
     }
@@ -499,7 +499,7 @@ HRESULT DetectExpandDirectoryPath(
     ExitOnFailure(hr, "Failed to lookup cached property value");
 
     hr = StrAllocString(&sczPropertyValue, pCacheLookupResult->sczPropertyValue, 0);
-    ExitOnFailure1(hr, "Failed to copy value of cached dir: %ls", pCacheLookupResult->sczPropertyValue);
+    ExitOnFailure(hr, "Failed to copy value of cached dir: %ls", pCacheLookupResult->sczPropertyValue);
 
     hr = PathConcat(sczPropertyValue, wzPathAfterColon, psczOutput);
     ExitOnFailure(hr, "Failed to concatenate paths while expanding detected exe path");
@@ -591,7 +591,7 @@ static HRESULT CorrectArpName(
     // TODO: allow some way (specified in manifest) of removing versions
 
     hr = StrAllocString(psczCorrectedName, sczOriginalName, 0);
-    ExitOnFailure1(hr, "Failed to allocate copy of string while correcting arp product name: %ls", sczOriginalName);
+    ExitOnFailure(hr, "Failed to allocate copy of string while correcting arp product name: %ls", sczOriginalName);
 
 LExit:
     return hr;
@@ -626,7 +626,7 @@ static HRESULT GetArpProducts(
             hr = S_OK;
             goto Skip;
         }
-        ExitOnFailure1(hr, "Failed to open arp subkey: %ls", sczSubkeyName);
+        ExitOnFailure(hr, "Failed to open arp subkey: %ls", sczSubkeyName);
 
         hr = RegReadString(hkSubkey, L"DisplayName", &sczDisplayName);
         if (FAILED(hr))
@@ -636,7 +636,7 @@ static HRESULT GetArpProducts(
         }
         else
         {
-            ExitOnFailure1(hr, "Failed to read DisplayName from registry for subkey: %ls", sczSubkeyName);
+            ExitOnFailure(hr, "Failed to read DisplayName from registry for subkey: %ls", sczSubkeyName);
 
             if (DWORD_MAX == pArpProducts->cProducts)
             {
@@ -649,21 +649,21 @@ static HRESULT GetArpProducts(
             ++pArpProducts->cProducts;
             
             hr = CorrectArpName(sczDisplayName, &pArpProducts->rgProducts[dwProductIndex].sczDisplayName);
-            ExitOnFailure1(hr, "Failed to correct displayname seen in arp: %ls", sczDisplayName);
+            ExitOnFailure(hr, "Failed to correct displayname seen in arp: %ls", sczDisplayName);
 
             hr = RegReadString(hkSubkey, L"InstallLocation", &pArpProducts->rgProducts[dwProductIndex].sczInstallLocation);
             if (E_FILENOTFOUND == hr)
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to read registry string InstallLocation under subkey: %ls", sczSubkeyName);
+            ExitOnFailure(hr, "Failed to read registry string InstallLocation under subkey: %ls", sczSubkeyName);
 
             hr = RegReadString(hkSubkey, L"UninstallString", &sczUninstallString);
             if (E_FILENOTFOUND == hr)
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to read registry string UninstallString under subkey: %ls", sczSubkeyName);
+            ExitOnFailure(hr, "Failed to read registry string UninstallString under subkey: %ls", sczSubkeyName);
 
             hr = PathGetDirectory(sczUninstallString, &pArpProducts->rgProducts[dwProductIndex].sczUninstallStringDir);
             ExitOnFailure(hr, "Failed to get directory portion of UninstallString");
@@ -673,7 +673,7 @@ static HRESULT GetArpProducts(
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to read registry string DisplayIcon under subkey: %ls", sczSubkeyName);
+            ExitOnFailure(hr, "Failed to read registry string DisplayIcon under subkey: %ls", sczSubkeyName);
 
             hr = PathGetDirectory(sczDisplayIcon, &pArpProducts->rgProducts[dwProductIndex].sczDisplayIconDir);
             ExitOnFailure(hr, "Failed to get directory portion of DisplayIcon string");
@@ -767,7 +767,7 @@ static HRESULT GetExeProductsFromApplications(
                 if (NULL == wzSecondQuote)
                 {
                     // The quote never ended, so this is probably a bad command - skip it
-                    Trace1(REPORT_DEBUG, "Failed to find ending quote in applications path: %ls", sczRawCommand);
+                    Trace(REPORT_DEBUG, "Failed to find ending quote in applications path: %ls", sczRawCommand);
                     goto InnerSkip;
                 }
 
@@ -785,7 +785,7 @@ static HRESULT GetExeProductsFromApplications(
                     ++pExeProducts->cProducts;
             
                     hr = PathGetDirectory(sczFilePath, &pExeProducts->rgProducts[dwProductIndex].sczFileDir);
-                    ExitOnFailure1(hr, "Failed to get directory of file path: %ls", sczFilePath);
+                    ExitOnFailure(hr, "Failed to get directory of file path: %ls", sczFilePath);
 
                     hr = StrAllocString(&pExeProducts->rgProducts[dwProductIndex].sczFileName, sczSubkeyName, 0);
                     ExitOnFailure(hr, "Failed to copy subkey name");
@@ -797,7 +797,7 @@ static HRESULT GetExeProductsFromApplications(
             else
             {
                 // We don't support non-quoted file paths today - skip it.
-                Trace1(REPORT_DEBUG, "This applications path is not quoted, and is not yet supported: %ls", sczRawCommand);
+                Trace(REPORT_DEBUG, "This applications path is not quoted, and is not yet supported: %ls", sczRawCommand);
                 goto InnerSkip;
             }
 
@@ -853,15 +853,15 @@ static HRESULT ReadCache(
         {
             ExitFunction1(hr = S_OK);
         }
-        ExitOnFailure1(hr, "Failed to read cached value for property %ls", wzPropertyName);
+        ExitOnFailure(hr, "Failed to read cached value for property %ls", wzPropertyName);
 
         hr = MemEnsureArraySize(reinterpret_cast<void**>(&pDetection->rgCachedDetectionProperties), pDetection->cCachedDetectionProperties + 1, sizeof(LEGACY_CACHED_DETECTION_RESULT), 3);
-        ExitOnFailure1(hr, "Failed to resize cached detection property values array to size %u", pDetection->cCachedDetectionProperties + 1);
+        ExitOnFailure(hr, "Failed to resize cached detection property values array to size %u", pDetection->cCachedDetectionProperties + 1);
         dwInsertedIndex = pDetection->cCachedDetectionProperties;
         ++pDetection->cCachedDetectionProperties;
 
         hr = StrAllocString(&pDetection->rgCachedDetectionProperties[dwInsertedIndex].sczPropertyName, wzPropertyName, 0);
-        ExitOnFailure1(hr, "Failed to copy property name: %ls", wzPropertyName);
+        ExitOnFailure(hr, "Failed to copy property name: %ls", wzPropertyName);
 
         pDetection->rgCachedDetectionProperties[dwInsertedIndex].sczPropertyValue = sczPropertyValue;
         sczPropertyValue = NULL;
@@ -869,7 +869,7 @@ static HRESULT ReadCache(
         hr = DictAddValue(pDetection->shCachedDetectionPropertyValues, pDetection->rgCachedDetectionProperties + dwInsertedIndex);
         ExitOnFailure(hr, "Failed to add item to dictionary");
     }
-    ExitOnFailure1(hr, "Failed to lookup property name in cached detection property values dict: %ls", wzPropertyName);
+    ExitOnFailure(hr, "Failed to lookup property name in cached detection property values dict: %ls", wzPropertyName);
 
 LExit:
     ReleaseStr(sczPropertyValue);
@@ -900,7 +900,7 @@ static HRESULT ReadCachedValue(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to find config value for cached directory named: %ls", sczValueName);
+    ExitOnFailure(hr, "Failed to find config value for cached directory named: %ls", sczValueName);
 
     hr = DictAddKey(shDictValuesSeen, sczValueName);
     ExitOnFailure(hr, "Failed to add cached value to values seen during sync");

--- a/src/SettingsEngine/lib/drspcial.cpp
+++ b/src/SettingsEngine/lib/drspcial.cpp
@@ -38,19 +38,19 @@ HRESULT DirSpecialFileRead(
         *pfContinueProcessing = TRUE;
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to find special for subpath: %ls in legacy file", wzSubPath);
+    ExitOnFailure(hr, "Failed to find special for subpath: %ls in legacy file", wzSubPath);
 
     *pfContinueProcessing = FALSE;
 
     if (1 < pFileSpecial->cIniInfo)
     {
         hr = E_FAIL;
-        ExitOnFailure1(hr, "Can't parse INI file %ls with two different Cfg file formats for the same file", wzSubPath);
+        ExitOnFailure(hr, "Can't parse INI file %ls with two different Cfg file formats for the same file", wzSubPath);
     }
     else if (1 == pFileSpecial->cIniInfo)
     {
         hr = IniFileRead(pcdb, pSyncProductSession, wzFullPath, pFileSpecial->rgIniInfo + 0);
-        ExitOnFailure1(hr, "Failed to parse INI file at path: %ls", wzFullPath);
+        ExitOnFailure(hr, "Failed to parse INI file at path: %ls", wzFullPath);
     }
 
 LExit:

--- a/src/SettingsEngine/lib/enum.cpp
+++ b/src/SettingsEngine/lib/enum.cpp
@@ -151,7 +151,7 @@ HRESULT EnumResize(
             break;
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Unexpected enumeration type encountered while initially allocating enumeration struct to %u size", dwNewSize);
+            ExitOnFailure(hr, "Unexpected enumeration type encountered while initially allocating enumeration struct to %u size", dwNewSize);
         }
     }
     else // else MemReAlloc
@@ -194,7 +194,7 @@ HRESULT EnumResize(
             break;
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Unexpected enumeration type encountered while initially allocating enumeration struct to %u size", dwNewSize);
+            ExitOnFailure(hr, "Unexpected enumeration type encountered while initially allocating enumeration struct to %u size", dwNewSize);
         }
     }
 
@@ -237,13 +237,13 @@ HRESULT EnumCopy(
         for (i = 0; i < dwNewCount; ++i)
         {
             hr = ValueCopy(&pcesInput->valueHistory.rgcValues[dwStartIndex+i], &(*ppcesEnumOut)->valueHistory.rgcValues[i]);
-            ExitOnFailure1(hr, "Failed to copy value at index %u while copying value history enum", i);
+            ExitOnFailure(hr, "Failed to copy value at index %u while copying value history enum", i);
         }
         break;
 
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "EnumCopy received enumType %d, this function only supports ENUMERATION_VALUE_HISTORY", pcesInput->enumType);
+        ExitOnFailure(hr, "EnumCopy received enumType %d, this function only supports ENUMERATION_VALUE_HISTORY", pcesInput->enumType);
         break;
     }
 
@@ -279,7 +279,7 @@ HRESULT EnumValues(
     ExitOnFailure(hr, "Failed to begin query into value table");
 
     hr = SceSetQueryColumnDword(sqhHandle, pcdb->dwAppID);
-    ExitOnFailure1(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
 
     hr = SceRunQueryRange(&sqhHandle, &sqrhResults);
     if (E_NOTFOUND == hr)
@@ -396,10 +396,10 @@ HRESULT EnumPastValues(
     ExitOnFailure(hr, "Failed to begin query into value table");
 
     hr = SceSetQueryColumnDword(sqhHandle, pcdb->dwAppID);
-    ExitOnFailure1(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
 
     hr = SceSetQueryColumnString(sqhHandle, wzName);
-    ExitOnFailure1(hr, "Failed to set query column string to: %ls", wzName);
+    ExitOnFailure(hr, "Failed to set query column string to: %ls", wzName);
 
     hr = SceRunQueryRange(&sqhHandle, &sqrhResults);
     if (E_NOTFOUND == hr)
@@ -487,7 +487,7 @@ HRESULT EnumDatabaseList(
     hr = SceGetFirstRow(pcdb->psceDb, DATABASE_INDEX_TABLE, &sceRow);
     while (E_NOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to get row from table: %u", DATABASE_INDEX_TABLE);
+        ExitOnFailure(hr, "Failed to get row from table: %u", DATABASE_INDEX_TABLE);
 
         hr = SceGetColumnString(sceRow, DATABASE_INDEX_FRIENDLY_NAME, &(pcesEnum->databaseList.rgsczFriendlyName[pcesEnum->dwNumValues]));
         ExitOnFailure(hr, "Failed to get friendly name from database index table");

--- a/src/SettingsEngine/lib/handle.cpp
+++ b/src/SettingsEngine/lib/handle.cpp
@@ -70,10 +70,10 @@ HRESULT HandleLock(
         ExitOnFailure(hr, "Failed to copy remote database locally");
 
         hr = FileGetTime(pcdb->sczDbCopiedPath, NULL, NULL, &pcdb->ftBeforeModify);
-        ExitOnFailure1(hr, "Failed to get modified time of copied remote %ls", pcdb->sczDbCopiedPath);
+        ExitOnFailure(hr, "Failed to get modified time of copied remote %ls", pcdb->sczDbCopiedPath);
 
         hr = SceEnsureDatabase(pcdb->sczDbCopiedPath, wzSqlCeDllPath, L"CfgRemote", 1, &pcdb->dsSceDb, &pcdb->psceDb);
-        ExitOnFailure1(hr, "Failed to ensure SQL CE database at %ls exists", pcdb->sczDbPath);
+        ExitOnFailure(hr, "Failed to ensure SQL CE database at %ls exists", pcdb->sczDbPath);
 
         // If the remote wasn't up when we initialized, we couldn't get cfg app id or GUID, so get it now
         if (DWORD_MAX == pcdb->dwCfgAppID)
@@ -125,14 +125,14 @@ void HandleUnlock(
         if (fCopyRemoteBack)
         {
             hr = FileGetTime(pcdb->sczDbPath, NULL, NULL, &ftRemote);
-            ExitOnFailure1(hr, "Failed to get modified time of actual remote %ls", &ftRemote);
+            ExitOnFailure(hr, "Failed to get modified time of actual remote %ls", &ftRemote);
 
             // Since DB file wasn't locked, we have to verify that nobody changed it in the meantime.
             // Do it once before we try uploading to the remote (because uploading could be a lengthy operation on a slow connection to remote path)
             if (0 != ::CompareFileTime(&ftRemote, &pcdb->ftBeforeModify))
             {
                 hr = HRESULT_FROM_WIN32(ERROR_LOCK_VIOLATION);
-                ExitOnFailure1(hr, "database %ls was modified (before copy), we can't overwrite it!", pcdb->sczDbPath);
+                ExitOnFailure(hr, "database %ls was modified (before copy), we can't overwrite it!", pcdb->sczDbPath);
             }
 
             // Get it on the volume first which may take time
@@ -142,16 +142,16 @@ void HandleUnlock(
             ExitOnFailure(hr, "Failed to get temp path in remote directory");
 
             hr = FileEnsureCopy(pcdb->sczDbCopiedPath, sczTempRemotePath, TRUE);
-            ExitOnFailure2(hr, "Failed to copy remote database back to remote location (from %ls to %ls) due to changes", pcdb->sczDbCopiedPath, pcdb->sczDbPath);
+            ExitOnFailure(hr, "Failed to copy remote database back to remote location (from %ls to %ls) due to changes", pcdb->sczDbCopiedPath, pcdb->sczDbPath);
 
             // Now do it again after the upload right before we do the actual move
             hr = FileGetTime(pcdb->sczDbPath, NULL, NULL, &ftRemote);
-            ExitOnFailure1(hr, "Failed to get modified time of original remote (again) %ls", &ftRemote);
+            ExitOnFailure(hr, "Failed to get modified time of original remote (again) %ls", &ftRemote);
 
             if (0 != ::CompareFileTime(&ftRemote, &pcdb->ftBeforeModify))
             {
                 hr = HRESULT_FROM_WIN32(ERROR_LOCK_VIOLATION);
-                ExitOnFailure1(hr, "database %ls was modified (after copy), we can't overwrite it!", pcdb->sczDbPath);
+                ExitOnFailure(hr, "database %ls was modified (after copy), we can't overwrite it!", pcdb->sczDbPath);
             }
 
             // Use MoveFile to ensure it's done as an atomic operation, so remote can never be left not existing.
@@ -162,7 +162,7 @@ void HandleUnlock(
             // that the DB changed, re-sync it, at which time we will try again to re-propagate the changes.
             if (!::MoveFileExW(sczTempRemotePath, pcdb->sczDbPath, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
             {
-                ExitWithLastError1(hr, "Failed to move uploaded database path back to original remote location %ls", pcdb->sczDbPath);
+                ExitWithLastError(hr, "Failed to move uploaded database path back to original remote location %ls", pcdb->sczDbPath);
             }
         }
 
@@ -173,11 +173,11 @@ void HandleUnlock(
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to get modified time of copied db: %ls", pcdb->sczDbCopiedPath);
+            ExitOnFailure(hr, "Failed to get modified time of copied db: %ls", pcdb->sczDbCopiedPath);
         }
 
         hr = FileEnsureDelete(pcdb->sczDbCopiedPath);
-        ExitOnFailure1(hr, "Failed to delete copied remote database from %ls", pcdb->sczDbCopiedPath);
+        ExitOnFailure(hr, "Failed to delete copied remote database from %ls", pcdb->sczDbCopiedPath);
 
         ReleaseNullStr(pcdb->sczDbCopiedPath);
     }
@@ -295,14 +295,14 @@ HRESULT DeleteStream(
     LPWSTR pwcLastBackslash = NULL;
 
     hr = FileEnsureDelete(sczStreamPath);
-    ExitOnFailure1(hr, "Failed to delete file: %ls", sczStreamPath);
+    ExitOnFailure(hr, "Failed to delete file: %ls", sczStreamPath);
 
     // Try to delete the two parent directories, in case they're empty
     pwcLastBackslash = wcsrchr(sczStreamPath, '\\');
     if (pwcLastBackslash == NULL)
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_PATHNAME);
-        ExitOnFailure1(hr, "Stream path unexpectedly doesn't contain backslash: %ls", sczStreamPath);
+        ExitOnFailure(hr, "Stream path unexpectedly doesn't contain backslash: %ls", sczStreamPath);
     }
     *pwcLastBackslash = '\0';
 
@@ -319,7 +319,7 @@ HRESULT DeleteStream(
         if (pwcLastBackslash == NULL)
         {
             hr = E_FAIL;
-            ExitOnFailure1(hr, "Stream path unexpectedly doesn't contain backslash: %ls", sczStreamPath);
+            ExitOnFailure(hr, "Stream path unexpectedly doesn't contain backslash: %ls", sczStreamPath);
         }
         *pwcLastBackslash = '\0';
 

--- a/src/SettingsEngine/lib/inifile.cpp
+++ b/src/SettingsEngine/lib/inifile.cpp
@@ -38,14 +38,14 @@ HRESULT IniFileRead(
     CONFIG_VALUE cvValue = { };
 
     hr = DictGetValue(pSyncProductSession->shIniFilesByNamespace, pIniInfo->sczNamespace, reinterpret_cast<void **>(&pIniFile));
-    ExitOnFailure1(hr, "Error finding INI struct for namespace: %ls", pIniInfo->sczNamespace);
+    ExitOnFailure(hr, "Error finding INI struct for namespace: %ls", pIniInfo->sczNamespace);
 
     hr = IniParse(pIniFile->pIniHandle, wzFullPath, &feEncoding);
     if (E_PATHNOTFOUND == hr || E_FILENOTFOUND == hr)
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to parse INI file: %ls", wzFullPath);
+    ExitOnFailure(hr, "Failed to parse INI file: %ls", wzFullPath);
 
     pIniFile->fetReadEncoding = FileEncodingToIniFileEncoding(feEncoding);
 
@@ -53,22 +53,22 @@ HRESULT IniFileRead(
     ExitOnFailure(hr, "Failed to get ini value list");
 
     hr = FileGetTime(wzFullPath, NULL, NULL, &ft);
-    ExitOnFailure1(hr, "failed to get modified time of file : %ls", wzFullPath);
+    ExitOnFailure(hr, "failed to get modified time of file : %ls", wzFullPath);
 
     fRet = FileTimeToSystemTime(&ft, &st);
     if (!fRet)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Failed to convert file time to system time for file: %ls", wzFullPath);
+        ExitOnFailure(hr, "Failed to convert file time to system time for file: %ls", wzFullPath);
     }
 
     for (DWORD i = 0; i < cIniValues; ++i)
     {
         hr = MapFileToCfgName(pIniFile->sczNamespace, rgIniValues[i].wzName, &sczFullValueName);
-        ExitOnFailure2(hr, "Failed ot map INI value name: %ls, %ls", pIniFile->sczNamespace, rgIniValues[i].wzName);
+        ExitOnFailure(hr, "Failed ot map INI value name: %ls, %ls", pIniFile->sczNamespace, rgIniValues[i].wzName);
 
         hr = FilterCheckValue(&pSyncProductSession->product, sczFullValueName, &fIgnore, NULL);
-        ExitOnFailure1(hr, "Failed to check if ini value should be ignored: %ls", sczFullValueName);
+        ExitOnFailure(hr, "Failed to check if ini value should be ignored: %ls", sczFullValueName);
 
         if (fIgnore)
         {
@@ -76,14 +76,14 @@ HRESULT IniFileRead(
         }
 
         hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczFullValueName);
-        ExitOnFailure1(hr, "Failed to add to dictionary value: %ls", sczFullValueName);
+        ExitOnFailure(hr, "Failed to add to dictionary value: %ls", sczFullValueName);
 
         ReleaseNullCfgValue(cvValue);
         hr = ValueSetString(rgIniValues[i].wzValue, FALSE, &st, pcdb->sczGuid, &cvValue);
-        ExitOnFailure1(hr, "Failed to set string in memory for value named %ls", sczFullValueName);
+        ExitOnFailure(hr, "Failed to set string in memory for value named %ls", sczFullValueName);
 
         hr = ValueWrite(pcdb, pcdb->dwAppID, sczFullValueName, &cvValue, TRUE);
-        ExitOnFailure1(hr, "Failed to set value from INI: %ls", sczFullValueName);
+        ExitOnFailure(hr, "Failed to set value from INI: %ls", sczFullValueName);
     }
 
 LExit:
@@ -120,7 +120,7 @@ HRESULT IniFileSetValue(
     }
     else
     {
-        ExitOnFailure1(hr, "Failed to lookup namespace in list of INI file namespaces: %ls", sczNamespace);
+        ExitOnFailure(hr, "Failed to lookup namespace in list of INI file namespaces: %ls", sczNamespace);
         *pfHandled = TRUE;
 
         if (VALUE_DELETED == pcvValue->cvType)
@@ -131,7 +131,7 @@ HRESULT IniFileSetValue(
         else if (VALUE_STRING == pcvValue->cvType)
         {
             hr = IniSetValue(pIniFile->pIniHandle, sczPlainValueName, pcvValue->string.sczValue);
-            ExitOnFailure1(hr, "Failed to set value %ls in INI", sczPlainValueName);
+            ExitOnFailure(hr, "Failed to set value %ls in INI", sczPlainValueName);
         }
         else
         {
@@ -176,7 +176,7 @@ HRESULT IniFileOpen(
 
     default:
         hr = E_FAIL;
-        ExitOnFailure1(hr, "Unexpected legacy file type encountered: %u", pFile->legacyFileType);
+        ExitOnFailure(hr, "Unexpected legacy file type encountered: %u", pFile->legacyFileType);
         break;
     }
 
@@ -195,7 +195,7 @@ HRESULT IniFileOpen(
     for (DWORD i = 0; i < pFileIniInfo->cValueSeparatorException; ++i)
     {
         hr = IniSetValueSeparatorException(pIniFile->pIniHandle, pFileIniInfo->rgsczValueSeparatorException[i]);
-        ExitOnFailure1(hr, "Failed to set value separator exception %ls", pFileIniInfo->rgsczValueSeparatorException[i]);
+        ExitOnFailure(hr, "Failed to set value separator exception %ls", pFileIniInfo->rgsczValueSeparatorException[i]);
     }
 
     hr = IniSetCommentStyle(pIniFile->pIniHandle, pFileIniInfo->sczCommentPrefix);
@@ -235,22 +235,22 @@ HRESULT IniFileWrite(
     if (fIniHasValues)
     {
         hr = PathGetDirectory(pIniFile->sczFullPath, &sczDirectoryToCreate);
-        ExitOnFailure1(hr, "Failed to get directory portion of path: %ls", pIniFile->sczFullPath);
+        ExitOnFailure(hr, "Failed to get directory portion of path: %ls", pIniFile->sczFullPath);
 
         hr = DirEnsureExists(sczDirectoryToCreate, NULL);
-        ExitOnFailure1(hr, "Failed to ensure directory exists: %ls", sczDirectoryToCreate);
+        ExitOnFailure(hr, "Failed to ensure directory exists: %ls", sczDirectoryToCreate);
 
         hr = IniWriteFile(pIniFile->pIniHandle, pIniFile->sczFullPath, IniFileEncodingToFileEncoding(pIniFile->fetManifestEncoding));
         if (E_ACCESSDENIED == hr)
         {
             hr = UtilConvertToVirtualStorePath(pIniFile->sczFullPath, &sczVirtualStorePath);
-            ExitOnFailure1(hr, "Failed to convert path to virtual store path: %ls", pIniFile->sczFullPath);
+            ExitOnFailure(hr, "Failed to convert path to virtual store path: %ls", pIniFile->sczFullPath);
 
             hr = PathGetDirectory(sczVirtualStorePath, &sczDirectoryToCreate);
-            ExitOnFailure1(hr, "Failed to get directory portion of path: %ls", pIniFile->sczFullPath);
+            ExitOnFailure(hr, "Failed to get directory portion of path: %ls", pIniFile->sczFullPath);
 
             hr = DirEnsureExists(sczDirectoryToCreate, NULL);
-            ExitOnFailure1(hr, "Failed to ensure directory exists: %ls", sczDirectoryToCreate);
+            ExitOnFailure(hr, "Failed to ensure directory exists: %ls", sczDirectoryToCreate);
 
             hr = IniWriteFile(pIniFile->pIniHandle, sczVirtualStorePath, IniFileEncodingToFileEncoding(pIniFile->fetManifestEncoding));
         }
@@ -262,11 +262,11 @@ HRESULT IniFileWrite(
         if (E_ACCESSDENIED == hr)
         {
             hr = UtilConvertToVirtualStorePath(pIniFile->sczFullPath, &sczVirtualStorePath);
-            ExitOnFailure1(hr, "Failed to convert path to virtual store path: %ls", pIniFile->sczFullPath);
+            ExitOnFailure(hr, "Failed to convert path to virtual store path: %ls", pIniFile->sczFullPath);
 
             hr = FileEnsureDelete(sczVirtualStorePath);
         }
-        ExitOnFailure1(hr, "Failed to delete empty INI file: %ls", pIniFile->sczFullPath);
+        ExitOnFailure(hr, "Failed to delete empty INI file: %ls", pIniFile->sczFullPath);
     }
 
 LExit:

--- a/src/SettingsEngine/lib/legsync.cpp
+++ b/src/SettingsEngine/lib/legsync.cpp
@@ -152,7 +152,7 @@ HRESULT LegacySyncSetProduct(
     ExitOnFailure(hr, "Failed to create cached detection property values dictionary");
 
     hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwCfgAppID, sczManifestValueName, &sceManifestValueRow);
-    ExitOnFailure2(hr, "Failed to find config value for legacy manifest (AppID: %u, Config Value named: %ls)", pcdb->dwCfgAppID, sczManifestValueName);
+    ExitOnFailure(hr, "Failed to find config value for legacy manifest (AppID: %u, Config Value named: %ls)", pcdb->dwCfgAppID, sczManifestValueName);
 
     hr = ValueRead(pcdb, sceManifestValueRow, &cvManifestContents);
     ExitOnFailure(hr, "Failed to read manifest contents");
@@ -166,12 +166,12 @@ HRESULT LegacySyncSetProduct(
         ExitOnFailure(hr, "Failed to set converted manifest value in memory");
 
         hr = ValueWrite(pcdb, pcdb->dwCfgAppID, sczManifestValueName, &cvManifestConvertedToBlob, TRUE);
-        ExitOnFailure1(hr, "Failed to set converted manifest blob: %ls", sczManifestValueName);
+        ExitOnFailure(hr, "Failed to set converted manifest blob: %ls", sczManifestValueName);
 
         ReleaseNullSceRow(sceManifestValueRow);
         ReleaseNullCfgValue(cvManifestContents);
         hr = ValueFindRow(pcdb, VALUE_INDEX_TABLE, pcdb->dwCfgAppID, sczManifestValueName, &sceManifestValueRow);
-        ExitOnFailure2(hr, "Failed to find config value for legacy manifest after conversion (AppID: %u, Config Value named: %ls)", pcdb->dwCfgAppID, sczManifestValueName);
+        ExitOnFailure(hr, "Failed to find config value for legacy manifest after conversion (AppID: %u, Config Value named: %ls)", pcdb->dwCfgAppID, sczManifestValueName);
 
         hr = ValueRead(pcdb, sceManifestValueRow, &cvManifestContents);
         ExitOnFailure(hr, "Failed to read converted manifest contents");
@@ -190,7 +190,7 @@ HRESULT LegacySyncSetProduct(
     }
 
     hr = StreamRead(pcdb, cvManifestContents.blob.dbstream.dwContentID, NULL, &pbManifestBuffer, &iManifestBuffer);
-    ExitOnFailure2(hr, "Failed to get binary content of blob named: %ls, with content ID: %u", sczManifestValueName, pcdb->dwCfgAppID);
+    ExitOnFailure(hr, "Failed to get binary content of blob named: %ls, with content ID: %u", sczManifestValueName, pcdb->dwCfgAppID);
 
     hr = StrAllocString(&sczBlobManifestAsString, reinterpret_cast<LPWSTR>(pbManifestBuffer), iManifestBuffer / sizeof(WCHAR));
     ExitOnFailure(hr, "Failed to add null terminator to manifest blob");
@@ -205,7 +205,7 @@ HRESULT LegacySyncSetProduct(
     ExitOnFailure(hr, "Failed to check if product is registered");
 
     hr = DetectProduct(pcdb, !pSyncSession->fDetect, &pSyncSession->arpProducts, &pSyncSession->exeProducts, pSyncProductSession);
-    ExitOnFailure1(hr, "Failed to detect product with AppID: %u", pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to detect product with AppID: %u", pcdb->dwAppID);
 
     // Don't bother writing new registration state data to the database if detect is disabled
     if (pSyncSession->fDetect)
@@ -246,7 +246,7 @@ HRESULT LegacySyncSetProduct(
                     ExitOnFailure(hr, "Failed to parse INI file");
 
                     hr = DictAddValue(pSyncProductSession->shIniFilesByNamespace, pIniFile);
-                    ExitOnFailure1(hr, "Failed to add INI file to dict for namespace: %ls", pIniFile->sczNamespace);
+                    ExitOnFailure(hr, "Failed to add INI file to dict for namespace: %ls", pIniFile->sczNamespace);
 
                     ++pSyncProductSession->cIniFiles;
                 }
@@ -289,7 +289,7 @@ HRESULT LegacyProductMachineToDb(
     {
         pRegKey = pSyncProductSession->product.rgRegKeys + i;
         hr = ReadRegKeyWriteLegacyDb(pcdb, pSyncProductSession, pRegKey, pRegKey->sczKey);
-        ExitOnFailure2(hr, "Failed to write data to settings engine from registry key: %u, %ls", pRegKey->dwRoot, pRegKey->sczKey);
+        ExitOnFailure(hr, "Failed to write data to settings engine from registry key: %u, %ls", pRegKey->dwRoot, pRegKey->sczKey);
     }
 
     for (DWORD i = 0; i < pSyncProductSession->product.cFiles; ++i)
@@ -297,14 +297,14 @@ HRESULT LegacyProductMachineToDb(
         pFile = pSyncProductSession->product.rgFiles + i;
         if (NULL != pFile->sczExpandedPath)
         {
-            ExitOnFailure1(hr, "Failed to expand legacy directory paths for directory: %ls", pFile->sczLocation);
+            ExitOnFailure(hr, "Failed to expand legacy directory paths for directory: %ls", pFile->sczLocation);
 
             dwExpandedPathLen = lstrlenW(pFile->sczExpandedPath);
 
             if (0 == dwExpandedPathLen)
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Empty expanded path encountered while processing files for appID: %u", pcdb->dwAppID);
+                ExitOnFailure(hr, "Empty expanded path encountered while processing files for appID: %u", pcdb->dwAppID);
             }
             else if (LEGACY_FILE_DIRECTORY == pFile->legacyFileType)
             {
@@ -313,7 +313,7 @@ HRESULT LegacyProductMachineToDb(
                 {
                     hr = S_OK;
                 }
-                ExitOnFailure1(hr, "Failed to write files to settings engine from directory: %ls", pFile->sczExpandedPath);
+                ExitOnFailure(hr, "Failed to write files to settings engine from directory: %ls", pFile->sczExpandedPath);
             }
             else if (LEGACY_FILE_PLAIN == pFile->legacyFileType)
             {
@@ -322,7 +322,7 @@ HRESULT LegacyProductMachineToDb(
                 {
                     hr = S_OK;
                 }
-                ExitOnFailure1(hr, "Failed to write individual file to settings engine from path: %ls", pFile->sczExpandedPath);
+                ExitOnFailure(hr, "Failed to write individual file to settings engine from path: %ls", pFile->sczExpandedPath);
             }
         }
     }
@@ -506,7 +506,7 @@ HRESULT LegacySyncPullDeletedValues(
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to run query into VALUE_INDEX_TABLE table for AppID: %u", pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to run query into VALUE_INDEX_TABLE table for AppID: %u", pcdb->dwAppID);
 
     hr = SceGetNextResultRow(sqrhResults, &sceRow);
     while (E_NOTFOUND != hr)
@@ -531,7 +531,7 @@ HRESULT LegacySyncPullDeletedValues(
                 ExitOnFailure(hr, "Failed to set deleted value in memory");
 
                 hr = ValueWrite(pcdb, pcdb->dwAppID, sczName, &cvNewValue, TRUE);
-                ExitOnFailure1(hr, "Failed to write deleted value to db: %ls", sczName);
+                ExitOnFailure(hr, "Failed to write deleted value to db: %ls", sczName);
             }
         }
         ExitOnFailure(hr, "Failed to check if registry value exists in reg values seen database");
@@ -586,7 +586,7 @@ static HRESULT ProductDbToMachine(
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to run query into VALUE_INDEX_TABLE table for AppID: %u", pcdb->dwAppID);
+    ExitOnFailure(hr, "Failed to run query into VALUE_INDEX_TABLE table for AppID: %u", pcdb->dwAppID);
 
     hr = SceGetNextResultRow(sqrhResults, &sceRow);
     while (E_NOTFOUND != hr)
@@ -597,7 +597,7 @@ static HRESULT ProductDbToMachine(
         ExitOnFailure(hr, "Failed to get name from row while querying VALUE_INDEX_TABLE table");
 
         hr = FilterCheckValue(&pSyncProductSession->product, sczName, &fIgnore, NULL);
-        ExitOnFailure1(hr, "Failed to check if cfg setting should be ignored: %ls", sczName);
+        ExitOnFailure(hr, "Failed to check if cfg setting should be ignored: %ls", sczName);
 
         if (!fIgnore)
         {
@@ -617,24 +617,24 @@ static HRESULT ProductDbToMachine(
 
             ReleaseNullCfgValue(cvValue);
             hr = ValueRead(pcdb, sceRow, &cvValue);
-            ExitOnFailure1(hr, "Failed to read value %ls", sczName);
+            ExitOnFailure(hr, "Failed to read value %ls", sczName);
 
             if (!fHandled)
             {
                 hr = RegDefaultWriteValue(&pSyncProductSession->product, sczName, &cvValue, &fHandled);
-                ExitOnFailure1(hr, "Failed to write value through registry default handler: %ls", sczName);
+                ExitOnFailure(hr, "Failed to write value through registry default handler: %ls", sczName);
             }
 
             if (!fHandled)
             {
                 hr = IniFileSetValue(pSyncProductSession, sczName, &cvValue, &fHandled);
-                ExitOnFailure1(hr, "Failed to write registry value through ini handler: %ls", sczName);
+                ExitOnFailure(hr, "Failed to write registry value through ini handler: %ls", sczName);
             }
 
             if (!fHandled)
             {
                 hr = DirDefaultWriteFile(&pSyncProductSession->product, sczName, &cvValue, &fHandled);
-                ExitOnFailure1(hr, "Failed to write file through default handler: %ls", sczName);
+                ExitOnFailure(hr, "Failed to write file through default handler: %ls", sczName);
             }
         }
 
@@ -688,7 +688,7 @@ static HRESULT DeleteEmptyRegistryKeyChildren(
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to open regkey: %ls", wzSubKey);
+    ExitOnFailure(hr, "Failed to open regkey: %ls", wzSubKey);
 
     if (E_NOMOREITEMS == RegValueEnum(hkKey, dwIndex, &sczValueName, NULL))
     {
@@ -699,7 +699,7 @@ static HRESULT DeleteEmptyRegistryKeyChildren(
     dwIndex = 0;
     while (E_NOMOREITEMS != (hr = RegKeyEnum(hkKey, dwIndex, &sczSubkeyName)))
     {
-        ExitOnFailure1(hr, "Failed to enumerate key %u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate key %u", dwIndex);
 
         hr = StrAllocString(&sczSubkeyPath, wzSubKey, 0);
         ExitOnFailure(hr, "Failed to allocate copy of subkey name");
@@ -709,7 +709,7 @@ static HRESULT DeleteEmptyRegistryKeyChildren(
         if (0 == dwSubKeyPathLen)
         {
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Encountered empty keyname while enumerating subkeys under key: %ls", wzSubKey);
+            ExitOnFailure(hr, "Encountered empty keyname while enumerating subkeys under key: %ls", wzSubKey);
         }
         else if (L'\\' != sczSubkeyPath[dwSubKeyPathLen - 1])
         {
@@ -727,14 +727,14 @@ static HRESULT DeleteEmptyRegistryKeyChildren(
             ++dwIndex;
             hr = S_OK;
         }
-        ExitOnFailure2(hr, "Failed to read regkey and write settings for root: %u, subkey: %ls", dwRoot, sczSubkeyPath);
+        ExitOnFailure(hr, "Failed to read regkey and write settings for root: %u, subkey: %ls", dwRoot, sczSubkeyPath);
     }
 
     // If there are no keys and no values under it, delete it
     if (fNoValues && 0 == dwIndex)
     {
         hr = RegDelete(ManifestConvertToRootKey(dwRoot), wzSubKey, REG_KEY_DEFAULT, FALSE);
-        ExitOnFailure2(hr, "Failed to delete registry key at root: %u, subkey: %ls", dwRoot, wzSubKey);
+        ExitOnFailure(hr, "Failed to delete registry key at root: %u, subkey: %ls", dwRoot, wzSubKey);
 
         ExitFunction1(hr = S_OK);
     }
@@ -772,7 +772,7 @@ static HRESULT DeleteEmptyRegistryKeys(
             hr = S_OK;
             continue;
         }
-        ExitOnFailure2(hr, "Failed to check for empty keys and delete them at root: %u, subkey: %ls", rgRegKeys[i].dwRoot, rgRegKeys[i].sczKey);
+        ExitOnFailure(hr, "Failed to check for empty keys and delete them at root: %u, subkey: %ls", rgRegKeys[i].dwRoot, rgRegKeys[i].sczKey);
 
         hr = StrAllocString(&sczParentKey, rgRegKeys[i].sczKey, 0);
         ExitOnFailure(hr, "Failed to allocate copy of subkey");
@@ -843,7 +843,7 @@ static HRESULT DeleteEmptyDirectoryChildren(
         {
             ExitFunction();
         }
-        ExitWithLastError1(hr, "Failed to find first file with query: %ls", sczSubDirWithWildcard);
+        ExitWithLastError(hr, "Failed to find first file with query: %ls", sczSubDirWithWildcard);
     }
 
     do
@@ -862,13 +862,13 @@ static HRESULT DeleteEmptyDirectoryChildren(
         }
 
         hr = PathConcat(wzPath, wfd.cFileName, &sczPath);
-        ExitOnFailure2(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzPath);
+        ExitOnFailure(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzPath);
 
         // If we found a directory, recurse!
         if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             hr = PathBackslashTerminate(&sczPath);
-            ExitOnFailure1(hr, "Failed to ensure path is backslash terminated: %ls", sczPath);
+            ExitOnFailure(hr, "Failed to ensure path is backslash terminated: %ls", sczPath);
 
             hr = DeleteEmptyDirectoryChildren(sczPath);
             if (HRESULT_FROM_WIN32(ERROR_DIR_NOT_EMPTY) == hr)
@@ -877,14 +877,14 @@ static HRESULT DeleteEmptyDirectoryChildren(
             }
             else
             {
-                ExitOnFailure1(hr, "Failed to recurse to directory: %ls", sczPath);
+                ExitOnFailure(hr, "Failed to recurse to directory: %ls", sczPath);
 
                 hr = DirEnsureDelete(sczPath, FALSE, FALSE);
                 if (HRESULT_FROM_WIN32(ERROR_DIR_NOT_EMPTY) == hr)
                 {
                     hr = S_OK;
                 }
-                ExitOnFailure1(hr, "Failed to delete directory: %ls", sczPath);
+                ExitOnFailure(hr, "Failed to delete directory: %ls", sczPath);
             }
         }
         else
@@ -901,7 +901,7 @@ static HRESULT DeleteEmptyDirectoryChildren(
     }
     else
     {
-        ExitWithLastError1(hr, "Failed while looping through files in directory: %ls", wzPath);
+        ExitWithLastError(hr, "Failed while looping through files in directory: %ls", wzPath);
     }
 
 LExit:
@@ -948,7 +948,7 @@ static HRESULT DeleteEmptyDirectory(
         {
             ExitFunction1(hr = S_OK);
         }
-        ExitOnFailure1(hr, "Failed to check for empty directories and delete them at path: %ls", wzPath);
+        ExitOnFailure(hr, "Failed to check for empty directories and delete them at path: %ls", wzPath);
     }
 
     hr = StrAllocString(&sczParentDirectory, wzPath, 0);
@@ -1012,14 +1012,14 @@ static HRESULT DeleteEmptyDirectories(
         }
 
         hr = DeleteEmptyDirectory(rgFiles[i].legacyFileType, rgFiles[i].sczExpandedPath);
-        ExitOnFailure1(hr, "Failed to scan for and delete empty directories for %ls", rgFiles[i].sczExpandedPath);
+        ExitOnFailure(hr, "Failed to scan for and delete empty directories for %ls", rgFiles[i].sczExpandedPath);
 
         // Delete the virtual store file as well
         hr = UtilConvertToVirtualStorePath(rgFiles[i].sczExpandedPath, &sczVirtualStorePath);
-        ExitOnFailure1(hr, "Failed to convert to virtualstore path: %ls", rgFiles[i].sczExpandedPath);
+        ExitOnFailure(hr, "Failed to convert to virtualstore path: %ls", rgFiles[i].sczExpandedPath);
 
         hr = DeleteEmptyDirectory(rgFiles[i].legacyFileType, sczVirtualStorePath);
-        ExitOnFailure1(hr, "Falied to delete scan for and delete empty virtual store directories for %ls", sczVirtualStorePath);
+        ExitOnFailure(hr, "Falied to delete scan for and delete empty virtual store directories for %ls", sczVirtualStorePath);
     }
 
 LExit:
@@ -1062,7 +1062,7 @@ static HRESULT UpdateProductRegistrationState(
     }
 
     hr = ProductRegister(pcdb, wzName, wzVersion, wzLegacyPublicKey, fRegistered);
-    ExitOnFailure3(hr, "Failed to update product registration state for product: '%ls', '%ls', '%ls'", wzName, wzVersion, wzLegacyPublicKey);
+    ExitOnFailure(hr, "Failed to update product registration state for product: '%ls', '%ls', '%ls'", wzName, wzVersion, wzLegacyPublicKey);
 
 LExit:
     return hr;
@@ -1094,7 +1094,7 @@ static HRESULT ReadDirWriteLegacyDbHelp(
         {
             ExitFunction();
         }
-        ExitWithLastError1(hr, "Failed to find first file with query: %ls", sczSubDirWithWildcard);
+        ExitWithLastError(hr, "Failed to find first file with query: %ls", sczSubDirWithWildcard);
     }
 
     do
@@ -1113,21 +1113,21 @@ static HRESULT ReadDirWriteLegacyDbHelp(
         }
 
         hr = PathConcat(wzSubDir, wfd.cFileName, &sczFileName);
-        ExitOnFailure2(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzSubDir);
+        ExitOnFailure(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzSubDir);
 
         // If we found a directory, recurse!
         if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             hr = PathBackslashTerminate(&sczFileName);
-            ExitOnFailure1(hr, "Failed to ensure path is backslash terminated: %ls", sczFileName);
+            ExitOnFailure(hr, "Failed to ensure path is backslash terminated: %ls", sczFileName);
 
             hr = ReadDirWriteLegacyDb(pcdb, pSyncProductSession, pFile, sczFileName);
-            ExitOnFailure1(hr, "Failed to recurse to directory: %ls", sczFileName);
+            ExitOnFailure(hr, "Failed to recurse to directory: %ls", sczFileName);
         }
         else
         {
             hr = ReadFileWriteLegacyDb(pcdb, pSyncProductSession, pFile, sczFileName, FALSE);
-            ExitOnFailure1(hr, "Failed while processing file: %ls", sczFileName);
+            ExitOnFailure(hr, "Failed while processing file: %ls", sczFileName);
         }
     }
     while (::FindNextFileW(hFind, &wfd));
@@ -1139,7 +1139,7 @@ static HRESULT ReadDirWriteLegacyDbHelp(
     }
     else
     {
-        ExitWithLastError1(hr, "Failed while looping through files in directory: %ls", wzSubDir);
+        ExitWithLastError(hr, "Failed while looping through files in directory: %ls", wzSubDir);
     }
 
 LExit:
@@ -1174,7 +1174,7 @@ static HRESULT ReadRegValueWriteLegacyDb(
     if (lstrlenW(pRegKey->sczKey) > lstrlenW(wzRegKey))
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Legacy registry key %ls was longer than the registry key sent to ReadRegValueWriteLegacyDb, %ls", pRegKey->sczKey, wzRegKey);
+        ExitOnFailure(hr, "Legacy registry key %ls was longer than the registry key sent to ReadRegValueWriteLegacyDb, %ls", pRegKey->sczKey, wzRegKey);
     }
 
     // Make the key reflect only the sub-portion under the original base key path
@@ -1186,7 +1186,7 @@ static HRESULT ReadRegValueWriteLegacyDb(
     
     // Pass the value up to check for special handling first
     hr = RegSpecialValueRead(pcdb, pSyncProductSession, pRegKey, hkKey, wzRegKey, wzValueName, dwType, &fContinueProcessing);
-    ExitOnFailure2(hr, "Failed to appropriately check for and handle special registry value, subkey: %ls, value: %ls", wzRegKey, wzValueName);
+    ExitOnFailure(hr, "Failed to appropriately check for and handle special registry value, subkey: %ls, value: %ls", wzRegKey, wzValueName);
 
     // If special handling tells us to avoid normal processing for this value, skip it
     if (!fContinueProcessing)
@@ -1195,7 +1195,7 @@ static HRESULT ReadRegValueWriteLegacyDb(
     }
 
     hr = RegDefaultReadValue(pcdb, pSyncProductSession, pRegKey->sczNamespace, hkKey, wzRegKey, wzValueName, dwType);
-    ExitOnFailure3(hr, "Failed to read registry with default handler valuetype: %u, key: %ls, named: %ls", dwType, wzRegKey, wzValueName);
+    ExitOnFailure(hr, "Failed to read registry with default handler valuetype: %u, key: %ls, named: %ls", dwType, wzRegKey, wzValueName);
 
 LExit:
     return hr;
@@ -1221,15 +1221,15 @@ static HRESULT ReadRegKeyWriteLegacyDb(
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to open regkey: %ls", wzSubKey);
+    ExitOnFailure(hr, "Failed to open regkey: %ls", wzSubKey);
 
     dwIndex = 0;
     while (E_NOMOREITEMS != (hr = RegValueEnum(hkKey, dwIndex, &sczValueName, &dwType)))
     {
-        ExitOnFailure1(hr, "Failed to enumerate value %u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate value %u", dwIndex);
 
         hr = ReadRegValueWriteLegacyDb(pcdb, pSyncProductSession, pRegKey, hkKey, wzSubKey, sczValueName, dwType);
-        ExitOnFailure1(hr, "Failed to write registry value setting: %ls", sczValueName);
+        ExitOnFailure(hr, "Failed to write registry value setting: %ls", sczValueName);
 
         ++dwIndex;
     }
@@ -1238,7 +1238,7 @@ static HRESULT ReadRegKeyWriteLegacyDb(
     dwIndex = 0;
     while (E_NOMOREITEMS != (hr = RegKeyEnum(hkKey, dwIndex, &sczSubkeyName)))
     {
-        ExitOnFailure1(hr, "Failed to enumerate key %u", dwIndex);
+        ExitOnFailure(hr, "Failed to enumerate key %u", dwIndex);
 
         hr = StrAllocString(&sczSubkeyPath, wzSubKey, 0);
         ExitOnFailure(hr, "Failed to allocate copy of subkey name");
@@ -1250,7 +1250,7 @@ static HRESULT ReadRegKeyWriteLegacyDb(
         ExitOnFailure(hr, "Failed to concatenate subkey name to subkey path");
 
         hr = ReadRegKeyWriteLegacyDb(pcdb, pSyncProductSession, pRegKey, sczSubkeyPath);
-        ExitOnFailure2(hr, "Failed to read regkey and write settings for root: %u, subkey: %ls", pRegKey->dwRoot, sczSubkeyPath);
+        ExitOnFailure(hr, "Failed to read regkey and write settings for root: %u, subkey: %ls", pRegKey->dwRoot, sczSubkeyPath);
 
         ++dwIndex;
     }
@@ -1286,7 +1286,7 @@ static HRESULT ReadFileWriteLegacyDb(
     if (lstrlenW(pFile->sczExpandedPath) > lstrlenW(wzFilePath))
     {
         hr = E_INVALIDARG;
-        ExitOnFailure2(hr, "Legacy file path %ls was longer than the file path sent to ReadFileWriteLegacyDb, %ls", pFile->sczExpandedPath, wzFilePath);
+        ExitOnFailure(hr, "Legacy file path %ls was longer than the file path sent to ReadFileWriteLegacyDb, %ls", pFile->sczExpandedPath, wzFilePath);
     }
 
     // Make the key reflect only the sub-portion under the original base key path
@@ -1308,16 +1308,16 @@ static HRESULT ReadFileWriteLegacyDb(
         {
             ExitFunction();
         }
-        ExitOnFailure1(hr, "Failed to check for write access to directory of file: %ls", wzFilePath);
+        ExitOnFailure(hr, "Failed to check for write access to directory of file: %ls", wzFilePath);
 
         if (!fWritePermission)
         {
             hr = UtilConvertToVirtualStorePath(wzFilePath, &sczVirtualStorePath);
-            ExitOnFailure1(hr, "Failed to convert file path to virtualstore path: %ls", wzFilePath);
+            ExitOnFailure(hr, "Failed to convert file path to virtualstore path: %ls", wzFilePath);
 
             // Pass the value up to check for special handling first
             hr = DirSpecialFileRead(pcdb, pSyncProductSession, pFile, sczVirtualStorePath, wzSubPath, &fContinueProcessing);
-            ExitOnFailure1(hr, "Failed to appropriately check for and handle special directory file under virtualstore, file path: %ls", wzFilePath);
+            ExitOnFailure(hr, "Failed to appropriately check for and handle special directory file under virtualstore, file path: %ls", wzFilePath);
 
             // If special handling tells us to avoid normal processing for this file, skip it
             if (!fContinueProcessing)
@@ -1326,7 +1326,7 @@ static HRESULT ReadFileWriteLegacyDb(
             }
 
             hr = DirDefaultReadFile(pcdb, pSyncProductSession, pFile->sczName, sczVirtualStorePath, NULL);
-            ExitOnFailure1(hr, "Failed to read virtualstore file with default handler, path: %ls", sczVirtualStorePath);
+            ExitOnFailure(hr, "Failed to read virtualstore file with default handler, path: %ls", sczVirtualStorePath);
 
             // Check if DirDefaultReadFile found the file or not
             hr = DictKeyExists(pSyncProductSession->shDictValuesSeen, pFile->sczName);
@@ -1336,7 +1336,7 @@ static HRESULT ReadFileWriteLegacyDb(
             }
             else
             {
-                ExitOnFailure1(hr, "Failed to check if file was seen under virtual store path: %ls", pFile->sczName);
+                ExitOnFailure(hr, "Failed to check if file was seen under virtual store path: %ls", pFile->sczName);
 
                 // It saw the file, so let's not proceed to check the non-virtualstore path
                 ExitFunction1(hr = S_OK);
@@ -1346,7 +1346,7 @@ static HRESULT ReadFileWriteLegacyDb(
 
     // Pass the value up to check for special handling first
     hr = DirSpecialFileRead(pcdb, pSyncProductSession, pFile, wzFilePath, wzSubPath, &fContinueProcessing);
-    ExitOnFailure1(hr, "Failed to appropriately check for and handle special directory file, file path: %ls", wzFilePath);
+    ExitOnFailure(hr, "Failed to appropriately check for and handle special directory file, file path: %ls", wzFilePath);
 
     // If special handling tells us to avoid normal processing for this file, skip it
     if (!fContinueProcessing)
@@ -1355,7 +1355,7 @@ static HRESULT ReadFileWriteLegacyDb(
     }
 
     hr = DirDefaultReadFile(pcdb, pSyncProductSession, pFile->sczName, wzFilePath, wzSubPath);
-    ExitOnFailure1(hr, "Failed to read file with default handler, path: %ls", wzFilePath);
+    ExitOnFailure(hr, "Failed to read file with default handler, path: %ls", wzFilePath);
 
 LExit:
     ReleaseStr(sczVirtualStorePath);
@@ -1381,18 +1381,18 @@ static HRESULT ReadDirWriteLegacyDb(
         fWritePermission = FALSE;
         hr = S_OK;
     }
-    ExitOnFailure1(hr, "Failed to check for write access to directory: %ls", wzSubDir);
+    ExitOnFailure(hr, "Failed to check for write access to directory: %ls", wzSubDir);
 
     if (!fWritePermission)
     {
         // If we don't have write permission to the directory, prefer files in virtualstore
         hr = UtilConvertToVirtualStorePath(wzSubDir, &sczFullPathToVirtualDirectory);
-        ExitOnFailure1(hr, "Failed to get path equivalent under virtualstore for directory: %ls", sczFullPathToVirtualDirectory);
+        ExitOnFailure(hr, "Failed to get path equivalent under virtualstore for directory: %ls", sczFullPathToVirtualDirectory);
 
         // Make the LEGACY_FILE struct temporarily appear as though its natural base path was under virtualstore
         pFile->sczExpandedPath = sczFullPathToVirtualDirectory;
         hr = ReadDirWriteLegacyDbHelp(pcdb, pSyncProductSession, pFile, sczFullPathToVirtualDirectory);
-        ExitOnFailure1(hr, "Failed to read files out of virtual store subdirectory: %ls", sczFullPathToVirtualDirectory);
+        ExitOnFailure(hr, "Failed to read files out of virtual store subdirectory: %ls", sczFullPathToVirtualDirectory);
 
         // Restore it back so it isn't pointing to virtualstore anymore
         pFile->sczExpandedPath = wzFullPathBackup;
@@ -1403,7 +1403,7 @@ static HRESULT ReadDirWriteLegacyDb(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to read files out of subdirectory: %ls", wzSubDir);
+    ExitOnFailure(hr, "Failed to read files out of subdirectory: %ls", wzSubDir);
 
 LExit:
     ReleaseStr(sczFullPathToVirtualDirectory);

--- a/src/SettingsEngine/lib/mapdata.cpp
+++ b/src/SettingsEngine/lib/mapdata.cpp
@@ -90,7 +90,7 @@ HRESULT MapRegValueToCfgName(
     else
     {
         hr = StrAllocString(&sczEscapedValueName, wzRawValueName, 0);
-        ExitOnFailure1(hr, "Failed to allocate copy of raw registry value name for escaping: %ls", wzRawValueName);
+        ExitOnFailure(hr, "Failed to allocate copy of raw registry value name for escaping: %ls", wzRawValueName);
 
         hr = StrReplaceStringAll(&sczEscapedValueName, L"\\", L"\\\\");
         ExitOnFailure(hr, "Failed to escape backslashes in registry value name");
@@ -203,15 +203,15 @@ HRESULT MapCfgNameToFile(
     {
         ExitFunction1(hr = E_INVALIDARG);
     }
-    ExitOnFailure1(hr, "Failed to lookup name %ls in file dictionary", wzName);
+    ExitOnFailure(hr, "Failed to lookup name %ls in file dictionary", wzName);
 
     hr = UtilExpandLegacyPath(pFile->sczLocation, &pProduct->detect, &sczExpandedPath);
-    ExitOnFailure1(hr, "Failed to expand legacy path: %ls", pFile->sczLocation);
+    ExitOnFailure(hr, "Failed to expand legacy path: %ls", pFile->sczLocation);
 
     if (NULL != wzFileName)
     {
         hr = PathConcat(sczExpandedPath, wzFileName, psczOutput);
-        ExitOnFailure2(hr, "Failed to concatenate base path '%ls' with name: %ls", sczExpandedPath, wzFileName);
+        ExitOnFailure(hr, "Failed to concatenate base path '%ls' with name: %ls", sczExpandedPath, wzFileName);
     }
     else
     {
@@ -268,7 +268,7 @@ HRESULT MapCfgNameToRegValue(
     {
         ExitFunction1(hr = E_INVALIDARG);
     }
-    ExitOnFailure1(hr, "Failed to lookup namespace %ls in regkey dictionary", wzNamespace);
+    ExitOnFailure(hr, "Failed to lookup namespace %ls in regkey dictionary", wzNamespace);
 
     *pdwRoot = pRegKey->dwRoot;
 

--- a/src/SettingsEngine/lib/parse.cpp
+++ b/src/SettingsEngine/lib/parse.cpp
@@ -142,7 +142,7 @@ HRESULT ParseManifest(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Product", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Product", bstrElement);
         }
 
         ReleaseNullObject(pixnNode);
@@ -295,7 +295,7 @@ HRESULT ParseDetectArp(
         ExitOnFailure(hr, "Failed to get next child element while going through list of elements under Detect/Arp");
 
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-        ExitOnFailure1(hr, "Unknown element '%ls' found under Detect/Arp", bstrElement);
+        ExitOnFailure(hr, "Unknown element '%ls' found under Detect/Arp", bstrElement);
 
         ReleaseNullObject(pixnChildElement);
     }
@@ -350,7 +350,7 @@ HRESULT ParseDetectExe(
         ExitOnFailure(hr, "Failed to get next child element while going through list of elements under Detect/Exe");
 
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-        ExitOnFailure1(hr, "Unknown element '%ls' found under Detect/Exe", bstrElement);
+        ExitOnFailure(hr, "Unknown element '%ls' found under Detect/Exe", bstrElement);
 
         ReleaseNullObject(pixnChildElement);
     }
@@ -417,7 +417,7 @@ HRESULT ParseDetects(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Detect", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Detect", bstrElement);
         }
 
         ReleaseNullObject(pixnNode);
@@ -462,7 +462,7 @@ HRESULT ParseDataRegistryKeyChildren(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Data/RegistryKey", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Data/RegistryKey", bstrElement);
         }
 
         ReleaseNullObject(pixnNode);
@@ -528,7 +528,7 @@ HRESULT ParseDataRegistryKeyBinary(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Data/RegistryKey/Binary", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Data/RegistryKey/Binary", bstrElement);
         }
 
         ReleaseNullObject(pixnNode);
@@ -616,7 +616,7 @@ HRESULT ParseDataRegistryKey(
     else
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-        ExitOnFailure1(hr, "Unexpected root type encountered: %ls", sczRoot);
+        ExitOnFailure(hr, "Unexpected root type encountered: %ls", sczRoot);
     }
     pProduct->rgRegKeys[pProduct->cRegKeys-1].sczKey = sczKey;
     sczKey = NULL;
@@ -691,7 +691,7 @@ HRESULT ParseDataDirectory(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, " Unknown element '%ls' found under Data/File", bstrElement);
+            ExitOnFailure(hr, " Unknown element '%ls' found under Data/File", bstrElement);
         }
 
         ReleaseNullObject(pixnChildElement);
@@ -733,7 +733,7 @@ HRESULT ParseDataFile(
     if (L'\\' == sczLocation[dwLocationLen - 1])
     {
         hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-        ExitOnFailure1(hr, "A path ending in backslash was specified for location in a file element: %ls", sczLocation);
+        ExitOnFailure(hr, "A path ending in backslash was specified for location in a file element: %ls", sczLocation);
     }
 
     hr = XmlGetAttributeEx(pixnElement, L"Name", &sczName);
@@ -774,7 +774,7 @@ HRESULT ParseDataFile(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Data/File", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Data/File", bstrElement);
         }
 
         ReleaseNullObject(pixnChildElement);
@@ -900,7 +900,7 @@ HRESULT ParseDataCfgFile(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Data/File", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Data/File", bstrElement);
         }
 
         ReleaseNullObject(pixnChildElement);
@@ -969,7 +969,7 @@ HRESULT ParseDataCfgFileValue(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under CfgFile/Value", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under CfgFile/Value", bstrElement);
         }
 
         ReleaseNullObject(pixnChildElement);
@@ -1025,7 +1025,7 @@ HRESULT ParseData(
         else
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Data", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Data", bstrElement);
         }
 
         ReleaseNullObject(pixnNode);
@@ -1068,7 +1068,7 @@ HRESULT ParseFilter(
         if (0 != lstrcmpW(bstrElement, L"Ignore") && 0 != lstrcmpW(bstrElement, L"Normal"))
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Unknown element '%ls' found under Filter element", bstrElement);
+            ExitOnFailure(hr, "Unknown element '%ls' found under Filter element", bstrElement);
         }
 
         hr = XmlGetAttributeEx(pixnNode, L"Name", &sczExactName);
@@ -1095,7 +1095,7 @@ HRESULT ParseFilter(
         if (NULL != sczExactName && (NULL != sczPrefix || NULL != sczPostfix))
         {
             hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-            ExitOnFailure1(hr, "Can't specify both a name and a (prefix or postfix) to a '%ls' element!", bstrElement);
+            ExitOnFailure(hr, "Can't specify both a name and a (prefix or postfix) to a '%ls' element!", bstrElement);
         }
 
         hr = MemEnsureArraySize(reinterpret_cast<void **>(&pProduct->rgFilters), pProduct->cFilters + 1, sizeof(LEGACY_VALUE_FILTER), 5);
@@ -1229,14 +1229,14 @@ static HRESULT AddLegacyRegistrySpecialCfgValuesToDict(
         ExitOnFailure(hr, "Failed to format cfg value name with namespace");
 
         hr = DictAddKey(*pshRegistrySpecials, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to add cfg value to list of specially-handled cfg values (flags): %ls", pRegKeySpecial->rgFlagsInfo[i].sczCfgValueName);
+        ExitOnFailure(hr, "Failed to add cfg value to list of specially-handled cfg values (flags): %ls", pRegKeySpecial->rgFlagsInfo[i].sczCfgValueName);
     }
 
     hr = MapRegSpecialToCfgValueName(pRegKey, pRegKeySpecial, &sczCfgValueName);
     ExitOnFailure(hr, "Failed to map registry value name to cfg value name");
 
     hr = DictAddKey(*pshRegistrySpecials, sczCfgValueName);
-    ExitOnFailure1(hr, "Failed to add cfg value to list of specially-handled cfg values (basic special): %ls", sczCfgValueName);
+    ExitOnFailure(hr, "Failed to add cfg value to list of specially-handled cfg values (basic special): %ls", sczCfgValueName);
 
 LExit:
     ReleaseStr(sczCfgValueName);

--- a/src/SettingsEngine/lib/precomp.h
+++ b/src/SettingsEngine/lib/precomp.h
@@ -14,9 +14,9 @@
 #pragma once
 
 #define ExitTrace LogErrorString
-#define ExitTrace1 LogErrorString
-#define ExitTrace2 LogErrorString
-#define ExitTrace3 LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
 
 #include <windows.h>
 #include <stdlib.h>

--- a/src/SettingsEngine/lib/product.cpp
+++ b/src/SettingsEngine/lib/product.cpp
@@ -26,7 +26,7 @@ HRESULT ProductValidateName(
     if (0 == lstrlenW(wzProductName))
     {
         hr = HRESULT_FROM_WIN32(ERROR_CLUSTER_INVALID_STRING_FORMAT);
-        ExitOnFailure1(hr, "ProductName \"%ls\" wasn't in a valid format - expected a non-empty string", wzProductName);
+        ExitOnFailure(hr, "ProductName \"%ls\" wasn't in a valid format - expected a non-empty string", wzProductName);
     }
 
 LExit:
@@ -52,7 +52,7 @@ HRESULT ProductValidateVersion(
     if (4 != dwResult)
     {
         hr = HRESULT_FROM_WIN32(ERROR_CLUSTER_INVALID_STRING_FORMAT);
-        ExitOnFailure1(hr, "Version \"%ls\" wasn't in a valid format - expected version like: 1.0.0.0", wzVersion);
+        ExitOnFailure(hr, "Version \"%ls\" wasn't in a valid format - expected version like: 1.0.0.0", wzVersion);
     }
 
     // TODO: Any additional validation here? Is "0.*" accepted? What about a version component > 65535?
@@ -71,7 +71,7 @@ HRESULT ProductValidatePublicKey(
     if (16 != lstrlenW(wzPublicKey))
     {
         hr = HRESULT_FROM_WIN32(ERROR_CLUSTER_INVALID_STRING_FORMAT);
-        ExitOnFailure1(hr, "Public key wasn't in a valid format - expect 16 characters: %ls", wzPublicKey);
+        ExitOnFailure(hr, "Public key wasn't in a valid format - expect 16 characters: %ls", wzPublicKey);
     }
 
     for (dwIndex = 0; dwIndex < 16; ++dwIndex)
@@ -86,7 +86,7 @@ HRESULT ProductValidatePublicKey(
 
         // This wasn't a valid character - return false
         hr = HRESULT_FROM_WIN32(ERROR_CLUSTER_INVALID_STRING_FORMAT);
-        ExitOnFailure2(hr, "Public key wasn't in a valid format - found non-hex digit: %lc in string \"%ls\"", wzPublicKey[dwIndex], wzPublicKey);
+        ExitOnFailure(hr, "Public key wasn't in a valid format - found non-hex digit: %lc in string \"%ls\"", wzPublicKey[dwIndex], wzPublicKey);
     }
 
 LExit:
@@ -110,13 +110,13 @@ HRESULT ProductFindRow(
     ExitOnFailure(hr, "Failed to begin query into product index table");
 
     hr = SceSetQueryColumnString(sqhHandle, wzProductName);
-    ExitOnFailure1(hr, "Failed to set query column name string to: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to set query column name string to: %ls", wzProductName);
 
     hr = SceSetQueryColumnString(sqhHandle, wzVersion);
-    ExitOnFailure1(hr, "Failed to set query column version string to: %ls", wzVersion);
+    ExitOnFailure(hr, "Failed to set query column version string to: %ls", wzVersion);
 
     hr = SceSetQueryColumnString(sqhHandle, wzPublicKey);
-    ExitOnFailure1(hr, "Failed to set query column publickey string to: %ls", wzPublicKey);
+    ExitOnFailure(hr, "Failed to set query column publickey string to: %ls", wzPublicKey);
 
     hr = SceRunQueryExact(&sqhHandle, pSceRow);
     if (E_NOTFOUND == hr)
@@ -124,7 +124,7 @@ HRESULT ProductFindRow(
         // Don't pollute our log with unnecessary messages
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to find product: %ls", wzProductName);
+    ExitOnFailure(hr, "Failed to find product: %ls", wzProductName);
 
 LExit:
     ReleaseSceQuery(sqhHandle);
@@ -160,14 +160,14 @@ HRESULT ProductSyncValues(
     ExitOnFailure(hr, "Failed to begin query into value table");
 
     hr = SceSetQueryColumnDword(sqhHandle, pcdb1->dwAppID);
-    ExitOnFailure1(hr, "Failed to set query column dword to: %u", pcdb1->dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", pcdb1->dwAppID);
 
     hr = SceRunQueryRange(&sqhHandle, &sqrhResults);
     if (E_NOTFOUND == hr)
     {
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure1(hr, "Failed to enumerate values for product %u", pcdb1->dwAppID);
+    ExitOnFailure(hr, "Failed to enumerate values for product %u", pcdb1->dwAppID);
 
     hr = SceGetNextResultRow(sqrhResults, &sceRow);
     while (E_NOTFOUND != hr)
@@ -188,11 +188,11 @@ HRESULT ProductSyncValues(
             if (E_NOTFOUND == hr)
             {
                 hr = DictAddKey(shDictValuesSeen, sczName);
-                ExitOnFailure1(hr, "Failed to add to dictionary value: %ls", sczName);
+                ExitOnFailure(hr, "Failed to add to dictionary value: %ls", sczName);
             }
             else
             {
-                ExitOnFailure1(hr, "Failed to check if key exists: %ls", sczName);
+                ExitOnFailure(hr, "Failed to check if key exists: %ls", sczName);
 
                 // This value was already synced; skip it!
                 goto Skip;
@@ -235,7 +235,7 @@ HRESULT ProductSyncValues(
                 for (DWORD i = 0; i < dwCfgCount1; ++i)
                 {
                     hr = EnumWriteValue(pcdb2, sczName, valueHistory1, i);
-                    ExitOnFailure2(hr, "Failed to write value %ls index %u", sczName, i);
+                    ExitOnFailure(hr, "Failed to write value %ls index %u", sczName, i);
                 }
             }
 
@@ -490,7 +490,7 @@ HRESULT ProductSet(
     else
     {
         hr = ProductEnsureCreated(pcdb, wzProductName, wzVersion, wzPublicKey, &pcdb->dwAppID, &pcdb->fProductIsLegacy);
-        ExitOnFailure1(hr, "Failed to ensure product exists: %ls", wzProductName);
+        ExitOnFailure(hr, "Failed to ensure product exists: %ls", wzProductName);
     }
 
     // Get the AppID (of either the found row, or the recently created row)
@@ -567,7 +567,7 @@ HRESULT ProductForget(
     ExitOnFailure(hr, "Failed to begin query into value table");
 
     hr = SceSetQueryColumnDword(sqhHandle, dwAppID);
-    ExitOnFailure1(hr, "Failed to set query column dword to: %u", dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", dwAppID);
 
     hr = SceRunQueryRange(&sqhHandle, &sqrhResults);
     if (E_NOTFOUND == hr)
@@ -582,7 +582,7 @@ HRESULT ProductForget(
         ExitOnFailure(hr, "Failed to get next result row");
 
         hr = ValueForget(pcdb, dwAppID, &sceRowValue);
-        ExitOnFailure1(hr, "Failed to forget value for AppID %u", dwAppID);
+        ExitOnFailure(hr, "Failed to forget value for AppID %u", dwAppID);
 
         ReleaseNullSceRow(sceRowValue);
         hr = SceGetNextResultRow(sqrhResults, &sceRowValue);
@@ -602,7 +602,7 @@ HRESULT ProductForget(
         ExitOnFailure(hr, "Failed to set delete value in memory");
 
         hr = ValueWrite(pcdb, pcdb->dwCfgAppID, sczLegacyManifestValueName, &cvValue, TRUE);
-        ExitOnFailure1(hr, "Failed to tombstone legacy manifest for product %ls", wzProductName);
+        ExitOnFailure(hr, "Failed to tombstone legacy manifest for product %ls", wzProductName);
     }
 
     hr = SceCommitTransaction(pcdb->psceDb);
@@ -642,7 +642,7 @@ HRESULT ProductGetLegacyManifestValueName(
     ExitOnFailure(hr, "Failed to allocate legacy manifest value prefix");
 
     hr = StrAllocConcat(psczManifestValueName, wzProductName, 0);
-    ExitOnFailure1(hr, "Failed to concat product name %ls to manifest value name", wzProductName);
+    ExitOnFailure(hr, "Failed to concat product name %ls to manifest value name", wzProductName);
 
 LExit:
     return hr;

--- a/src/SettingsEngine/lib/rgdfault.cpp
+++ b/src/SettingsEngine/lib/rgdfault.cpp
@@ -53,10 +53,10 @@ extern "C" HRESULT RegDefaultReadValue(
     LPWSTR sczCfgValueName = NULL;
 
     hr = MapRegValueToCfgName(wzNamespace, wzRegKey, wzValueName, &sczCfgValueName);
-    ExitOnFailure3(hr, "Failed to format default legacy value name from namespace: %ls, key: %ls, valuename: %ls", wzNamespace, wzRegKey, wzValueName);
+    ExitOnFailure(hr, "Failed to format default legacy value name from namespace: %ls, key: %ls, valuename: %ls", wzNamespace, wzRegKey, wzValueName);
 
     hr = FilterCheckValue(&pSyncProductSession->product, sczCfgValueName, &fIgnore, NULL);
-    ExitOnFailure1(hr, "Failed to check if cfg value should be ignored: %ls", sczCfgValueName);
+    ExitOnFailure(hr, "Failed to check if cfg value should be ignored: %ls", sczCfgValueName);
 
     if (fIgnore)
     {
@@ -64,28 +64,28 @@ extern "C" HRESULT RegDefaultReadValue(
     }
 
     hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczCfgValueName);
-    ExitOnFailure1(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
+    ExitOnFailure(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
 
     switch (dwRegType)
     {
     case REG_BINARY:
         hr = RegDefaultReadValueBinary(pcdb, hkKey, wzValueName, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to handle binary value by default handler while reading from registry: %ls", wzValueName);
+        ExitOnFailure(hr, "Failed to handle binary value by default handler while reading from registry: %ls", wzValueName);
         break;
 
     case REG_SZ:
         hr = RegDefaultReadValueString(pcdb, hkKey, wzValueName, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to handle string value by default handler while reading from registry: %ls", wzValueName);
+        ExitOnFailure(hr, "Failed to handle string value by default handler while reading from registry: %ls", wzValueName);
         break;
 
     case REG_DWORD:
         hr = RegDefaultReadValueDword(pcdb, hkKey, wzValueName, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to handle dword value by default handler while reading from registry: %ls", wzValueName);
+        ExitOnFailure(hr, "Failed to handle dword value by default handler while reading from registry: %ls", wzValueName);
         break;
 
     case REG_QWORD:
         hr = RegDefaultReadValueQword(pcdb, hkKey, wzValueName, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to handle qword value by default handler while reading from registry: %ls", wzValueName);
+        ExitOnFailure(hr, "Failed to handle qword value by default handler while reading from registry: %ls", wzValueName);
         break;
 
     default:
@@ -138,9 +138,9 @@ extern "C" HRESULT RegDefaultWriteValue(
             ExitFunction1(hr = S_OK);
         }
         hr = RegCreate(ManifestConvertToRootKey(dwRoot), sczRegKey, KEY_SET_VALUE, &hk);
-        ExitOnFailure1(hr, "Failed to create regkey: %ls", sczRegKey);
+        ExitOnFailure(hr, "Failed to create regkey: %ls", sczRegKey);
     }
-    ExitOnFailure1(hr, "Failed to open regkey: %ls", sczRegKey);
+    ExitOnFailure(hr, "Failed to open regkey: %ls", sczRegKey);
 
     switch (pcvValue->cvType)
     {
@@ -216,13 +216,13 @@ static HRESULT RegDefaultReadValueBinary(
     CONFIG_VALUE cvNewValue = { };
 
     hr = RegReadBinary(hkKey, wzValueName, &pbBuffer, &cbBuffer);
-    ExitOnFailure1(hr, "Failed to read binary value from registry: %ls", wzValueName);
+    ExitOnFailure(hr, "Failed to read binary value from registry: %ls", wzValueName);
 
     hr = ValueSetBlob(pbBuffer, cbBuffer, FALSE, NULL, pcdb->sczGuid, &cvNewValue);
-    ExitOnFailure1(hr, "Failed to set string value %ls in memory", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set string value %ls in memory", wzCfgValueName);
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzCfgValueName, &cvNewValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set value in db: %ls", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set value in db: %ls", wzCfgValueName);
 
 LExit:
     ReleaseMem(pbBuffer);
@@ -243,13 +243,13 @@ static HRESULT RegDefaultReadValueString(
     CONFIG_VALUE cvNewValue = { };
 
     hr = RegReadString(hkKey, wzValueName, &sczStringValue);
-    ExitOnFailure1(hr, "Failed to read string value from registry: %ls", wzValueName);
+    ExitOnFailure(hr, "Failed to read string value from registry: %ls", wzValueName);
 
     hr = ValueSetString(sczStringValue, FALSE, NULL, pcdb->sczGuid, &cvNewValue);
-    ExitOnFailure1(hr, "Failed to set string value %ls in memory", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set string value %ls in memory", wzCfgValueName);
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzCfgValueName, &cvNewValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set value in db: %ls", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set value in db: %ls", wzCfgValueName);
 
 LExit:
     ReleaseStr(sczStringValue);
@@ -270,13 +270,13 @@ static HRESULT RegDefaultReadValueDword(
     CONFIG_VALUE cvNewValue = { };
 
     hr = RegReadNumber(hkKey, wzValueName, &dwValue);
-    ExitOnFailure1(hr, "Failed to read dword value from registry: %ls", wzValueName);
+    ExitOnFailure(hr, "Failed to read dword value from registry: %ls", wzValueName);
 
     hr = ValueSetDword(dwValue, NULL, pcdb->sczGuid, &cvNewValue);
-    ExitOnFailure1(hr, "Failed to set string value %ls in memory", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set string value %ls in memory", wzCfgValueName);
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzCfgValueName, &cvNewValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set value in db: %ls", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set value in db: %ls", wzCfgValueName);
 
 LExit:
     ReleaseCfgValue(cvNewValue);
@@ -296,13 +296,13 @@ static HRESULT RegDefaultReadValueQword(
     CONFIG_VALUE cvNewValue = { };
 
     hr = RegReadQword(hkKey, wzValueName, &qwValue);
-    ExitOnFailure1(hr, "Failed to read qword value from registry: %ls", wzValueName);
+    ExitOnFailure(hr, "Failed to read qword value from registry: %ls", wzValueName);
 
     hr = ValueSetQword(qwValue, NULL, pcdb->sczGuid, &cvNewValue);
-    ExitOnFailure1(hr, "Failed to set string value %ls in memory", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set string value %ls in memory", wzCfgValueName);
 
     hr = ValueWrite(pcdb, pcdb->dwAppID, wzCfgValueName, &cvNewValue, TRUE);
-    ExitOnFailure1(hr, "Failed to set value in db: %ls", wzCfgValueName);
+    ExitOnFailure(hr, "Failed to set value in db: %ls", wzCfgValueName);
 
 LExit:
     ReleaseCfgValue(cvNewValue);

--- a/src/SettingsEngine/lib/rgspcial.cpp
+++ b/src/SettingsEngine/lib/rgspcial.cpp
@@ -72,13 +72,13 @@ extern "C" HRESULT RegSpecialValueRead(
     if (0 < pRegKeySpecial->cFlagsInfo)
     {
         hr = RegSpecialValueReadFlags(pcdb, pSyncProductSession, pRegKey, pRegKeySpecial, hkKey, wzValueName, dwValueType);
-        ExitOnFailure2(hr, "Failed to handle registry special type flags on read for value name: %ls, type: %u", wzValueName, dwValueType);
+        ExitOnFailure(hr, "Failed to handle registry special type flags on read for value name: %ls, type: %u", wzValueName, dwValueType);
     }
 
     if (pRegKeySpecial->fHandleNonTypecasted)
     {
         hr = RegSpecialValueReadNonTypecasted(pcdb, pSyncProductSession, pRegKey, pRegKeySpecial, hkKey, wzValueName);
-        ExitOnFailure2(hr, "Failed to handle registry special basic on read for value name: %ls, type: %u", wzValueName, dwValueType);
+        ExitOnFailure(hr, "Failed to handle registry special basic on read for value name: %ls, type: %u", wzValueName, dwValueType);
     }
     
 LExit:
@@ -127,7 +127,7 @@ extern "C" HRESULT RegSpecialsProductWrite(
                 // Don't create it here, because it may not need to be created at all. Delay creation until a value needs to be written.
                 hr = S_OK;
             }
-            ExitOnFailure2(hr, "Failed to open or create registry key at root: %u, key: %ls", pRegKey->dwRoot, wzRegKey);
+            ExitOnFailure(hr, "Failed to open or create registry key at root: %u, key: %ls", pRegKey->dwRoot, wzRegKey);
 
             switch (pRegKeySpecial->dwRegValueType)
             {
@@ -137,7 +137,7 @@ extern "C" HRESULT RegSpecialsProductWrite(
                 break;
             default:
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Registry value type unhandled in RegSpecialsProductWrite(): %u", pRegKeySpecial->dwRegValueType);
+                ExitOnFailure(hr, "Registry value type unhandled in RegSpecialsProductWrite(): %u", pRegKeySpecial->dwRegValueType);
                 break;
 
             }
@@ -222,7 +222,7 @@ static HRESULT RegSpecialValueReadFlags(
             ExitOnFailure(hr, "Failed to format Cfg Value name with namespace");
 
             hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczCfgValueName);
-            ExitOnFailure1(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
+            ExitOnFailure(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
 
             dwOffset = pRegKeySpecial->rgFlagsInfo[i].dwOffset;
 
@@ -288,10 +288,10 @@ static HRESULT RegSpecialValueReadNonTypecasted(
         ExitOnFailure(hr, "Failed to read dword value from registry");
 
         hr = ValueSetDword(dwValue, NULL, pcdb->sczGuid, &cvNewValue);
-        ExitOnFailure1(hr, "Failed to set dword value %ls in memory", sczCfgValueName);
+        ExitOnFailure(hr, "Failed to set dword value %ls in memory", sczCfgValueName);
 
         hr = ValueWrite(pcdb, pcdb->dwAppID, sczCfgValueName, &cvNewValue, TRUE);
-        ExitOnFailure1(hr, "Failed to set dword value: %ls", sczCfgValueName);
+        ExitOnFailure(hr, "Failed to set dword value: %ls", sczCfgValueName);
         break;
     case REG_NONE:
         fFound = FALSE;
@@ -301,7 +301,7 @@ static HRESULT RegSpecialValueReadNonTypecasted(
     if (fFound)
     {
         hr = DictAddKey(pSyncProductSession->shDictValuesSeen, sczCfgValueName);
-        ExitOnFailure1(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
+        ExitOnFailure(hr, "Failed to add to dictionary value: %ls", sczCfgValueName);
     }
 
 LExit:
@@ -345,11 +345,11 @@ static HRESULT RegSpecialProductWriteBinary(
             hr = S_OK;
             continue;
         }
-        ExitOnFailure2(hr, "Failed to find value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, sczCfgValueName);
+        ExitOnFailure(hr, "Failed to find value for AppID: %u, Config Value named: %ls", pcdb->dwAppID, sczCfgValueName);
 
         ReleaseNullCfgValue(cvExistingValue);
         hr = ValueRead(pcdb, sceRow, &cvExistingValue);
-        ExitOnFailure1(hr, "Failed to read value: %ls", sczCfgValueName);
+        ExitOnFailure(hr, "Failed to read value: %ls", sczCfgValueName);
 
         if (VALUE_BOOL != cvExistingValue.cvType)
         {
@@ -364,7 +364,7 @@ static HRESULT RegSpecialProductWriteBinary(
         {
             cbBuffer = (pFlagsInfo->dwOffset / 8) + 1;
             hr = MemEnsureArraySize(reinterpret_cast<void **>(&rgbBuffer), cbBuffer, sizeof(BYTE), 0);
-            ExitOnFailure1(hr, "Failed to ensure byte array is of size: %u", cbBuffer);
+            ExitOnFailure(hr, "Failed to ensure byte array is of size: %u", cbBuffer);
 
             if (cvExistingValue.boolean.fValue)
             {
@@ -394,7 +394,7 @@ static HRESULT RegSpecialProductWriteBinary(
         if (NULL != *phkKey)
         {
             hr = RegWriteString(*phkKey, wzRegValueName, NULL);
-            ExitOnFailure1(hr, "Failed to delete binary value: %ls", wzRegValueName);
+            ExitOnFailure(hr, "Failed to delete binary value: %ls", wzRegValueName);
         }
     }
     else
@@ -402,11 +402,11 @@ static HRESULT RegSpecialProductWriteBinary(
         if (NULL == *phkKey)
         {
             hr = RegCreate(ManifestConvertToRootKey(pRegKey->dwRoot), wzRegKey, KEY_SET_VALUE | KEY_CREATE_SUB_KEY, phkKey);
-            ExitOnFailure2(hr, "Failed to create registry key in root: %u, key %ls", pRegKey->dwRoot, wzRegKey);
+            ExitOnFailure(hr, "Failed to create registry key in root: %u, key %ls", pRegKey->dwRoot, wzRegKey);
         }
 
         hr = RegWriteBinary(*phkKey, wzRegValueName, rgbBuffer, cbBuffer);
-        ExitOnFailure2(hr, "Failed to write binary value: %ls with %u bytes", wzRegValueName, cbBuffer);
+        ExitOnFailure(hr, "Failed to write binary value: %ls with %u bytes", wzRegValueName, cbBuffer);
     }
 
 LExit:

--- a/src/SettingsEngine/lib/stream.cpp
+++ b/src/SettingsEngine/lib/stream.cpp
@@ -43,7 +43,7 @@ HRESULT StreamRead(
     ExitOnFailure(hr, "Failed to begin query into binary content table");
 
     hr = SceSetQueryColumnDword(sqhHandle, dwContentID);
-    ExitOnFailure1(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
 
     hr = SceRunQueryExact(&sqhHandle, &sceRow);
     if (E_NOTFOUND == hr)
@@ -53,29 +53,29 @@ HRESULT StreamRead(
     ExitOnFailure(hr, "Failed to run query into binary content table");
 
     hr = SceGetColumnDword(sceRow, BINARY_RAW_SIZE, &cbDbSize);
-    ExitOnFailure1(hr, "Failed to get raw size for binary content of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get raw size for binary content of ID: %u", dwContentID);
 
     hr = SceGetColumnBinary(sceRow, BINARY_HASH, &pbHashBuffer, &cbHashSize);
-    ExitOnFailure1(hr, "Failed to get hash for binary content of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get hash for binary content of ID: %u", dwContentID);
 
     if (CFG_HASH_LEN != cbHashSize)
     {
         hr = E_NOTFOUND;
-        ExitOnFailure2(hr, "Wrong size of hash encountered in database - expected %u, found %u", CFG_HASH_LEN, cbHashSize);
+        ExitOnFailure(hr, "Wrong size of hash encountered in database - expected %u, found %u", CFG_HASH_LEN, cbHashSize);
     }
 
     hr = SceGetColumnDword(sceRow, BINARY_COMPRESSION, reinterpret_cast<DWORD *>(&cfCompressionFormat));
-    ExitOnFailure1(hr, "Failed to get compression format for binary content of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get compression format for binary content of ID: %u", dwContentID);
 
     if (NULL != ppbFileBuffer)
     {
         hr = CompressReadStream(pcdb, pbHashBuffer, cfCompressionFormat, &pbContent, &cbDiskSize);
-        ExitOnFailure1(hr, "Failed to read stream file from disk for content ID %u", dwContentID);
+        ExitOnFailure(hr, "Failed to read stream file from disk for content ID %u", dwContentID);
 
         if (cbDiskSize != cbDbSize)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Stream with ID %u has error - size mismatch - stream size on disk = %u, stream size in DB = %u", cbDiskSize, cbDbSize);
+            ExitOnFailure(hr, "Stream with ID %u has error - size mismatch - stream size on disk = %u, stream size in DB = %u", cbDiskSize, cbDbSize);
         }
 
         *ppbFileBuffer = pbContent;
@@ -140,7 +140,7 @@ HRESULT StreamWrite(
         ExitOnFailure(hr, "Failed to find file by hash while setting stream");
 
         hr = StreamIncreaseRefcount(pcdb, dwContentID, 1);
-        ExitOnFailure1(hr, "Failed to increase stream ref count of Content ID %u", dwContentID);
+        ExitOnFailure(hr, "Failed to increase stream ref count of Content ID %u", dwContentID);
 
         *pdwContentID = dwContentID;
         ExitFunction1(hr = S_OK);
@@ -216,7 +216,7 @@ HRESULT StreamCopy(
     ExitOnFailure(hr, "Failed to begin query into binary content table");
 
     hr = SceSetQueryColumnDword(sqhHandle, dwContentIDFrom);
-    ExitOnFailure1(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentIDFrom);
+    ExitOnFailure(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentIDFrom);
 
     hr = SceRunQueryExact(&sqhHandle, &sceRowRead);
     if (E_NOTFOUND == hr)
@@ -226,7 +226,7 @@ HRESULT StreamCopy(
     ExitOnFailure(hr, "Failed to run query into binary content table");
 
     hr = SceGetColumnBinary(sceRowRead, BINARY_HASH, &pbHashBuffer, reinterpret_cast<DWORD *>(&cbHashSize));
-    ExitOnFailure1(hr, "Failed to get hash for binary content of ID: %u", dwContentIDFrom);
+    ExitOnFailure(hr, "Failed to get hash for binary content of ID: %u", dwContentIDFrom);
 
     // If a file with this hash already exists, recycle the same row
     hr = FindByHash(pcdbTo, pbHashBuffer, &dwContentIDTemp, NULL);
@@ -239,22 +239,22 @@ HRESULT StreamCopy(
         ExitOnFailure(hr, "Failed to find file by hash while setting stream");
 
         hr = StreamIncreaseRefcount(pcdbTo, dwContentIDTemp, 1);
-        ExitOnFailure1(hr, "Failed to increase stream ref count of Content ID %u", dwContentIDTemp);
+        ExitOnFailure(hr, "Failed to increase stream ref count of Content ID %u", dwContentIDTemp);
 
         *pdwContentIDTo = dwContentIDTemp;
         ExitFunction1(hr = S_OK);
     }
 
     hr = SceGetColumnDword(sceRowRead, BINARY_COMPRESSION, reinterpret_cast<DWORD *>(&cfCompressionFormat));
-    ExitOnFailure1(hr, "Failed to get compression format for binary content of ID: %u", dwContentIDFrom);
+    ExitOnFailure(hr, "Failed to get compression format for binary content of ID: %u", dwContentIDFrom);
 
     hr = SceGetColumnDword(sceRowRead, BINARY_RAW_SIZE, reinterpret_cast<DWORD *>(&cbSize));
-    ExitOnFailure1(hr, "Failed to get compression format for binary content of ID: %u", dwContentIDFrom);
+    ExitOnFailure(hr, "Failed to get compression format for binary content of ID: %u", dwContentIDFrom);
 
     if (CFG_HASH_LEN != cbHashSize)
     {
         hr = E_NOTFOUND;
-        ExitOnFailure2(hr, "Wrong size of hash encountered in database - expected %u, found %u", CFG_HASH_LEN, cbHashSize);
+        ExitOnFailure(hr, "Wrong size of hash encountered in database - expected %u, found %u", CFG_HASH_LEN, cbHashSize);
     }
 
     hr = SceBeginTransaction(pcdbTo->psceDb);
@@ -285,7 +285,7 @@ HRESULT StreamCopy(
         LogStringLine(REPORT_STANDARD, "Stream %ls was missing. If syncing to a cloud-managed directory, this is normal, and autosync (when the file is downloaded to the machine) will automatically fix the situation.", sczStreamPathFrom);
         ExitFunction1(hr = HRESULT_FROM_WIN32(PEERDIST_ERROR_MISSING_DATA));
     }
-    ExitOnFailure2(hr, "Failed to copy file from %ls to %ls", sczStreamPathFrom, sczStreamPathTo);
+    ExitOnFailure(hr, "Failed to copy file from %ls to %ls", sczStreamPathFrom, sczStreamPathTo);
 
     hr = SceSetColumnDword(sceRowInsert, BINARY_COMPRESSION, static_cast<DWORD>(cfCompressionFormat));
     ExitOnFailure(hr, "Failed to set Compression column to 0");
@@ -330,7 +330,7 @@ HRESULT StreamIncreaseRefcount(
     ExitOnFailure(hr, "Failed to begin query into binary content table");
 
     hr = SceSetQueryColumnDword(sqhHandle, dwContentID);
-    ExitOnFailure1(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
 
     hr = SceRunQueryExact(&sqhHandle, &sceRow);
     if (E_NOTFOUND == hr)
@@ -340,15 +340,15 @@ HRESULT StreamIncreaseRefcount(
     ExitOnFailure(hr, "Failed to run query into binary content table");
 
     hr = SceGetColumnDword(sceRow, BINARY_REFCOUNT, &dwRefCount);
-    ExitOnFailure1(hr, "Failed to get current refcount for binary ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get current refcount for binary ID: %u", dwContentID);
 
     dwRefCount += dwAmount;
 
     hr = SceSetColumnDword(sceRow, BINARY_REFCOUNT, dwRefCount);
-    ExitOnFailure1(hr, "Failed to refcount binary of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to refcount binary of ID: %u", dwContentID);
 
     hr = SceFinishUpdate(sceRow);
-    ExitOnFailure1(hr, "Failed to finish update while refcounting binary of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to finish update while refcounting binary of ID: %u", dwContentID);
 
 LExit:
     ReleaseSceQuery(sqhHandle);
@@ -375,7 +375,7 @@ HRESULT StreamDecreaseRefcount(
     ExitOnFailure(hr, "Failed to begin query into binary content table");
 
     hr = SceSetQueryColumnDword(sqhHandle, dwContentID);
-    ExitOnFailure1(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to set query column dword for ContentID column while querying binary content table, ContentID: %u", dwContentID);
 
     hr = SceRunQueryExact(&sqhHandle, &sceRow);
     if (E_NOTFOUND == hr)
@@ -385,10 +385,10 @@ HRESULT StreamDecreaseRefcount(
     ExitOnFailure(hr, "Failed to run query into binary content table");
 
     hr = SceGetColumnDword(sceRow, BINARY_REFCOUNT, &dwRefCount);
-    ExitOnFailure1(hr, "Failed to get current refcount for binary ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get current refcount for binary ID: %u", dwContentID);
 
     hr = SceGetColumnBinary(sceRow, BINARY_HASH, &pbHashBuffer, &cbHashSize);
-    ExitOnFailure1(hr, "Failed to get hash for binary content of ID: %u", dwContentID);
+    ExitOnFailure(hr, "Failed to get hash for binary content of ID: %u", dwContentID);
 
     // Don't let us do a negative overflow
     if (dwRefCount < dwAmount)
@@ -411,15 +411,15 @@ HRESULT StreamDecreaseRefcount(
         ExitOnFailure(hr, "Failed to get stream file path");
 
         hr = SceDeleteRow(&sceRow);
-        ExitOnFailure1(hr, "Failed to delete row of binary ID: %u", dwContentID);
+        ExitOnFailure(hr, "Failed to delete row of binary ID: %u", dwContentID);
     }
     else
     {
         hr = SceSetColumnDword(sceRow, BINARY_REFCOUNT, dwRefCount);
-        ExitOnFailure1(hr, "Failed to refcount binary of ID: %u", dwContentID);
+        ExitOnFailure(hr, "Failed to refcount binary of ID: %u", dwContentID);
 
         hr = SceFinishUpdate(sceRow);
-        ExitOnFailure1(hr, "Failed to finish update while de-refcounting binary of ID: %u", dwContentID);
+        ExitOnFailure(hr, "Failed to finish update while de-refcounting binary of ID: %u", dwContentID);
     }
 
 LExit:
@@ -467,7 +467,7 @@ HRESULT StreamGetFilePath(
     if (fCreateDirectory)
     {
         hr = DirEnsureExists(sczDirectory, NULL);
-        ExitOnFailure1(hr, "Failed to create directory: %ls", sczDirectory);
+        ExitOnFailure(hr, "Failed to create directory: %ls", sczDirectory);
     }
 
 LExit:

--- a/src/SettingsEngine/lib/util.cpp
+++ b/src/SettingsEngine/lib/util.cpp
@@ -253,7 +253,7 @@ static HRESULT IsProductInDictAndAddToDict(
     if (E_NOTFOUND == hr)
     {
         hr = DictAddKey(shDictProductsSeen, sczProductKey);
-        ExitOnFailure1(hr, "Failed to add product key to dict: %ls", sczProductKey);
+        ExitOnFailure(hr, "Failed to add product key to dict: %ls", sczProductKey);
 
         *pfResult = FALSE;
 
@@ -261,7 +261,7 @@ static HRESULT IsProductInDictAndAddToDict(
     }
     else
     {
-        ExitOnFailure1(hr, "Failed to check if key exists in dict: %ls", sczProductKey);
+        ExitOnFailure(hr, "Failed to check if key exists in dict: %ls", sczProductKey);
     }
 
     *pfResult = TRUE;
@@ -292,7 +292,7 @@ HRESULT UtilExpandLegacyPath(
         if (wzFindResult == wzInput)
         {
             hr = PathGetKnownFolder(LEGACY_DIRECTORIES[i].nFolder, &sczExpandedPath);
-            ExitOnFailure1(hr, "Failed to get known folder with ID: %d", LEGACY_DIRECTORIES[i].nFolder);
+            ExitOnFailure(hr, "Failed to get known folder with ID: %d", LEGACY_DIRECTORIES[i].nFolder);
 
             if (NULL != LEGACY_DIRECTORIES[i].wzAppend)
             {
@@ -327,7 +327,7 @@ HRESULT UtilExpandLegacyPath(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to expand directory path from detection results: %ls", wzInput);
+    ExitOnFailure(hr, "Failed to expand directory path from detection results: %ls", wzInput);
 
 LExit:
     ReleaseStr(sczExpandedPath);
@@ -362,7 +362,7 @@ HRESULT UtilTestWriteAccess(
     genericMapping.GenericAll     = ACCESS_READ | ACCESS_WRITE;
 
     hr = PathGetDirectory(wzPath, &sczDir);
-    ExitOnFailure1(hr, "Failed to get directory portion of path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to get directory portion of path: %ls", wzPath);
 
     if (!FileExistsEx(wzPath, NULL) && !DirExists(wzPath, NULL))
     {
@@ -378,12 +378,12 @@ HRESULT UtilTestWriteAccess(
     {
         ExitFunction1(hr = E_PATHNOTFOUND);
     }
-    ExitOnFailure1(hr, "Failed to get security descriptor for directory: %ls", sczDir);
+    ExitOnFailure(hr, "Failed to get security descriptor for directory: %ls", sczDir);
 
     fResult = ::AccessCheck(pSecurityDescriptor, hToken, ACCESS_WRITE, &genericMapping, &privilegeSet, &cbPrivilegeSetLength, &dwGrantedAccess, &fAccessStatus);
     if (!fResult)
     {
-        ExitWithLastError1(hr, "Failed to check for access to directory: %ls", wzPath);
+        ExitWithLastError(hr, "Failed to check for access to directory: %ls", wzPath);
     }
 
     if (fAccessStatus)
@@ -419,13 +419,13 @@ HRESULT UtilConvertToVirtualStorePath(
     LPWSTR sczFullPathToVirtual = NULL;
 
     hr = PathGetKnownFolder(CSIDL_LOCAL_APPDATA, &sczLocalAppData);
-    ExitOnFailure1(hr, "Failed to get known folder with ID: %d", CSIDL_LOCAL_APPDATA);
+    ExitOnFailure(hr, "Failed to get known folder with ID: %d", CSIDL_LOCAL_APPDATA);
 
     hr = PathConcat(sczLocalAppData, L"VirtualStore\\", &sczVirtualStore);
     ExitOnFailure(hr, "Failed to append VirtualStore to localappdata path");
 
     hr = PathConcat(sczVirtualStore, wzOriginalPath + 3, psczOutput);
-    ExitOnFailure1(hr, "Failed to append '%ls' to virtualstore directory", wzOriginalPath + 2);
+    ExitOnFailure(hr, "Failed to append '%ls' to virtualstore directory", wzOriginalPath + 2);
 
 LExit:
     ReleaseStr(sczTempFilePath);
@@ -574,7 +574,7 @@ static HRESULT UtilSyncAllProductsHelp(
         if (fLegacyProduct)
         {
             hr = LegacySyncFinalizeProduct(fFirstIsLocal ? pcdb1 : pcdb2, pSyncSession);
-            ExitOnFailure1(hr, "Failed to finalize product %u in legacy sync session", fFirstIsLocal ? pcdb1->dwAppID : pcdb2->dwAppID);
+            ExitOnFailure(hr, "Failed to finalize product %u in legacy sync session", fFirstIsLocal ? pcdb1->dwAppID : pcdb2->dwAppID);
         }
         else
         {

--- a/src/burn/engine/EngineForApplication.cpp
+++ b/src/burn/engine/EngineForApplication.cpp
@@ -458,12 +458,12 @@ public: // IBootstrapperEngine
         else if (wzPayloadId && * wzPayloadId)
         {
             hr = PayloadFindById(&m_pEngineState->payloads, wzPayloadId, &pPayload);
-            ExitOnFailure1(hr, "UX requested unknown payload with id: %ls", wzPayloadId);
+            ExitOnFailure(hr, "UX requested unknown payload with id: %ls", wzPayloadId);
 
             if (BURN_PAYLOAD_PACKAGING_EMBEDDED == pPayload->packaging)
             {
                 hr = HRESULT_FROM_WIN32(ERROR_INVALID_OPERATION);
-                ExitOnFailure1(hr, "UX denied while trying to set source on embedded payload: %ls", wzPayloadId);
+                ExitOnFailure(hr, "UX denied while trying to set source on embedded payload: %ls", wzPayloadId);
             }
 
             hr = StrAllocString(&pPayload->sczSourcePath, wzPath, 0);
@@ -472,7 +472,7 @@ public: // IBootstrapperEngine
         else if (wzPackageOrContainerId && *wzPackageOrContainerId)
         {
             hr = ContainerFindById(&m_pEngineState->containers, wzPackageOrContainerId, &pContainer);
-            ExitOnFailure1(hr, "UX requested unknown container with id: %ls", wzPackageOrContainerId);
+            ExitOnFailure(hr, "UX requested unknown container with id: %ls", wzPackageOrContainerId);
 
             hr = StrAllocString(&pContainer->sczSourcePath, wzPath, 0);
             ExitOnFailure(hr, "Failed to set source path for container.");
@@ -507,12 +507,12 @@ public: // IBootstrapperEngine
         if (wzPayloadId && * wzPayloadId)
         {
             hr = PayloadFindById(&m_pEngineState->payloads, wzPayloadId, &pPayload);
-            ExitOnFailure1(hr, "UX requested unknown payload with id: %ls", wzPayloadId);
+            ExitOnFailure(hr, "UX requested unknown payload with id: %ls", wzPayloadId);
 
             if (BURN_PAYLOAD_PACKAGING_EMBEDDED == pPayload->packaging)
             {
                 hr = HRESULT_FROM_WIN32(ERROR_INVALID_OPERATION);
-                ExitOnFailure1(hr, "UX denied while trying to set download URL on embedded payload: %ls", wzPayloadId);
+                ExitOnFailure(hr, "UX denied while trying to set download URL on embedded payload: %ls", wzPayloadId);
             }
 
             pDownloadSource = &pPayload->downloadSource;
@@ -520,7 +520,7 @@ public: // IBootstrapperEngine
         else if (wzPackageOrContainerId && *wzPackageOrContainerId)
         {
             hr = ContainerFindById(&m_pEngineState->containers, wzPackageOrContainerId, &pContainer);
-            ExitOnFailure1(hr, "UX requested unknown container with id: %ls", wzPackageOrContainerId);
+            ExitOnFailure(hr, "UX requested unknown container with id: %ls", wzPackageOrContainerId);
 
             pDownloadSource = &pContainer->downloadSource;
         }
@@ -747,7 +747,7 @@ public: // IBootstrapperEngine
         }
 
         hr = ApprovedExesFindById(&m_pEngineState->approvedExes, wzApprovedExeForElevationId, &pApprovedExe);
-        ExitOnFailure1(hr, "UX requested unknown approved exe with id: %ls", wzApprovedExeForElevationId);
+        ExitOnFailure(hr, "UX requested unknown approved exe with id: %ls", wzApprovedExeForElevationId);
 
         ::LeaveCriticalSection(&m_pEngineState->csActive);
         fLeaveCriticalSection = FALSE;

--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -894,7 +894,7 @@ static HRESULT ExtractContainer(
     }
 
     hr = ContainerOpen(&context, pContainer, hContainerHandle, wzContainerPath);
-    ExitOnFailure1(hr, "Failed to open container: %ls.", pContainer->sczId);
+    ExitOnFailure(hr, "Failed to open container: %ls.", pContainer->sczId);
 
     while (S_OK == (hr = ContainerNextStream(&context, &sczExtractPayloadId)))
     {
@@ -907,7 +907,7 @@ static HRESULT ExtractContainer(
             {
                 // TODO: Send progress when extracting stream to file.
                 hr = ContainerStreamToFile(&context, pExtract->sczUnverifiedPath);
-                ExitOnFailure2(hr, "Failed to extract payload: %ls from container: %ls", sczExtractPayloadId, pContainer->sczId);
+                ExitOnFailure(hr, "Failed to extract payload: %ls from container: %ls", sczExtractPayloadId, pContainer->sczId);
 
                 fExtracted = TRUE;
                 break;
@@ -917,7 +917,7 @@ static HRESULT ExtractContainer(
         if (!fExtracted)
         {
             hr = ContainerSkipStream(&context);
-            ExitOnFailure2(hr, "Failed to skip the extraction of payload: %ls from container: %ls", sczExtractPayloadId, pContainer->sczId);
+            ExitOnFailure(hr, "Failed to skip the extraction of payload: %ls from container: %ls", sczExtractPayloadId, pContainer->sczId);
         }
     }
 
@@ -925,7 +925,7 @@ static HRESULT ExtractContainer(
     {
         hr = S_OK;
     }
-    ExitOnFailure1(hr, "Failed to extract all payloads from container: %ls", pContainer->sczId);
+    ExitOnFailure(hr, "Failed to extract all payloads from container: %ls", pContainer->sczId);
 
 LExit:
     ReleaseStr(sczExtractPayloadId);
@@ -1015,7 +1015,7 @@ static HRESULT LayoutBundle(
             {
                 hr = S_FALSE;
             }
-            ExitOnFailure2(hr, "Failed to copy bundle from: '%ls' to: '%ls'", sczBundlePath, wzUnverifiedPath);
+            ExitOnFailure(hr, "Failed to copy bundle from: '%ls' to: '%ls'", sczBundlePath, wzUnverifiedPath);
         } while (S_FALSE == hr);
 
         if (FAILED(hr))
@@ -1053,7 +1053,7 @@ static HRESULT LayoutBundle(
             }
         } while (S_FALSE == hr);
     } while (fRetry);
-    LogExitOnFailure2(hr, MSG_FAILED_LAYOUT_BUNDLE, "Failed to layout bundle: %ls to layout directory: %ls", sczBundlePath, wzLayoutDirectory);
+    LogExitOnFailure(hr, MSG_FAILED_LAYOUT_BUNDLE, "Failed to layout bundle: %ls to layout directory: %ls", sczBundlePath, wzLayoutDirectory);
 
 LExit:
     ReleaseStr(sczDestinationPath);
@@ -1134,7 +1134,7 @@ static HRESULT AcquireContainerOrPayload(
             }
 
             // Log the error
-            LogExitOnFailure1(hr, MSG_PAYLOAD_FILE_NOT_PRESENT, "Failed while prompting for source (original path '%ls').", sczSourceFullPath);
+            LogExitOnFailure(hr, MSG_PAYLOAD_FILE_NOT_PRESENT, "Failed while prompting for source (original path '%ls').", sczSourceFullPath);
         }
 
         if (fCopy)
@@ -1172,7 +1172,7 @@ static HRESULT AcquireContainerOrPayload(
                 hr = S_OK;
             }
         }
-        ExitOnFailure2(hr, "Failed to acquire payload from: '%ls' to working path: '%ls'", fCopy ? sczSourceFullPath : wzDownloadUrl, wzDestinationPath);
+        ExitOnFailure(hr, "Failed to acquire payload from: '%ls' to working path: '%ls'", fCopy ? sczSourceFullPath : wzDownloadUrl, wzDestinationPath);
     } while (fRetry);
     ExitOnFailure(hr, "Failed to find external payload to cache.");
 
@@ -1259,7 +1259,7 @@ static HRESULT LayoutOrCacheContainerOrPayload(
             {
                 hr = HRESULT_FROM_WIN32(ERROR_INSTALL_FAILURE);
             }
-            ExitOnRootFailure2(hr, "BA aborted verify of %hs: %ls", pContainer ? "container" : "payload", pContainer ? wzPackageOrContainerId : wzPayloadId);
+            ExitOnRootFailure(hr, "BA aborted verify of %hs: %ls", pContainer ? "container" : "payload", pContainer ? wzPackageOrContainerId : wzPayloadId);
         }
 
         nResult = pUX->pUserExperience->OnCacheVerifyComplete(wzPackageOrContainerId, wzPayloadId, hr, FAILED(hr) && cTryAgainAttempts < BURN_CACHE_MAX_RECOMMENDED_VERIFY_TRYAGAIN_ATTEMPTS ? IDTRYAGAIN : IDNOACTION);
@@ -1353,7 +1353,7 @@ static HRESULT CopyPayload(
             dwFileAttributes &= ~FILE_ATTRIBUTE_READONLY;
             if (!::SetFileAttributes(wzDestinationPath, dwFileAttributes))
             {
-                ExitWithLastError1(hr, "Failed to clear readonly bit on payload destination path: %ls", wzDestinationPath);
+                ExitWithLastError(hr, "Failed to clear readonly bit on payload destination path: %ls", wzDestinationPath);
             }
         }
     }
@@ -1363,11 +1363,11 @@ static HRESULT CopyPayload(
         if (pProgress->fCancel)
         {
             hr = HRESULT_FROM_WIN32(ERROR_INSTALL_USEREXIT);
-            ExitOnRootFailure2(hr, "BA aborted copy of payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+            ExitOnRootFailure(hr, "BA aborted copy of payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
         }
         else
         {
-            ExitWithLastError2(hr, "Failed attempt to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+            ExitWithLastError(hr, "Failed attempt to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
         }
     }
 
@@ -1401,7 +1401,7 @@ static HRESULT DownloadPayload(
             dwFileAttributes &= ~FILE_ATTRIBUTE_READONLY;
             if (!::SetFileAttributes(wzDestinationPath, dwFileAttributes))
             {
-                ExitWithLastError1(hr, "Failed to clear readonly bit on payload destination path: %ls", wzDestinationPath);
+                ExitWithLastError(hr, "Failed to clear readonly bit on payload destination path: %ls", wzDestinationPath);
             }
         }
     }
@@ -1430,7 +1430,7 @@ static HRESULT DownloadPayload(
         
         hr = DownloadUrl(pDownloadSource, qwDownloadSize, wzDestinationPath, &cacheCallback, &authenticationCallback);
     }
-    ExitOnFailure2(hr, "Failed attempt to download URL: '%ls' to: '%ls'", pDownloadSource->sczUrl, wzDestinationPath);
+    ExitOnFailure(hr, "Failed attempt to download URL: '%ls' to: '%ls'", pDownloadSource->sczUrl, wzDestinationPath);
 
 LExit:
     return hr;
@@ -1816,7 +1816,7 @@ static HRESULT DoRollbackActions(
             case BURN_EXECUTE_ACTION_TYPE_SERVICE_START: __fallthrough;
             default:
                 hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid rollback action: %d.", pRollbackAction->type);
+                ExitOnFailure(hr, "Invalid rollback action: %d.", pRollbackAction->type);
             }
 
             if (*pRestart < restart)

--- a/src/burn/engine/approvedexe.cpp
+++ b/src/burn/engine/approvedexe.cpp
@@ -198,7 +198,7 @@ extern "C" HRESULT ApprovedExesLaunch(
     si.cb = sizeof(si);
     if (!::CreateProcessW(pLaunchApprovedExe->sczExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NEW_PROCESS_GROUP, NULL, sczExecutableDirectory, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to CreateProcess on path: %ls", pLaunchApprovedExe->sczExecutablePath);
+        ExitWithLastError(hr, "Failed to CreateProcess on path: %ls", pLaunchApprovedExe->sczExecutablePath);
     }
 
     *pdwProcessId = pi.dwProcessId;
@@ -249,7 +249,7 @@ extern "C" HRESULT ApprovedExesVerifySecureLocation(
         }
         else if (E_NOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed to get the variable: %ls", wzSecureFolderVariable);
+            ExitOnFailure(hr, "Failed to get the variable: %ls", wzSecureFolderVariable);
         }
     }
 

--- a/src/burn/engine/bitsengine.cpp
+++ b/src/burn/engine/bitsengine.cpp
@@ -341,7 +341,7 @@ extern "C" HRESULT BitsDownloadUrl(
     if (8 > lstrlenW(pDownloadSource->sczUrl))
     {
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Invalid BITS engine URL: %ls", pDownloadSource->sczUrl);
+        ExitOnRootFailure(hr, "Invalid BITS engine URL: %ls", pDownloadSource->sczUrl);
     }
 
     // Fix the URL to be "http" instead of "bits".

--- a/src/burn/engine/cabextract.cpp
+++ b/src/burn/engine/cabextract.cpp
@@ -431,7 +431,7 @@ static DWORD WINAPI ExtractThreadProc(
                 }
             }
         }
-        ExitOnFailure3(hr, "Failed to extract all files from container, erf: %d:%X:%d", erf.fError, erf.erfOper, erf.erfType);
+        ExitOnFailure(hr, "Failed to extract all files from container, erf: %d:%X:%d", erf.fError, erf.erfOper, erf.erfType);
     }
 
     // set operation complete event
@@ -554,7 +554,7 @@ static INT_PTR CopyFileCallback(
 
     // copy stream name
     hr = StrAllocStringAnsi(pContext->Cabinet.psczStreamName, pFDINotify->psz1, 0, CP_UTF8);
-    ExitOnFailure1(hr, "Failed to copy stream name: %ls", pFDINotify->psz1);
+    ExitOnFailure(hr, "Failed to copy stream name: %ls", pFDINotify->psz1);
 
     // set operation complete event
     if (!::SetEvent(pContext->Cabinet.hOperationCompleteEvent))
@@ -581,7 +581,7 @@ static INT_PTR CopyFileCallback(
         pContext->Cabinet.hTargetFile = ::CreateFileW(pContext->Cabinet.wzTargetFile, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (INVALID_HANDLE_VALUE == pContext->Cabinet.hTargetFile)
         {
-            ExitWithLastError1(hr, "Failed to create file: %ls", pContext->Cabinet.wzTargetFile);
+            ExitWithLastError(hr, "Failed to create file: %ls", pContext->Cabinet.wzTargetFile);
         }
 
         // set file size
@@ -676,7 +676,7 @@ static INT_PTR CloseFileInfoCallback(
     //if (pContext->pfnProgress)
     //{
     //    hr = StrAllocFormatted(&pwzPath, L"%s%ls", pContext->wzRootPath, pFDINotify->psz1);
-    //    ExitOnFailure2(hr, "Failed to calculate file path from: %ls and %s", pContext->wzRootPath, pFDINotify->psz1);
+    //    ExitOnFailure(hr, "Failed to calculate file path from: %ls and %s", pContext->wzRootPath, pFDINotify->psz1);
     //    if (SUCCEEDED(hr))
     //    {
     //        hr = pContext->pfnProgress(BOX_PROGRESS_DECOMPRESSION_END, pwzPath, 0, pContext->pvContext);
@@ -733,7 +733,7 @@ static INT_PTR FAR DIAMONDAPI CabOpen(
     else // open file requested. This is used in the rare cases where the CAB API wants to create a temp file.
     {
         hFile = ::CreateFileA(pszFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-        ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open cabinet file: %hs", pszFile);
+        ExitOnInvalidHandleWithLastError(hFile, hr, "Failed to open cabinet file: %hs", pszFile);
     }
 
 LExit:
@@ -845,7 +845,7 @@ static long FAR DIAMONDAPI CabSeek(
         // set file pointer
         if (!::SetFilePointerEx(hFile, liDistance, &liNewPointer, seektype))
         {
-            ExitWithLastError1(hr, "Failed to move file pointer 0x%x bytes.", dist);
+            ExitWithLastError(hr, "Failed to move file pointer 0x%x bytes.", dist);
         }
     }
 

--- a/src/burn/engine/cache.cpp
+++ b/src/burn/engine/cache.cpp
@@ -128,7 +128,7 @@ extern "C" HRESULT CacheInitialize(
     ExitOnFailure(hr, "Failed to combine working path with engine file name.");
 
     hr = PathCompare(sczCurrentPath, sczCompletedPath, &nCompare);
-    ExitOnFailure1(hr, "Failed to compare current path for bundle: %ls", sczCurrentPath);
+    ExitOnFailure(hr, "Failed to compare current path for bundle: %ls", sczCurrentPath);
 
     vfRunningFromCache = (CSTR_EQUAL == nCompare);
 
@@ -315,7 +315,7 @@ extern "C" HRESULT CacheGetCompletedPath(
     LPWSTR sczDefaultCompletedPath = NULL;
 
     hr = GetRootPath(fPerMachine, TRUE, &sczRootPath);
-    ExitOnFailure1(hr, "Failed to get %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
+    ExitOnFailure(hr, "Failed to get %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
 
     // GetRootPath returns S_FALSE if the package cache is redirected elsewhere.
     fRedirected = S_FALSE == hr;
@@ -331,7 +331,7 @@ extern "C" HRESULT CacheGetCompletedPath(
     if (fRedirected && !DirExists(sczCurrentCompletedPath, NULL))
     {
         hr = GetRootPath(fPerMachine, FALSE, &sczRootPath);
-        ExitOnFailure1(hr, "Failed to get old %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
+        ExitOnFailure(hr, "Failed to get old %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
 
         hr = PathConcat(sczRootPath, wzCacheId, &sczDefaultCompletedPath);
         ExitOnFailure(hr, "Failed to construct cache path.");
@@ -630,7 +630,7 @@ extern "C" HRESULT CacheBundleToWorkingDirectory(
     else // otherwise, carry on putting the bundle in the working folder.
     {
         hr = PathGetDirectory(sczSourcePath, &sczSourceDirectory);
-        ExitOnFailure1(hr, "Failed to get directory from engine path: %ls", sczSourcePath);
+        ExitOnFailure(hr, "Failed to get directory from engine path: %ls", sczSourcePath);
 
         hr = CacheEnsureWorkingFolder(wzBundleId, &sczWorkingFolder);
         ExitOnFailure(hr, "Failed to create working path to copy engine.");
@@ -646,7 +646,7 @@ extern "C" HRESULT CacheBundleToWorkingDirectory(
 
         // Copy the engine without any attached containers to the working path.
         hr = CopyEngineWithSignatureFixup(pSection->hEngineFile, sczSourcePath, sczTargetPath, pSection);
-        ExitOnFailure2(hr, "Failed to copy engine: '%ls' to working path: %ls", sczSourcePath, sczTargetPath);
+        ExitOnFailure(hr, "Failed to copy engine: '%ls' to working path: %ls", sczSourcePath, sczTargetPath);
 
         // Copy external UX payloads to working path.
         for (DWORD i = 0; i < pUxPayloads->cPayloads; ++i)
@@ -662,7 +662,7 @@ extern "C" HRESULT CacheBundleToWorkingDirectory(
                 ExitOnFailure(hr, "Failed to build payload target path for working copy.");
 
                 hr = FileEnsureCopyWithRetry(sczPayloadSourcePath, sczPayloadTargetPath, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-                ExitOnFailure2(hr, "Failed to copy UX payload from: '%ls' to: '%ls'", sczPayloadSourcePath, sczPayloadTargetPath);
+                ExitOnFailure(hr, "Failed to copy UX payload from: '%ls' to: '%ls'", sczPayloadSourcePath, sczPayloadTargetPath);
             }
         }
     }
@@ -699,7 +699,7 @@ extern "C" HRESULT CacheLayoutBundle(
     LogStringLine(REPORT_STANDARD, "Layout bundle from: '%ls' to: '%ls'", wzSourceBundlePath, sczTargetPath);
 
     hr = FileEnsureMoveWithRetry(wzSourceBundlePath, sczTargetPath, TRUE, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-    ExitOnFailure2(hr, "Failed to layout bundle from: '%ls' to '%ls'", wzSourceBundlePath, sczTargetPath);
+    ExitOnFailure(hr, "Failed to layout bundle from: '%ls' to '%ls'", wzSourceBundlePath, sczTargetPath);
 
 LExit:
     ReleaseStr(sczTargetPath);
@@ -736,7 +736,7 @@ extern "C" HRESULT CacheCompleteBundle(
     // If the bundle is running out of the package cache then we don't need to copy it there
     // (and don't want to since it'll be in use) so bail.
     hr = PathCompare(wzSourceBundlePath, sczTargetPath, &nCompare);
-    ExitOnFailure1(hr, "Failed to compare completed cache path for bundle: %ls", wzSourceBundlePath);
+    ExitOnFailure(hr, "Failed to compare completed cache path for bundle: %ls", wzSourceBundlePath);
 
     if (CSTR_EQUAL == nCompare)
     {
@@ -749,14 +749,14 @@ extern "C" HRESULT CacheCompleteBundle(
     FileRemoveFromPendingRename(sczTargetPath); // best effort to ensure bundle is not deleted from cache post restart.
 
     hr = FileEnsureCopyWithRetry(wzSourceBundlePath, sczTargetPath, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-    ExitOnFailure2(hr, "Failed to cache bundle from: '%ls' to '%ls'", wzSourceBundlePath, sczTargetPath);
+    ExitOnFailure(hr, "Failed to cache bundle from: '%ls' to '%ls'", wzSourceBundlePath, sczTargetPath);
 
     // Reset the path permissions in the cache.
     hr = ResetPathPermissions(fPerMachine, sczTargetPath);
-    ExitOnFailure1(hr, "Failed to reset permissions on cached bundle: '%ls'", sczTargetPath);
+    ExitOnFailure(hr, "Failed to reset permissions on cached bundle: '%ls'", sczTargetPath);
 
     hr = PathGetDirectory(wzSourceBundlePath, &sczSourceDirectory);
-    ExitOnFailure1(hr, "Failed to get directory from engine working path: %ls", wzSourceBundlePath);
+    ExitOnFailure(hr, "Failed to get directory from engine working path: %ls", wzSourceBundlePath);
 
     // Cache external UX payloads to completed path.
     for (DWORD i = 0; i < pUxPayloads->cPayloads; ++i)
@@ -769,7 +769,7 @@ extern "C" HRESULT CacheCompleteBundle(
             ExitOnFailure(hr, "Failed to build payload source path.");
 
             hr = CacheCompletePayload(fPerMachine, pPayload, wzBundleId, sczPayloadSourcePath, FALSE);
-            ExitOnFailure1(hr, "Failed to complete the cache of payload: %ls", pPayload->sczKey);
+            ExitOnFailure(hr, "Failed to complete the cache of payload: %ls", pPayload->sczKey);
         }
     }
 
@@ -796,7 +796,7 @@ extern "C" HRESULT CacheLayoutContainer(
     ExitOnFailure(hr, "Failed to concat complete cached path.");
 
     hr = VerifyThenTransferContainer(pContainer, sczCachedPath, wzUnverifiedContainerPath, fMove);
-    ExitOnFailure1(hr, "Failed to layout container from cached path: %ls", sczCachedPath);
+    ExitOnFailure(hr, "Failed to layout container from cached path: %ls", sczCachedPath);
 
 LExit:
     ReleaseStr(sczCachedPath);
@@ -818,7 +818,7 @@ extern "C" HRESULT CacheLayoutPayload(
     ExitOnFailure(hr, "Failed to concat complete cached path.");
 
     hr = VerifyThenTransferPayload(pPayload, sczCachedPath, wzUnverifiedPayloadPath, fMove);
-    ExitOnFailure1(hr, "Failed to layout payload from cached payload: %ls", sczCachedPath);
+    ExitOnFailure(hr, "Failed to layout payload from cached payload: %ls", sczCachedPath);
 
 LExit:
     ReleaseStr(sczCachedPath);
@@ -840,7 +840,7 @@ extern "C" HRESULT CacheCompletePayload(
     LPWSTR sczUnverifiedPayloadPath = NULL;
 
     hr = CreateCompletedPath(fPerMachine, wzCacheId, &sczCachedDirectory);
-    ExitOnFailure1(hr, "Failed to get cached path for package with cache id: %ls", wzCacheId);
+    ExitOnFailure(hr, "Failed to get cached path for package with cache id: %ls", wzCacheId);
 
     hr = PathConcat(sczCachedDirectory, pPayload->sczFilePath, &sczCachedPath);
     ExitOnFailure(hr, "Failed to concat complete cached path.");
@@ -867,16 +867,16 @@ extern "C" HRESULT CacheCompletePayload(
     if (FileExistsEx(wzWorkingPayloadPath, NULL))
     {
         hr = TransferWorkingPathToUnverifiedPath(wzWorkingPayloadPath, sczUnverifiedPayloadPath, fMove);
-        ExitOnFailure1(hr, "Failed to transfer working path to unverified path for payload: %ls.", pPayload->sczKey);
+        ExitOnFailure(hr, "Failed to transfer working path to unverified path for payload: %ls.", pPayload->sczKey);
     }
     else if (!FileExistsEx(sczUnverifiedPayloadPath, NULL)) // if the working path and unverified path do not exist, nothing we can do.
     {
         hr = E_FILENOTFOUND;
-        ExitOnFailure3(hr, "Failed to find payload: %ls in working path: %ls and unverified path: %ls", pPayload->sczKey, wzWorkingPayloadPath, sczUnverifiedPayloadPath);
+        ExitOnFailure(hr, "Failed to find payload: %ls in working path: %ls and unverified path: %ls", pPayload->sczKey, wzWorkingPayloadPath, sczUnverifiedPayloadPath);
     }
 
     hr = ResetPathPermissions(fPerMachine, sczUnverifiedPayloadPath);
-    ExitOnFailure1(hr, "Failed to reset permissions on unverified cached payload: %ls", pPayload->sczKey);
+    ExitOnFailure(hr, "Failed to reset permissions on unverified cached payload: %ls", pPayload->sczKey);
 
     hr = VerifyFileAgainstPayload(pPayload, sczUnverifiedPayloadPath);
     if (FAILED(hr))
@@ -890,7 +890,7 @@ extern "C" HRESULT CacheCompletePayload(
     LogId(REPORT_STANDARD, MSG_VERIFIED_ACQUIRED_PAYLOAD, pPayload->sczKey, sczUnverifiedPayloadPath, fMove ? "moving" : "copying", sczCachedPath);
 
     hr = FileEnsureMoveWithRetry(sczUnverifiedPayloadPath, sczCachedPath, TRUE, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-    ExitOnFailure1(hr, "Failed to move verified file to complete payload path: %ls", sczCachedPath);
+    ExitOnFailure(hr, "Failed to move verified file to complete payload path: %ls", sczCachedPath);
 
     ::DecryptFileW(sczCachedPath, 0);  // Let's try to make sure it's not encrypted.
 
@@ -942,7 +942,7 @@ extern "C" HRESULT CacheRemoveBundle(
     HRESULT hr = S_OK;
 
     hr = RemoveBundleOrPackage(TRUE, fPerMachine, wzBundleId, wzBundleId);
-    ExitOnFailure1(hr, "Failed to remove bundle id: %ls.", wzBundleId);
+    ExitOnFailure(hr, "Failed to remove bundle id: %ls.", wzBundleId);
 
 LExit:
     return hr;
@@ -957,7 +957,7 @@ extern "C" HRESULT CacheRemovePackage(
     HRESULT hr = S_OK;
 
     hr = RemoveBundleOrPackage(FALSE, fPerMachine, wzPackageId, wzCacheId);
-    ExitOnFailure1(hr, "Failed to remove package id: %ls.", wzPackageId);
+    ExitOnFailure(hr, "Failed to remove package id: %ls.", wzPackageId);
 
 LExit:
     return hr;
@@ -997,7 +997,7 @@ extern "C" HRESULT CacheVerifyPayloadSignature(
         wtd.dwProvFlags |= WTD_CACHE_ONLY_URL_RETRIEVAL;
 
         er = ::WinVerifyTrust(static_cast<HWND>(INVALID_HANDLE_VALUE), &guidAuthenticode, &wtd);
-        ExitOnWin32Error1(er, hr, "Failed authenticode verification of payload: %ls", wzUnverifiedPayloadPath);
+        ExitOnWin32Error(er, hr, "Failed authenticode verification of payload: %ls", wzUnverifiedPayloadPath);
     }
 
     pProviderData = WTHelperProvDataFromStateData(wtd.hWVTStateData);
@@ -1128,13 +1128,13 @@ static HRESULT GetRootPath(
         if (!vsczDefaultMachinePackageCache)
         {
             hr = PathGetKnownFolder(CSIDL_COMMON_APPDATA, &sczAppData);
-            ExitOnFailure1(hr, "Failed to find local %hs appdata directory.", "per-machine");
+            ExitOnFailure(hr, "Failed to find local %hs appdata directory.", "per-machine");
 
             hr = PathConcat(sczAppData, PACKAGE_CACHE_FOLDER_NAME, &vsczDefaultMachinePackageCache);
-            ExitOnFailure1(hr, "Failed to construct %hs package cache directory name.", "per-machine");
+            ExitOnFailure(hr, "Failed to construct %hs package cache directory name.", "per-machine");
 
             hr = PathBackslashTerminate(&vsczDefaultMachinePackageCache);
-            ExitOnFailure1(hr, "Failed to backslash terminate default %hs package cache directory name.", "per-machine");
+            ExitOnFailure(hr, "Failed to backslash terminate default %hs package cache directory name.", "per-machine");
         }
 
         if (!vsczCurrentMachinePackageCache)
@@ -1155,7 +1155,7 @@ static HRESULT GetRootPath(
         }
 
         hr = StrAllocString(psczRootPath, fAllowRedirect ? vsczCurrentMachinePackageCache : vsczDefaultMachinePackageCache, 0);
-        ExitOnFailure1(hr, "Failed to copy %hs package cache root directory.", "per-machine");
+        ExitOnFailure(hr, "Failed to copy %hs package cache root directory.", "per-machine");
 
         hr = PathCompare(vsczDefaultMachinePackageCache, *psczRootPath, &nCompare);
         ExitOnFailure(hr, "Failed to compare default and current package cache directories.");
@@ -1168,17 +1168,17 @@ static HRESULT GetRootPath(
         if (!vsczDefaultUserPackageCache)
         {
             hr = PathGetKnownFolder(CSIDL_LOCAL_APPDATA, &sczAppData);
-            ExitOnFailure1(hr, "Failed to find local %hs appdata directory.", "per-user");
+            ExitOnFailure(hr, "Failed to find local %hs appdata directory.", "per-user");
 
             hr = PathConcat(sczAppData, PACKAGE_CACHE_FOLDER_NAME, &vsczDefaultUserPackageCache);
-            ExitOnFailure1(hr, "Failed to construct %hs package cache directory name.", "per-user");
+            ExitOnFailure(hr, "Failed to construct %hs package cache directory name.", "per-user");
 
             hr = PathBackslashTerminate(&vsczDefaultUserPackageCache);
-            ExitOnFailure1(hr, "Failed to backslash terminate default %hs package cache directory name.", "per-user");
+            ExitOnFailure(hr, "Failed to backslash terminate default %hs package cache directory name.", "per-user");
         }
 
         hr = StrAllocString(psczRootPath, vsczDefaultUserPackageCache, 0);
-        ExitOnFailure1(hr, "Failed to copy %hs package cache root directory.", "per-user");
+        ExitOnFailure(hr, "Failed to copy %hs package cache root directory.", "per-user");
     }
 
 LExit:
@@ -1228,10 +1228,10 @@ static HRESULT CreateCompletedPath(
         ExitOnFailure(hr, "Failed to get cache directory.");
 
         hr = DirEnsureExists(sczCacheDirectory, NULL);
-        ExitOnFailure1(hr, "Failed to create cache directory: %ls", sczCacheDirectory);
+        ExitOnFailure(hr, "Failed to create cache directory: %ls", sczCacheDirectory);
 
         hr = SecurePath(sczCacheDirectory);
-        ExitOnFailure1(hr, "Failed to secure cache directory: %ls", sczCacheDirectory);
+        ExitOnFailure(hr, "Failed to secure cache directory: %ls", sczCacheDirectory);
 
         fPerMachineCacheRootVerified = TRUE;
     }
@@ -1243,7 +1243,7 @@ static HRESULT CreateCompletedPath(
     ExitOnFailure(hr, "Failed to get cache directory.");
 
     hr = DirEnsureExists(sczCacheDirectory, NULL);
-    ExitOnFailure1(hr, "Failed to create cache directory: %ls", sczCacheDirectory);
+    ExitOnFailure(hr, "Failed to create cache directory: %ls", sczCacheDirectory);
 
     ResetPathPermissions(fPerMachine, sczCacheDirectory);
 
@@ -1272,7 +1272,7 @@ static HRESULT CreateUnverifiedPath(
     if (!fUnverifiedCacheFolderCreated)
     {
         hr = DirEnsureExists(sczUnverifiedCacheFolder, NULL);
-        ExitOnFailure1(hr, "Failed to create unverified cache directory: %ls", sczUnverifiedCacheFolder);
+        ExitOnFailure(hr, "Failed to create unverified cache directory: %ls", sczUnverifiedCacheFolder);
 
         ResetPathPermissions(fPerMachine, sczUnverifiedCacheFolder);
     }
@@ -1300,14 +1300,14 @@ static HRESULT VerifyThenTransferContainer(
     hFile = ::CreateFileW(wzUnverifiedContainerPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to open container in working path: %ls", wzUnverifiedContainerPath);
+        ExitWithLastError(hr, "Failed to open container in working path: %ls", wzUnverifiedContainerPath);
     }
 
     // Container should have a hash we can use to verify with.
     if (pContainer->pbHash)
     {
         hr = VerifyHash(pContainer->pbHash, pContainer->cbHash, wzUnverifiedContainerPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify container hash: %ls", wzCachedPath);
+        ExitOnFailure(hr, "Failed to verify container hash: %ls", wzCachedPath);
     }
 
     LogStringLine(REPORT_STANDARD, "%ls container from working path '%ls' to path '%ls'", fMove ? L"Moving" : L"Copying", wzUnverifiedContainerPath, wzCachedPath);
@@ -1315,12 +1315,12 @@ static HRESULT VerifyThenTransferContainer(
     if (fMove)
     {
         hr = FileEnsureMoveWithRetry(wzUnverifiedContainerPath, wzCachedPath, TRUE, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to move %ls to %ls", wzUnverifiedContainerPath, wzCachedPath);
+        ExitOnFailure(hr, "Failed to move %ls to %ls", wzUnverifiedContainerPath, wzCachedPath);
     }
     else
     {
         hr = FileEnsureCopyWithRetry(wzUnverifiedContainerPath, wzCachedPath, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to copy %ls to %ls", wzUnverifiedContainerPath, wzCachedPath);
+        ExitOnFailure(hr, "Failed to copy %ls to %ls", wzUnverifiedContainerPath, wzCachedPath);
     }
 
 LExit:
@@ -1343,24 +1343,24 @@ static HRESULT VerifyThenTransferPayload(
     hFile = ::CreateFileW(wzUnverifiedPayloadPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to open payload in working path: %ls", wzUnverifiedPayloadPath);
+        ExitWithLastError(hr, "Failed to open payload in working path: %ls", wzUnverifiedPayloadPath);
     }
 
     // If the payload has a certificate root public key identifier provided, verify the certificate.
     if (pPayload->pbCertificateRootPublicKeyIdentifier)
     {
         hr = CacheVerifyPayloadSignature(pPayload, wzUnverifiedPayloadPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify payload signature: %ls", wzCachedPath);
+        ExitOnFailure(hr, "Failed to verify payload signature: %ls", wzCachedPath);
     }
     else if (pPayload->pCatalog) // If catalog files are specified, attempt to verify the file with a catalog file
     {
         hr = VerifyPayloadWithCatalog(pPayload, wzUnverifiedPayloadPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify payload signature: %ls", wzCachedPath);
+        ExitOnFailure(hr, "Failed to verify payload signature: %ls", wzCachedPath);
     }
     else if (pPayload->pbHash) // the payload should have a hash we can use to verify it.
     {
         hr = VerifyHash(pPayload->pbHash, pPayload->cbHash, wzUnverifiedPayloadPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify payload hash: %ls", wzCachedPath);
+        ExitOnFailure(hr, "Failed to verify payload hash: %ls", wzCachedPath);
     }
 
     LogStringLine(REPORT_STANDARD, "%ls payload from working path '%ls' to path '%ls'", fMove ? L"Moving" : L"Copying", wzUnverifiedPayloadPath, wzCachedPath);
@@ -1368,12 +1368,12 @@ static HRESULT VerifyThenTransferPayload(
     if (fMove)
     {
         hr = FileEnsureMoveWithRetry(wzUnverifiedPayloadPath, wzCachedPath, TRUE, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to move %ls to %ls", wzUnverifiedPayloadPath, wzCachedPath);
+        ExitOnFailure(hr, "Failed to move %ls to %ls", wzUnverifiedPayloadPath, wzCachedPath);
     }
     else
     {
         hr = FileEnsureCopyWithRetry(wzUnverifiedPayloadPath, wzCachedPath, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to copy %ls to %ls", wzUnverifiedPayloadPath, wzCachedPath);
+        ExitOnFailure(hr, "Failed to copy %ls to %ls", wzUnverifiedPayloadPath, wzCachedPath);
     }
 
 LExit:
@@ -1393,12 +1393,12 @@ static HRESULT TransferWorkingPathToUnverifiedPath(
     if (fMove)
     {
         hr = FileEnsureMoveWithRetry(wzWorkingPath, wzUnverifiedPayloadPath, TRUE, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to move %ls to %ls", wzWorkingPath, wzUnverifiedPayloadPath);
+        ExitOnFailure(hr, "Failed to move %ls to %ls", wzWorkingPath, wzUnverifiedPayloadPath);
     }
     else
     {
         hr = FileEnsureCopyWithRetry(wzWorkingPath, wzUnverifiedPayloadPath, TRUE, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-        ExitOnFailure2(hr, "Failed to copy %ls to %ls", wzWorkingPath, wzUnverifiedPayloadPath);
+        ExitOnFailure(hr, "Failed to copy %ls to %ls", wzWorkingPath, wzUnverifiedPayloadPath);
     }
 
 LExit:
@@ -1422,24 +1422,24 @@ static HRESULT VerifyFileAgainstPayload(
         {
             ExitFunction(); // do not log error when the file was not found.
         }
-        ExitOnRootFailure1(hr, "Failed to open payload at path: %ls", wzVerifyPath);
+        ExitOnRootFailure(hr, "Failed to open payload at path: %ls", wzVerifyPath);
     }
 
     // If the payload has a certificate root public key identifier provided, verify the certificate.
     if (pPayload->pbCertificateRootPublicKeyIdentifier)
     {
         hr = CacheVerifyPayloadSignature(pPayload, wzVerifyPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify signature of payload: %ls", pPayload->sczKey);
+        ExitOnFailure(hr, "Failed to verify signature of payload: %ls", pPayload->sczKey);
     }
     else if (pPayload->pCatalog) // If catalog files are specified, attempt to verify the file with a catalog file
     {
         hr = VerifyPayloadWithCatalog(pPayload, wzVerifyPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify catalog signature of payload: %ls", pPayload->sczKey);
+        ExitOnFailure(hr, "Failed to verify catalog signature of payload: %ls", pPayload->sczKey);
     }
     else if (pPayload->pbHash) // the payload should have a hash we can use to verify it.
     {
         hr = VerifyHash(pPayload->pbHash, pPayload->cbHash, wzVerifyPath, hFile);
-        ExitOnFailure1(hr, "Failed to verify hash of payload: %ls", pPayload->sczKey);
+        ExitOnFailure(hr, "Failed to verify hash of payload: %ls", pPayload->sczKey);
     }
 
 LExit:
@@ -1500,7 +1500,7 @@ static HRESULT ResetPathPermissions(
     }
 
     hr = AclSetSecurityWithRetry(wzPath, SE_FILE_OBJECT, dwSetSecurity, pSid, NULL, &acl, NULL, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-    ExitOnWin32Error1(er, hr, "Failed to reset the ACL on cached file: %ls", wzPath);
+    ExitOnWin32Error(er, hr, "Failed to reset the ACL on cached file: %ls", wzPath);
 
     ::SetFileAttributesW(wzPath, FILE_ATTRIBUTE_NORMAL); // Let's try to reset any possible read-only/system bits.
 
@@ -1543,24 +1543,24 @@ static HRESULT SecurePath(
 
     // Administrators must be the first one in the array so we can reuse the allocated SID below.
     hr = GrantAccessAndAllocateSid(WinBuiltinAdministratorsSid, FILE_ALL_ACCESS, &access[0]);
-    ExitOnFailure1(hr, "Failed to allocate access for Administrators group to path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to allocate access for Administrators group to path: %ls", wzPath);
 
     hr = GrantAccessAndAllocateSid(WinLocalSystemSid, FILE_ALL_ACCESS, &access[1]);
-    ExitOnFailure1(hr, "Failed to allocate access for SYSTEM group to path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to allocate access for SYSTEM group to path: %ls", wzPath);
 
     hr = GrantAccessAndAllocateSid(WinWorldSid, GENERIC_READ | GENERIC_EXECUTE, &access[2]);
-    ExitOnFailure1(hr, "Failed to allocate access for Everyone group to path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to allocate access for Everyone group to path: %ls", wzPath);
 
     hr = GrantAccessAndAllocateSid(WinBuiltinUsersSid, GENERIC_READ | GENERIC_EXECUTE, &access[3]);
-    ExitOnFailure1(hr, "Failed to allocate access for Users group to path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to allocate access for Users group to path: %ls", wzPath);
 
     er = ::SetEntriesInAclW(countof(access), access, NULL, &pAcl);
-    ExitOnWin32Error1(er, hr, "Failed to create ACL to secure cache path: %ls", wzPath);
+    ExitOnWin32Error(er, hr, "Failed to create ACL to secure cache path: %ls", wzPath);
 
     // Set the ACL and ensure the Administrators group ends up the owner
     hr = AclSetSecurityWithRetry(wzPath, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
                                  reinterpret_cast<PSID>(access[0].Trustee.ptstrName), NULL, pAcl, NULL, FILE_OPERATION_RETRY_COUNT, FILE_OPERATION_RETRY_WAIT);
-    ExitOnFailure1(hr, "Failed to secure cache path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to secure cache path: %ls", wzPath);
 
 LExit:
     if (pAcl)
@@ -1592,14 +1592,14 @@ static HRESULT CopyEngineWithSignatureFixup(
     hTarget = ::CreateFileW(wzTargetPath, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hTarget)
     {
-        ExitWithLastError1(hr, "Failed to create engine file at path: %ls", wzTargetPath);
+        ExitWithLastError(hr, "Failed to create engine file at path: %ls", wzTargetPath);
     }
 
     hr = FileSetPointer(hEngineFile, 0, NULL, FILE_BEGIN);
-    ExitOnFailure1(hr, "Failed to seek to beginning of engine file: %ls", wzEnginePath);
+    ExitOnFailure(hr, "Failed to seek to beginning of engine file: %ls", wzEnginePath);
 
     hr = FileCopyUsingHandles(hEngineFile, hTarget, pSection->cbEngineSize, NULL);
-    ExitOnFailure2(hr, "Failed to copy engine from: %ls to: %ls", wzEnginePath, wzTargetPath);
+    ExitOnFailure(hr, "Failed to copy engine from: %ls to: %ls", wzEnginePath, wzTargetPath);
 
     // If the original executable was signed, let's put back the checksum and signature.
     if (pSection->dwOriginalSignatureOffset)
@@ -1686,14 +1686,14 @@ static HRESULT RemoveBundleOrPackage(
     {
         // Try to remove root package cache in the off chance it is now empty.
         hr = GetRootPath(fPerMachine, TRUE, &sczRootCacheDirectory);
-        ExitOnFailure1(hr, "Failed to get %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
+        ExitOnFailure(hr, "Failed to get %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
         DirEnsureDeleteEx(sczRootCacheDirectory, DIR_DELETE_SCHEDULE);
 
         // GetRootPath returns S_FALSE if the package cache is redirected elsewhere.
         if (S_FALSE == hr)
         {
             hr = GetRootPath(fPerMachine, FALSE, &sczRootCacheDirectory);
-            ExitOnFailure1(hr, "Failed to get old %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
+            ExitOnFailure(hr, "Failed to get old %hs package cache root directory.", fPerMachine ? "per-machine" : "per-user");
             DirEnsureDeleteEx(sczRootCacheDirectory, DIR_DELETE_SCHEDULE);
         }
     }
@@ -1721,13 +1721,13 @@ static HRESULT VerifyHash(
 
     // TODO: create a cryp hash file that sends progress.
     hr = CrypHashFileHandle(hFile, PROV_RSA_FULL, CALG_SHA1, rgbActualHash, sizeof(rgbActualHash), &qwHashedBytes);
-    ExitOnFailure1(hr, "Failed to calculate hash for path: %ls", wzUnverifiedPayloadPath);
+    ExitOnFailure(hr, "Failed to calculate hash for path: %ls", wzUnverifiedPayloadPath);
 
     // Compare hashes.
     if (cbHash != sizeof(rgbActualHash) || 0 != memcmp(pbHash, rgbActualHash, SHA1_HASH_LEN))
     {
         hr = CRYPT_E_HASH_VALUE;
-        ExitOnFailure1(hr, "Hash mismatch for path: %ls", wzUnverifiedPayloadPath);
+        ExitOnFailure(hr, "Hash mismatch for path: %ls", wzUnverifiedPayloadPath);
     }
 
 LExit:
@@ -1815,7 +1815,7 @@ static HRESULT VerifyPayloadWithCatalog(
         // WinVerifyTrust returns 0 for success, a few different Win32 error codes if it can't
         // find the provider, and any other error code is provider specific, so may not
         // be an actual Win32 error code
-        ExitOnWin32Error1(er, hr, "Could not verify file %ls.", wzUnverifiedPayloadPath);
+        ExitOnWin32Error(er, hr, "Could not verify file %ls.", wzUnverifiedPayloadPath);
     }
 
     // Need to close the WinVerifyTrust action

--- a/src/burn/engine/catalog.cpp
+++ b/src/burn/engine/catalog.cpp
@@ -126,12 +126,12 @@ extern "C" HRESULT CatalogLoadFromPayload(
         pCatalog->hFile = ::CreateFileW(pCatalog->sczLocalFilePath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
         if (INVALID_HANDLE_VALUE == pCatalog->hFile)
         {
-            ExitWithLastError1(hr, "Failed to open catalog in working path: %ls", pCatalog->sczLocalFilePath);
+            ExitWithLastError(hr, "Failed to open catalog in working path: %ls", pCatalog->sczLocalFilePath);
         }
 
         // Verify the catalog file
         hr = CacheVerifyPayloadSignature(pPayload, pCatalog->sczLocalFilePath, pCatalog->hFile);
-        ExitOnFailure1(hr, "Failed to verify catalog signature: %ls", pCatalog->sczLocalFilePath);
+        ExitOnFailure(hr, "Failed to verify catalog signature: %ls", pCatalog->sczLocalFilePath);
     }
 
 LExit:
@@ -160,7 +160,7 @@ extern "C" HRESULT CatalogElevatedUpdateCatalogFile(
         pCatalog->hFile = ::CreateFileW(pCatalog->sczLocalFilePath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
         if (INVALID_HANDLE_VALUE == pCatalog->hFile)
         {
-            ExitWithLastError1(hr, "Failed to open catalog in working path: %ls", pCatalog->sczLocalFilePath);
+            ExitWithLastError(hr, "Failed to open catalog in working path: %ls", pCatalog->sczLocalFilePath);
         }
     }
 

--- a/src/burn/engine/condition.cpp
+++ b/src/burn/engine/condition.cpp
@@ -207,7 +207,7 @@ extern "C" HRESULT ConditionGlobalCheck(
         if (NULL != pCondition->sczConditionString)
         {
             hr = ConditionEvaluate(pVariables, pCondition->sczConditionString, &fSuccess);
-            ExitOnFailure1(hr, "Failed to evaluate condition: %ls", pCondition->sczConditionString);
+            ExitOnFailure(hr, "Failed to evaluate condition: %ls", pCondition->sczConditionString);
         }
     }
 
@@ -463,7 +463,7 @@ static HRESULT ParseValue(
     default:
         pContext->fError = TRUE;
         hr = E_INVALIDDATA;
-        ExitOnRootFailure2(hr, "Failed to parse condition '%ls' at position: %u", pContext->wzCondition, pContext->NextSymbol.iPosition);
+        ExitOnRootFailure(hr, "Failed to parse condition '%ls' at position: %u", pContext->wzCondition, pContext->NextSymbol.iPosition);
     }
 
     // get next symbol
@@ -488,7 +488,7 @@ static HRESULT Expect(
     {
         pContext->fError = TRUE;
         hr = E_INVALIDDATA;
-        ExitOnRootFailure2(hr, "Failed to parse condition '%ls' at position: %u", pContext->wzCondition, pContext->NextSymbol.iPosition);
+        ExitOnRootFailure(hr, "Failed to parse condition '%ls' at position: %u", pContext->wzCondition, pContext->NextSymbol.iPosition);
     }
 
     hr = NextSymbol(pContext);
@@ -583,7 +583,7 @@ static HRESULT NextSymbol(
             // error
             pContext->fError = TRUE;
             hr = E_INVALIDDATA;
-            ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Unexpected '~' operator at position %d.", pContext->wzCondition, iPosition);
+            ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Unexpected '~' operator at position %d.", pContext->wzCondition, iPosition);
         }
         break;
     case L'>':
@@ -647,7 +647,7 @@ static HRESULT NextSymbol(
                 // error
                 pContext->fError = TRUE;
                 hr = E_INVALIDDATA;
-                ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Unterminated literal at position %d.", pContext->wzCondition, iPosition);
+                ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Unterminated literal at position %d.", pContext->wzCondition, iPosition);
             }
         } while (L'"' != pContext->wzRead[n]);
         ++n; // terminating '"'
@@ -668,7 +668,7 @@ static HRESULT NextSymbol(
                     // error, identifier cannot start with a digit
                     pContext->fError = TRUE;
                     hr = E_INVALIDDATA;
-                    ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Identifier cannot start at a digit, at position %d.", pContext->wzCondition, iPosition);
+                    ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Identifier cannot start at a digit, at position %d.", pContext->wzCondition, iPosition);
                 }
             } while (C1_DIGIT & charType);
 
@@ -681,7 +681,7 @@ static HRESULT NextSymbol(
             {
                 pContext->fError = TRUE;
                 hr = E_INVALIDDATA;
-                ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Constant too big, at position %d.", pContext->wzCondition, iPosition);
+                ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Constant too big, at position %d.", pContext->wzCondition, iPosition);
             }
 
             hr = BVariantSetNumeric(&pContext->NextSymbol.Value, ll);
@@ -705,7 +705,7 @@ static HRESULT NextSymbol(
                             // error, too many parts in version
                             pContext->fError = TRUE;
                             hr = E_INVALIDDATA;
-                            ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Version can have a maximum of 4 parts, at position %d.", pContext->wzCondition, iPosition);
+                            ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Version can have a maximum of 4 parts, at position %d.", pContext->wzCondition, iPosition);
                         }
                     }
                     else
@@ -724,7 +724,7 @@ static HRESULT NextSymbol(
                 {
                     pContext->fError = TRUE;
                     hr = E_INVALIDDATA;
-                    ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Invalid version format, at position %d.", pContext->wzCondition, iPosition);
+                    ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Invalid version format, at position %d.", pContext->wzCondition, iPosition);
                 }
 
                 pContext->NextSymbol.Value.Type = BURN_VARIANT_TYPE_VERSION;
@@ -767,7 +767,7 @@ static HRESULT NextSymbol(
             // error, unexpected character
             pContext->fError = TRUE;
             hr = E_INVALIDDATA;
-            ExitOnRootFailure2(hr, "Failed to parse condition \"%ls\". Unexpected character at position %d.", pContext->wzCondition, iPosition);
+            ExitOnRootFailure(hr, "Failed to parse condition \"%ls\". Unexpected character at position %d.", pContext->wzCondition, iPosition);
         }
     }
     pContext->NextSymbol.iPosition = iPosition;

--- a/src/burn/engine/container.cpp
+++ b/src/burn/engine/container.cpp
@@ -223,13 +223,13 @@ extern "C" HRESULT ContainerOpen(
     if (INVALID_HANDLE_VALUE == hContainerFile)
     {
         pContext->hFile = ::CreateFileW(wzFilePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-        ExitOnInvalidHandleWithLastError1(pContext->hFile, hr, "Failed to open file: %ls", wzFilePath);
+        ExitOnInvalidHandleWithLastError(pContext->hFile, hr, "Failed to open file: %ls", wzFilePath);
     }
     else // use the container file handle.
     {
         if (!::DuplicateHandle(::GetCurrentProcess(), hContainerFile, ::GetCurrentProcess(), &pContext->hFile, 0, FALSE, DUPLICATE_SAME_ACCESS))
         {
-            ExitWithLastError1(hr, "Failed to duplicate handle to container: %ls", wzFilePath);
+            ExitWithLastError(hr, "Failed to duplicate handle to container: %ls", wzFilePath);
         }
     }
 

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -91,7 +91,7 @@ extern "C" HRESULT CoreInitialize(
 
     // retain whether burn was initially run elevated
     hr = VariableSetNumeric(&pEngineState->variables, BURN_BUNDLE_ELEVATED, BURN_ELEVATION_STATE_UNELEVATED != pEngineState->elevationState, TRUE);
-    ExitOnFailure1(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_ELEVATED);
+    ExitOnFailure(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_ELEVATED);
 
     // open attached UX container
     hr = ContainerOpenUX(&pEngineState->section, &containerContext);
@@ -274,7 +274,7 @@ extern "C" HRESULT CoreDetect(
 
         // Detect the cache state of the package.
         hr = DetectPackagePayloadsCached(pPackage);
-        ExitOnFailure1(hr, "Failed to detect if payloads are all cached for package: %ls", pPackage->sczId);
+        ExitOnFailure(hr, "Failed to detect if payloads are all cached for package: %ls", pPackage->sczId);
 
         // Use the correct engine to detect the package.
         switch (pPackage->type)
@@ -507,7 +507,7 @@ extern "C" HRESULT CoreElevate(
         ExitOnFailure(hr, "Failed to actually elevate.");
 
         hr = VariableSetNumeric(&pEngineState->variables, BURN_BUNDLE_ELEVATED, TRUE, TRUE);
-        ExitOnFailure1(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_ELEVATED);
+        ExitOnFailure(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_ELEVATED);
     }
 
 LExit:
@@ -1251,7 +1251,7 @@ static HRESULT ParseCommandLine(
                 LPCWSTR wzParam = &argv[i][1 + lstrlenW(BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES)];
                 if (L'=' != wzParam[0] || L'\0' == wzParam[1])
                 {
-                    ExitOnRootFailure1(hr = E_INVALIDARG, "Missing required parameter for switch: %ls", BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES);
+                    ExitOnRootFailure(hr = E_INVALIDARG, "Missing required parameter for switch: %ls", BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES);
                 }
 
                 hr = StrAllocString(psczIgnoreDependencies, &wzParam[1], 0);
@@ -1263,7 +1263,7 @@ static HRESULT ParseCommandLine(
                 LPCWSTR wzParam = &argv[i][1 + lstrlenW(BURN_COMMANDLINE_SWITCH_ANCESTORS)];
                 if (L'=' != wzParam[0] || L'\0' == wzParam[1])
                 {
-                    ExitOnRootFailure1(hr = E_INVALIDARG, "Missing required parameter for switch: %ls", BURN_COMMANDLINE_SWITCH_ANCESTORS);
+                    ExitOnRootFailure(hr = E_INVALIDARG, "Missing required parameter for switch: %ls", BURN_COMMANDLINE_SWITCH_ANCESTORS);
                 }
 
                 hr = StrAllocString(psczAncestors, &wzParam[1], 0);

--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -305,7 +305,7 @@ extern "C" HRESULT DependencyAddIgnoreDependencies(
         else
         {
             hr = DictAddKey(sdIgnoreDependencies, wzToken);
-            ExitOnFailure1(hr, "Failed to add \"%ls\" to the string dictionary.", wzToken);
+            ExitOnFailure(hr, "Failed to add \"%ls\" to the string dictionary.", wzToken);
         }
     }
 
@@ -377,7 +377,7 @@ extern "C" HRESULT DependencyPlanPackageBegin(
                 hr = DepCheckDependents(hkHive, pProvider->sczKey, 0, sdIgnoredDependents, &rgDependents, &cDependents);
                 if (E_FILENOTFOUND != hr)
                 {
-                    ExitOnFailure1(hr, "Failed dependents check on package provider: %ls", pProvider->sczKey);
+                    ExitOnFailure(hr, "Failed dependents check on package provider: %ls", pProvider->sczKey);
                 }
                 else
                 {
@@ -436,7 +436,7 @@ extern "C" HRESULT DependencyPlanPackageBegin(
             const BURN_DEPENDENCY_PROVIDER* pProvider = &pPackage->rgDependencyProviders[i];
 
             hr = DepDependencyArrayAlloc(&pPlan->rgPlannedProviders, &pPlan->cPlannedProviders, pProvider->sczKey, NULL);
-            ExitOnFailure1(hr, "Failed to add the package provider key \"%ls\" to the planned list.", pProvider->sczKey);
+            ExitOnFailure(hr, "Failed to add the package provider key \"%ls\" to the planned list.", pProvider->sczKey);
         }
     }
 
@@ -464,7 +464,7 @@ extern "C" HRESULT DependencyPlanPackage(
     if (BURN_DEPENDENCY_ACTION_UNREGISTER == pPackage->dependencyExecute)
     {
         hr = AddPackageDependencyActions(pdwInsertSequence, pPackage, pPlan, pPackage->dependencyExecute, pPackage->dependencyRollback);
-        ExitOnFailure1(hr, "Failed to plan the dependency actions for package: %ls", pPackage->sczId);
+        ExitOnFailure(hr, "Failed to plan the dependency actions for package: %ls", pPackage->sczId);
     }
 
     // Add the provider rollback plan.
@@ -530,7 +530,7 @@ extern "C" HRESULT DependencyPlanPackageComplete(
         if (BURN_DEPENDENCY_ACTION_REGISTER == pPackage->dependencyExecute)
         {
             hr = AddPackageDependencyActions(NULL, pPackage, pPlan, pPackage->dependencyExecute, pPackage->dependencyRollback);
-            ExitOnFailure1(hr, "Failed to plan the dependency actions for package: %ls", pPackage->sczId);
+            ExitOnFailure(hr, "Failed to plan the dependency actions for package: %ls", pPackage->sczId);
         }
     }
 
@@ -630,17 +630,17 @@ extern "C" HRESULT DependencyProcessDependentRegistration(
     {
     case BURN_DEPENDENT_REGISTRATION_ACTION_TYPE_REGISTER:
         hr = DepRegisterDependent(pRegistration->hkRoot, pRegistration->sczProviderKey, pAction->sczDependentProviderKey, NULL, NULL, 0);
-        ExitOnFailure1(hr, "Failed to register dependent: %ls", pAction->sczDependentProviderKey);
+        ExitOnFailure(hr, "Failed to register dependent: %ls", pAction->sczDependentProviderKey);
         break;
 
     case BURN_DEPENDENT_REGISTRATION_ACTION_TYPE_UNREGISTER:
         hr = DepUnregisterDependent(pRegistration->hkRoot, pRegistration->sczProviderKey, pAction->sczDependentProviderKey);
-        ExitOnFailure1(hr, "Failed to unregister dependent: %ls", pAction->sczDependentProviderKey);
+        ExitOnFailure(hr, "Failed to unregister dependent: %ls", pAction->sczDependentProviderKey);
         break;
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unrecognized registration action type: %d", pAction->type);
+        ExitOnRootFailure(hr, "Unrecognized registration action type: %d", pAction->type);
     }
 
 LExit:
@@ -697,10 +697,10 @@ static HRESULT SplitIgnoreDependencies(
         else
         {
             hr = DepDependencyArrayAlloc(prgDependencies, pcDependencies, wzToken, NULL);
-            ExitOnFailure1(hr, "Failed to add \"%ls\" to the list of dependencies to ignore.", wzToken);
+            ExitOnFailure(hr, "Failed to add \"%ls\" to the list of dependencies to ignore.", wzToken);
 
             hr = DictAddKey(sdIgnoreDependencies, wzToken);
-            ExitOnFailure1(hr, "Failed to add \"%ls\" to the string dictionary.", wzToken);
+            ExitOnFailure(hr, "Failed to add \"%ls\" to the string dictionary.", wzToken);
         }
     }
 
@@ -752,10 +752,10 @@ static HRESULT JoinIgnoreDependencies(
             }
 
             hr = StrAllocConcat(psczIgnoreDependencies, pDependency->sczKey, 0);
-            ExitOnFailure1(hr, "Failed to append the key \"%ls\".", pDependency->sczKey);
+            ExitOnFailure(hr, "Failed to append the key \"%ls\".", pDependency->sczKey);
 
             hr = DictAddKey(sdIgnoreDependencies, pDependency->sczKey);
-            ExitOnFailure1(hr, "Failed to add \"%ls\" to the string dictionary.", pDependency->sczKey);
+            ExitOnFailure(hr, "Failed to add \"%ls\" to the string dictionary.", pDependency->sczKey);
         }
     }
 
@@ -786,7 +786,7 @@ static HRESULT GetIgnoredDependents(
     ExitOnFailure(hr, "Failed to create the string dictionary.");
 
     hr = DictAddKey(*psdIgnoredDependents, pPlan->wzBundleProviderKey);
-    ExitOnFailure1(hr, "Failed to add the bundle provider key \"%ls\" to the list of ignored dependencies.", pPlan->wzBundleProviderKey);
+    ExitOnFailure(hr, "Failed to add the bundle provider key \"%ls\" to the list of ignored dependencies.", pPlan->wzBundleProviderKey);
 
     // Add previously planned package providers to the dictionary.
     for (DWORD i = 0; i < pPlan->cPlannedProviders; ++i)
@@ -794,14 +794,14 @@ static HRESULT GetIgnoredDependents(
         const DEPENDENCY* pDependency = &pPlan->rgPlannedProviders[i];
 
         hr = DictAddKey(*psdIgnoredDependents, pDependency->sczKey);
-        ExitOnFailure1(hr, "Failed to add the package provider key \"%ls\" to the list of ignored dependencies.", pDependency->sczKey);
+        ExitOnFailure(hr, "Failed to add the package provider key \"%ls\" to the list of ignored dependencies.", pDependency->sczKey);
     }
 
     // Get the IGNOREDEPENDENCIES property if defined.
     hr = PackageGetProperty(pPackage, DEPENDENCY_IGNOREDEPENDENCIES, &sczIgnoreDependencies);
     if (E_NOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to get the package property: %ls", DEPENDENCY_IGNOREDEPENDENCIES);
+        ExitOnFailure(hr, "Failed to get the package property: %ls", DEPENDENCY_IGNOREDEPENDENCIES);
 
         hr = DependencyAddIgnoreDependencies(*psdIgnoredDependents, sczIgnoreDependencies);
         ExitOnFailure(hr, "Failed to add the authored ignored dependencies to the cumulative list of ignored dependencies.");
@@ -1062,7 +1062,7 @@ static HRESULT RegisterPackageProvider(
                 LogId(REPORT_VERBOSE, MSG_DEPENDENCY_PACKAGE_REGISTER, pProvider->sczKey, pProvider->sczVersion, pPackage->sczId);
 
                 hr = DepRegisterDependency(hkRoot, pProvider->sczKey, pProvider->sczVersion, pProvider->sczDisplayName, wzId, 0);
-                ExitOnFailure1(hr, "Failed to register the package dependency provider: %ls", pProvider->sczKey);
+                ExitOnFailure(hr, "Failed to register the package dependency provider: %ls", pProvider->sczKey);
             }
         }
     }
@@ -1143,7 +1143,7 @@ static HRESULT RegisterPackageDependency(
             hr = DepRegisterDependent(hkRoot, pProvider->sczKey, wzDependentProviderKey, NULL, NULL, 0);
             if (E_FILENOTFOUND != hr || pPackage->fVital)
             {
-                ExitOnFailure1(hr, "Failed to register the dependency on package dependency provider: %ls", pProvider->sczKey);
+                ExitOnFailure(hr, "Failed to register the dependency on package dependency provider: %ls", pProvider->sczKey);
             }
             else
             {

--- a/src/burn/engine/detect.cpp
+++ b/src/burn/engine/detect.cpp
@@ -207,7 +207,7 @@ extern "C" HRESULT DetectReportRelatedBundles(
 
         default:
             hr = E_FAIL;
-            ExitOnRootFailure1(hr, "Unexpected relation type encountered: %d", pRelatedBundle->relationType);
+            ExitOnRootFailure(hr, "Unexpected relation type encountered: %d", pRelatedBundle->relationType);
             break;
         }
 
@@ -356,7 +356,7 @@ static HRESULT DownloadUpdateFeed(
     authenticationCallback.pfnAuthenticate = &AuthenticationRequired;
 
     hr = DownloadUrl(&downloadSource, qwDownloadSize, sczDestinationPath, &cacheCallback, &authenticationCallback);
-    ExitOnFailure2(hr, "Failed attempt to download update feed from URL: '%ls' to: '%ls'", downloadSource.sczUrl, sczDestinationPath);
+    ExitOnFailure(hr, "Failed attempt to download update feed from URL: '%ls' to: '%ls'", downloadSource.sczUrl, sczDestinationPath);
 
     if (psczTempFile)
     {
@@ -401,7 +401,7 @@ static HRESULT DetectAtomFeedUpdate(
     ExitOnFailure(hr, "Failed to download update feed.");
 
     hr = AtomParseFromFile(sczUpdateFeedTempFile, &pAtomFeed);
-    ExitOnFailure1(hr, "Failed to parse update atom feed: %ls.", sczUpdateFeedTempFile);
+    ExitOnFailure(hr, "Failed to parse update atom feed: %ls.", sczUpdateFeedTempFile);
 
     hr = ApupAllocChainFromAtom(pAtomFeed, &pApupChain);
     ExitOnFailure(hr, "Failed to allocate update chain from atom feed.");

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -1263,7 +1263,7 @@ static HRESULT ProcessGenericExecuteMessages(
         for (DWORD i = 0; i < cFiles; ++i)
         {
             hr = BuffReadString((BYTE*)pMsg->pvData, pMsg->cbData, &iData, &rgwzFiles[i]);
-            ExitOnFailure1(hr, "Failed to read file name: %u", i);
+            ExitOnFailure(hr, "Failed to read file name: %u", i);
         }
 
         message.filesInUse.cFiles = cFiles;
@@ -1319,7 +1319,7 @@ static HRESULT ProcessMsiPackageMessages(
         for (DWORD i = 0; i < cMsiData; ++i)
         {
             hr = BuffReadString((BYTE*)pMsg->pvData, pMsg->cbData, &iData, &rgwzMsiData[i]);
-            ExitOnFailure1(hr, "Failed to read MSI data: %u", i);
+            ExitOnFailure(hr, "Failed to read MSI data: %u", i);
         }
 
         message.cData = cMsiData;
@@ -1507,7 +1507,7 @@ static HRESULT ProcessElevatedChildMessage(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unexpected elevated message sent to child process, msg: %u", pMsg->dwMessage);
+        ExitOnRootFailure(hr, "Unexpected elevated message sent to child process, msg: %u", pMsg->dwMessage);
     }
 
     *pdwResult = dwPid ? dwPid : (DWORD)hrResult;
@@ -1547,7 +1547,7 @@ static HRESULT ProcessElevatedChildCacheMessage(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unexpected elevated cache message sent to child process, msg: %u", pMsg->dwMessage);
+        ExitOnRootFailure(hr, "Unexpected elevated cache message sent to child process, msg: %u", pMsg->dwMessage);
     }
 
     *pdwResult = (DWORD)hrResult;
@@ -1820,7 +1820,7 @@ static HRESULT OnLayoutBundle(
 
     // Layout the bundle.
     hr = CacheLayoutBundle(wzExecutableName, sczLayoutDirectory, sczUnverifiedPath);
-    ExitOnFailure1(hr, "Failed to layout bundle from: %ls", sczUnverifiedPath);
+    ExitOnFailure(hr, "Failed to layout bundle from: %ls", sczUnverifiedPath);
 
 LExit:
     ReleaseStr(sczUnverifiedPath);
@@ -1854,7 +1854,7 @@ static HRESULT OnCacheOrLayoutContainerOrPayload(
     if (scz && *scz)
     {
         hr = ContainerFindById(pContainers, scz, &pContainer);
-        ExitOnFailure1(hr, "Failed to find container: %ls", scz);
+        ExitOnFailure(hr, "Failed to find container: %ls", scz);
     }
 
     hr = BuffReadString(pbData, cbData, &iData, &scz);
@@ -1863,7 +1863,7 @@ static HRESULT OnCacheOrLayoutContainerOrPayload(
     if (scz && *scz)
     {
         hr = PackageFindById(pPackages, scz, &pPackage);
-        ExitOnFailure1(hr, "Failed to find package: %ls", scz);
+        ExitOnFailure(hr, "Failed to find package: %ls", scz);
     }
 
     hr = BuffReadString(pbData, cbData, &iData, &scz);
@@ -1872,7 +1872,7 @@ static HRESULT OnCacheOrLayoutContainerOrPayload(
     if (scz && *scz)
     {
         hr = PayloadFindById(pPayloads, scz, &pPayload);
-        ExitOnFailure1(hr, "Failed to find payload: %ls", scz);
+        ExitOnFailure(hr, "Failed to find payload: %ls", scz);
     }
 
     hr = BuffReadString(pbData, cbData, &iData, &sczLayoutDirectory);
@@ -1893,12 +1893,12 @@ static HRESULT OnCacheOrLayoutContainerOrPayload(
             Assert(!pPayload);
 
             hr = CacheLayoutContainer(pContainer, sczLayoutDirectory, sczUnverifiedPath, fMove);
-            ExitOnFailure2(hr, "Failed to layout container from: %ls to %ls", sczUnverifiedPath, sczLayoutDirectory);
+            ExitOnFailure(hr, "Failed to layout container from: %ls to %ls", sczUnverifiedPath, sczLayoutDirectory);
         }
         else
         {
             hr = CacheLayoutPayload(pPayload, sczLayoutDirectory, sczUnverifiedPath, fMove);
-            ExitOnFailure2(hr, "Failed to layout payload from: %ls to %ls", sczUnverifiedPath, sczLayoutDirectory);
+            ExitOnFailure(hr, "Failed to layout payload from: %ls to %ls", sczUnverifiedPath, sczLayoutDirectory);
         }
     }
     else if (pPackage) // complete payload.
@@ -1906,7 +1906,7 @@ static HRESULT OnCacheOrLayoutContainerOrPayload(
         Assert(!pContainer);
 
         hr = CacheCompletePayload(pPackage->fPerMachine, pPayload, pPackage->sczCacheId, sczUnverifiedPath, fMove);
-        ExitOnFailure1(hr, "Failed to cache payload: %ls", pPayload->sczKey);
+        ExitOnFailure(hr, "Failed to cache payload: %ls", pPayload->sczKey);
     }
     else
     {
@@ -1951,7 +1951,7 @@ static HRESULT OnProcessDependentRegistration(
 
     // Execute the registration action.
     hr = DependencyProcessDependentRegistration(pRegistration, &action);
-    ExitOnFailure1(hr, "Failed to execute dependent registration action for provider key: %ls", action.sczDependentProviderKey);
+    ExitOnFailure(hr, "Failed to execute dependent registration action for provider key: %ls", action.sczDependentProviderKey);
 
 LExit:
     // TODO: do the right thing here.
@@ -2006,7 +2006,7 @@ static HRESULT OnExecuteExePackage(
     {
         hr = PackageFindRelatedById(pRelatedBundles, sczPackage, &executeAction.exePackage.pPackage);
     }
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     // Pass the list of dependencies to ignore, if any, to the related bundle.
     if (sczIgnoreDependencies && *sczIgnoreDependencies)
@@ -2070,7 +2070,7 @@ static HRESULT OnExecuteMsiPackage(
     ExitOnFailure(hr, "Failed to read action.");
 
     hr = PackageFindById(pPackages, sczPackage, &executeAction.msiPackage.pPackage);
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     hr = BuffReadNumber(pbData, cbData, &iData, (DWORD*)&hwndParent);
     ExitOnFailure(hr, "Failed to read parent hwnd.");
@@ -2162,7 +2162,7 @@ static HRESULT OnExecuteMspPackage(
     ExitOnFailure(hr, "Failed to read action.");
 
     hr = PackageFindById(pPackages, sczPackage, &executeAction.mspTarget.pPackage);
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     hr = BuffReadNumber(pbData, cbData, &iData, (DWORD*)&hwndParent);
     ExitOnFailure(hr, "Failed to read parent hwnd.");
@@ -2198,7 +2198,7 @@ static HRESULT OnExecuteMspPackage(
             ExitOnFailure(hr, "Failed to read ordered patch package id.");
 
             hr = PackageFindById(pPackages, sczPackage, &executeAction.mspTarget.rgOrderedPatches[i].pPackage);
-            ExitOnFailure1(hr, "Failed to find ordered patch package: %ls", sczPackage);
+            ExitOnFailure(hr, "Failed to find ordered patch package: %ls", sczPackage);
         }
     }
 
@@ -2266,7 +2266,7 @@ static HRESULT OnExecuteMsuPackage(
     ExitOnFailure(hr, "Failed to read StopWusaService.");
 
     hr = PackageFindById(pPackages, sczPackage, &executeAction.msuPackage.pPackage);
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     // execute MSU package
     hr = MsuEngineExecutePackage(&executeAction, pVariables, static_cast<BOOL>(dwRollback), static_cast<BOOL>(dwStopWusaService), GenericExecuteMessageHandler, hPipe, &restart);
@@ -2318,7 +2318,7 @@ static HRESULT OnExecutePackageProviderAction(
     {
         hr = PackageFindRelatedById(pRelatedBundles, sczPackage, &executeAction.packageProvider.pPackage);
     }
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     // Execute the package provider action.
     hr = DependencyExecutePackageProviderAction(&executeAction);
@@ -2361,7 +2361,7 @@ static HRESULT OnExecutePackageDependencyAction(
     {
         hr = PackageFindRelatedById(pRelatedBundles, sczPackage, &executeAction.packageDependency.pPackage);
     }
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     // Execute the package dependency action.
     hr = DependencyExecutePackageDependencyAction(TRUE, &executeAction);
@@ -2393,7 +2393,7 @@ static HRESULT OnLoadCompatiblePackage(
 
     // Find the reference package.
     hr = PackageFindById(pPackages, sczPackage, &executeAction.compatiblePackage.pReferencePackage);
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     hr = BuffReadString(pbData, cbData, &iData, &executeAction.compatiblePackage.sczInstalledProductCode);
     ExitOnFailure(hr, "Failed to read installed ProductCode from message buffer.");
@@ -2547,7 +2547,7 @@ static int MsiExecuteMessageHandler(
 
     default:
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "Invalid message type: %d", pMessage->type);
+        ExitOnFailure(hr, "Invalid message type: %d", pMessage->type);
     }
 
     // send message
@@ -2576,11 +2576,11 @@ static HRESULT OnCleanPackage(
     ExitOnFailure(hr, "Failed to read package id.");
 
     hr = PackageFindById(pPackages, sczPackage, &pPackage);
-    ExitOnFailure1(hr, "Failed to find package: %ls", sczPackage);
+    ExitOnFailure(hr, "Failed to find package: %ls", sczPackage);
 
     // Remove the package from the cache.
     hr = CacheRemovePackage(TRUE, pPackage->sczId, pPackage->sczCacheId);
-    ExitOnFailure1(hr, "Failed to remove from cache package: %ls", pPackage->sczId);
+    ExitOnFailure(hr, "Failed to remove from cache package: %ls", pPackage->sczId);
 
 LExit:
     ReleaseStr(sczPackage);
@@ -2619,7 +2619,7 @@ static HRESULT OnLaunchApprovedExe(
     ExitOnFailure(hr, "Failed to read approved exe WaitForInputIdle timeout.");
 
     hr = ApprovedExesFindById(pApprovedExes, pLaunchApprovedExe->sczId, &pApprovedExe);
-    ExitOnFailure1(hr, "The per-user process requested unknown approved exe with id: %ls", pLaunchApprovedExe->sczId);
+    ExitOnFailure(hr, "The per-user process requested unknown approved exe with id: %ls", pLaunchApprovedExe->sczId);
 
     LogId(REPORT_STANDARD, MSG_LAUNCH_APPROVED_EXE_SEARCH, pApprovedExe->sczKey, pApprovedExe->sczValueName ? pApprovedExe->sczValueName : L"", pApprovedExe->fWin64 ? L"yes" : L"no");
 
@@ -2635,7 +2635,7 @@ static HRESULT OnLaunchApprovedExe(
     ExitOnFailure(hr, "Failed to read the value for the approved exe path.");
 
     hr = ApprovedExesVerifySecureLocation(pVariables, pLaunchApprovedExe);
-    ExitOnFailure1(hr, "Failed to verify the executable path is in a secure location: %ls", pLaunchApprovedExe->sczExecutablePath);
+    ExitOnFailure(hr, "Failed to verify the executable path is in a secure location: %ls", pLaunchApprovedExe->sczExecutablePath);
     if (S_FALSE == hr)
     {
         LogStringLine(REPORT_STANDARD, "The executable path is not in a secure location: %ls", pLaunchApprovedExe->sczExecutablePath);
@@ -2643,7 +2643,7 @@ static HRESULT OnLaunchApprovedExe(
     }
 
     hr = ApprovedExesLaunch(pVariables, pLaunchApprovedExe, &dwProcessId);
-    ExitOnFailure1(hr, "Failed to launch approved exe: %ls", pLaunchApprovedExe->sczExecutablePath);
+    ExitOnFailure(hr, "Failed to launch approved exe: %ls", pLaunchApprovedExe->sczExecutablePath);
 
     //send process id over pipe
     hr = BuffWriteNumber(&pbSendData, &cbSendData, dwProcessId);

--- a/src/burn/engine/embedded.cpp
+++ b/src/burn/engine/embedded.cpp
@@ -86,7 +86,7 @@ extern "C" HRESULT EmbeddedRunBundle(
 
     if (!::CreateProcessW(wzExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to create embedded process atpath: %ls", wzExecutablePath);
+        ExitWithLastError(hr, "Failed to create embedded process atpath: %ls", wzExecutablePath);
     }
 
     connection.dwProcessId = ::GetProcessId(pi.hProcess);
@@ -101,7 +101,7 @@ extern "C" HRESULT EmbeddedRunBundle(
 
     // Get the return code from the embedded process.
     hr = ProcWaitForCompletion(connection.hProcess, INFINITE, pdwExitCode);
-    ExitOnFailure1(hr, "Failed to wait for embedded executable: %ls", wzExecutablePath);
+    ExitOnFailure(hr, "Failed to wait for embedded executable: %ls", wzExecutablePath);
 
 LExit:
     ReleaseHandle(pi.hThread);
@@ -142,7 +142,7 @@ static HRESULT ProcessEmbeddedMessages(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unexpected embedded message sent to child process, msg: %u", pMsg->dwMessage);
+        ExitOnRootFailure(hr, "Unexpected embedded message sent to child process, msg: %u", pMsg->dwMessage);
     }
 
     *pdwResult = dwResult;

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -549,7 +549,7 @@ static HRESULT RunRunOnce(
     ExitOnFailure(hr, "Failed to get current process path.");
 
     hr = ProcExec(sczBurnPath, 0 < sczNewCommandLine ? sczNewCommandLine : L"", nCmdShow, &hProcess);
-    ExitOnFailure1(hr, "Failed to re-launch bundle process after RunOnce: %ls", sczBurnPath);
+    ExitOnFailure(hr, "Failed to re-launch bundle process after RunOnce: %ls", sczBurnPath);
 
 LExit:
     ReleaseHandle(hProcess);

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -78,7 +78,7 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
         else
         {
             hr = E_UNEXPECTED;
-            ExitOnFailure1(hr, "Invalid protocol type: %ls", scz);
+            ExitOnFailure(hr, "Invalid protocol type: %ls", scz);
         }
     }
     else if (E_NOTFOUND != hr)
@@ -133,7 +133,7 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
             else
             {
                 hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid exit code type: %ls", scz);
+                ExitOnFailure(hr, "Invalid exit code type: %ls", scz);
             }
 
             // @Code
@@ -147,7 +147,7 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
             else
             {
                 hr = StrStringToUInt32(scz, 0, (UINT*)&pExitCode->dwCode);
-                ExitOnFailure1(hr, "Failed to parse @Code value: %ls", scz);
+                ExitOnFailure(hr, "Failed to parse @Code value: %ls", scz);
             }
 
             // prepare next iteration
@@ -267,7 +267,7 @@ extern "C" HRESULT ExeEnginePlanCalculatePackage(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Invalid package current state: %d.", pPackage->currentState);
+        ExitOnRootFailure(hr, "Invalid package current state: %d.", pPackage->currentState);
     }
 
     // Calculate the rollback action if there is an execute action.
@@ -439,7 +439,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
 
     // get cached executable path
     hr = CacheGetCompletedPath(pExecuteAction->exePackage.pPackage->fPerMachine, pExecuteAction->exePackage.pPackage->sczCacheId, &sczCachedDirectory);
-    ExitOnFailure1(hr, "Failed to get cached path for package: %ls", pExecuteAction->exePackage.pPackage->sczId);
+    ExitOnFailure(hr, "Failed to get cached path for package: %ls", pExecuteAction->exePackage.pPackage->sczId);
 
     // Best effort to set the execute package cache folder variable.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
@@ -519,12 +519,12 @@ extern "C" HRESULT ExeEngineExecutePackage(
     if (!pExecuteAction->exePackage.fFireAndForget && BURN_EXE_PROTOCOL_TYPE_BURN == pExecuteAction->exePackage.pPackage->Exe.protocol)
     {
         hr = EmbeddedRunBundle(sczExecutablePath, sczCommand, pfnGenericMessageHandler, pvContext, &dwExitCode);
-        ExitOnFailure1(hr, "Failed to run bundle as embedded from path: %ls", sczExecutablePath);
+        ExitOnFailure(hr, "Failed to run bundle as embedded from path: %ls", sczExecutablePath);
     }
     else if (!pExecuteAction->exePackage.fFireAndForget && BURN_EXE_PROTOCOL_TYPE_NETFX4 == pExecuteAction->exePackage.pPackage->Exe.protocol)
     {
         hr = NetFxRunChainer(sczExecutablePath, sczCommand, pfnGenericMessageHandler, pvContext, &dwExitCode);
-        ExitOnFailure1(hr, "Failed to run netfx chainer: %ls", sczExecutablePath);
+        ExitOnFailure(hr, "Failed to run netfx chainer: %ls", sczExecutablePath);
     }
     else // create and wait for the executable process while sending fake progress to allow cancel.
     {
@@ -538,7 +538,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         si.cb = sizeof(si); // TODO: hookup the stdin/stdout/stderr pipes for logging purposes?
         if (!::CreateProcessW(sczExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
         {
-            ExitWithLastError1(hr, "Failed to CreateProcess on path: %ls", sczExecutablePath);
+            ExitWithLastError(hr, "Failed to CreateProcess on path: %ls", sczExecutablePath);
         }
 
         if (pExecuteAction->exePackage.fFireAndForget)
@@ -559,13 +559,13 @@ extern "C" HRESULT ExeEngineExecutePackage(
             hr = ProcWaitForCompletion(pi.hProcess, 500, &dwExitCode);
             if (HRESULT_FROM_WIN32(WAIT_TIMEOUT) != hr)
             {
-                ExitOnFailure1(hr, "Failed to wait for executable to complete: %ls", sczExecutablePath);
+                ExitOnFailure(hr, "Failed to wait for executable to complete: %ls", sczExecutablePath);
             }
         } while (HRESULT_FROM_WIN32(WAIT_TIMEOUT) == hr);
     }
 
     hr = HandleExitCode(pExecuteAction->exePackage.pPackage, dwExitCode, pRestart);
-    ExitOnRootFailure1(hr, "Process returned error: 0x%x", dwExitCode);
+    ExitOnRootFailure(hr, "Process returned error: 0x%x", dwExitCode);
 
 LExit:
     if (fChangedCurrentDirectory)

--- a/src/burn/engine/logging.cpp
+++ b/src/burn/engine/logging.cpp
@@ -107,7 +107,7 @@ extern "C" HRESULT LoggingOpen(
                 hr = HRESULT_FROM_WIN32(ERROR_INSTALL_LOG_FAILURE);
                 SplashScreenDisplayError(display, wzBundleName, hr);
 
-                ExitOnFailure1(hrOriginal, "Failed to open log: %ls", pLog->sczPath);
+                ExitOnFailure(hrOriginal, "Failed to open log: %ls", pLog->sczPath);
             }
         }
         else

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -88,7 +88,7 @@ extern "C" HRESULT MsiEngineParsePackageFromXml(
     ExitOnFailure(hr, "Failed to get @Version.");
 
     hr = FileVersionFromStringEx(scz, 0, &pPackage->Msi.qwVersion);
-    ExitOnFailure1(hr, "Failed to parse @Version: %ls", scz);
+    ExitOnFailure(hr, "Failed to parse @Version: %ls", scz);
 
     // @DisplayInternalUI
     hr = XmlGetYesNoAttribute(pixnMsiPackage, L"DisplayInternalUI", &pPackage->Msi.fDisplayInternalUI);
@@ -400,7 +400,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
     __in BURN_USER_EXPERIENCE* pUserExperience
     )
 {
-    Trace1(REPORT_STANDARD, "Detecting MSI package 0x%p", pPackage);
+    Trace(REPORT_STANDARD, "Detecting MSI package 0x%p", pPackage);
 
     HRESULT hr = S_OK;
     LPWSTR sczInstalledVersion = NULL;
@@ -422,7 +422,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
     if (SUCCEEDED(hr))
     {
         hr = FileVersionFromStringEx(sczInstalledVersion, 0, &pPackage->Msi.qwInstalledVersion);
-        ExitOnFailure2(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, pPackage->Msi.sczProductCode);
+        ExitOnFailure(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, pPackage->Msi.sczProductCode);
 
         // compare versions
         if (pPackage->Msi.qwVersion < pPackage->Msi.qwInstalledVersion)
@@ -460,7 +460,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
             if (SUCCEEDED(hr))
             {
                 hr = FileVersionFromStringEx(sczInstalledVersion, 0, &qwVersion);
-                ExitOnFailure2(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, sczInstalledProductCode);
+                ExitOnFailure(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, sczInstalledProductCode);
 
                 if (pPackage->Msi.qwVersion < qwVersion)
                 {
@@ -484,7 +484,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
     }
     else
     {
-        ExitOnFailure1(hr, "Failed to get product information for ProductCode: %ls", pPackage->Msi.sczProductCode);
+        ExitOnFailure(hr, "Failed to get product information for ProductCode: %ls", pPackage->Msi.sczProductCode);
     }
 
     // detect related packages by upgrade code
@@ -513,7 +513,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
             hr = WiuGetProductInfoEx(wzProductCode, NULL, MSIINSTALLCONTEXT_USERUNMANAGED, INSTALLPROPERTY_VERSIONSTRING, &sczInstalledVersion);
             if (HRESULT_FROM_WIN32(ERROR_UNKNOWN_PRODUCT) != hr && HRESULT_FROM_WIN32(ERROR_UNKNOWN_PROPERTY) != hr)
             {
-                ExitOnFailure1(hr, "Failed to get version for product in user unmanaged context: %ls", wzProductCode);
+                ExitOnFailure(hr, "Failed to get version for product in user unmanaged context: %ls", wzProductCode);
                 fPerMachine = FALSE;
             }
             else
@@ -521,7 +521,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
                 hr = WiuGetProductInfoEx(wzProductCode, NULL, MSIINSTALLCONTEXT_MACHINE, INSTALLPROPERTY_VERSIONSTRING, &sczInstalledVersion);
                 if (HRESULT_FROM_WIN32(ERROR_UNKNOWN_PRODUCT) != hr && HRESULT_FROM_WIN32(ERROR_UNKNOWN_PROPERTY) != hr)
                 {
-                    ExitOnFailure1(hr, "Failed to get version for product in machine context: %ls", wzProductCode);
+                    ExitOnFailure(hr, "Failed to get version for product in machine context: %ls", wzProductCode);
                     fPerMachine = TRUE;
                 }
                 else
@@ -532,7 +532,7 @@ extern "C" HRESULT MsiEngineDetectPackage(
             }
 
             hr = FileVersionFromStringEx(sczInstalledVersion, 0, &qwVersion);
-            ExitOnFailure2(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, wzProductCode);
+            ExitOnFailure(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, wzProductCode);
 
             // compare versions
             if (pRelatedMsi->fMinProvided && (pRelatedMsi->fMinInclusive ? (qwVersion < pRelatedMsi->qwMinVersion) : (qwVersion <= pRelatedMsi->qwMinVersion)))
@@ -689,7 +689,7 @@ extern "C" HRESULT MsiEnginePlanCalculatePackage(
     __in BURN_USER_EXPERIENCE* pUserExperience
     )
 {
-    Trace1(REPORT_STANDARD, "Planning MSI package 0x%p", pPackage);
+    Trace(REPORT_STANDARD, "Planning MSI package 0x%p", pPackage);
 
     HRESULT hr = S_OK;
     DWORD64 qwVersion = pPackage->Msi.qwVersion;
@@ -794,7 +794,7 @@ extern "C" HRESULT MsiEnginePlanCalculatePackage(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Invalid package current state result encountered during plan: %d", pPackage->currentState);
+        ExitOnRootFailure(hr, "Invalid package current state result encountered during plan: %d", pPackage->currentState);
     }
 
     // Calculate the rollback action if there is an execute action.
@@ -1003,7 +1003,7 @@ extern "C" HRESULT MsiEngineAddCompatiblePackage(
         ExitOnFailure(hr, "Failed to read version from compatible package.");
 
         hr = FileVersionFromStringEx(sczInstalledVersion, 0, &pCompatiblePackage->Msi.qwVersion);
-        ExitOnFailure2(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, pCompatiblePackage->Msi.sczProductCode);
+        ExitOnFailure(hr, "Failed to convert version: %ls to DWORD64 for ProductCode: %ls", sczInstalledVersion, pCompatiblePackage->Msi.sczProductCode);
     }
 
     // For now, copy enough information to support uninstalling the newer, compatible package.
@@ -1130,7 +1130,7 @@ extern "C" HRESULT MsiEngineExecutePackage(
     {
         // get cached MSI path
         hr = CacheGetCompletedPath(pExecuteAction->msiPackage.pPackage->fPerMachine, pExecuteAction->msiPackage.pPackage->sczCacheId, &sczCachedDirectory);
-        ExitOnFailure1(hr, "Failed to get cached path for package: %ls", pExecuteAction->msiPackage.pPackage->sczId);
+        ExitOnFailure(hr, "Failed to get cached path for package: %ls", pExecuteAction->msiPackage.pPackage->sczId);
 
         // Best effort to set the execute package cache folder variable.
         VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
@@ -1146,7 +1146,7 @@ extern "C" HRESULT MsiEngineExecutePackage(
     if (pExecuteAction->msiPackage.sczLogPath && *pExecuteAction->msiPackage.sczLogPath)
     {
         hr = WiuEnableLog(dwLogMode, pExecuteAction->msiPackage.sczLogPath, 0);
-        ExitOnFailure2(hr, "Failed to enable logging for package: %ls to: %ls", pExecuteAction->msiPackage.pPackage->sczId, pExecuteAction->msiPackage.sczLogPath);
+        ExitOnFailure(hr, "Failed to enable logging for package: %ls to: %ls", pExecuteAction->msiPackage.pPackage->sczId, pExecuteAction->msiPackage.sczLogPath);
     }
 
     // set up properties
@@ -1381,7 +1381,7 @@ static HRESULT ParseRelatedMsiFromXml(
         ExitOnFailure(hr, "Failed to get @MinVersion.");
 
         hr = FileVersionFromStringEx(scz, 0, &pRelatedMsi->qwMinVersion);
-        ExitOnFailure1(hr, "Failed to parse @MinVersion: %ls", scz);
+        ExitOnFailure(hr, "Failed to parse @MinVersion: %ls", scz);
 
         // flag that we have a min version
         pRelatedMsi->fMinProvided = TRUE;
@@ -1398,7 +1398,7 @@ static HRESULT ParseRelatedMsiFromXml(
         ExitOnFailure(hr, "Failed to get @MaxVersion.");
 
         hr = FileVersionFromStringEx(scz, 0, &pRelatedMsi->qwMaxVersion);
-        ExitOnFailure1(hr, "Failed to parse @MaxVersion: %ls", scz);
+        ExitOnFailure(hr, "Failed to parse @MaxVersion: %ls", scz);
 
         // flag that we have a max version
         pRelatedMsi->fMaxProvided = TRUE;
@@ -1812,7 +1812,7 @@ static HRESULT ConcatPatchProperty(
             if (BOOTSTRAPPER_ACTION_STATE_UNINSTALL < patchExecuteAction)
             {
                 hr = CacheGetCompletedPath(pMspPackage->fPerMachine, pMspPackage->sczCacheId, &sczCachedDirectory);
-                ExitOnFailure1(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
+                ExitOnFailure(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
 
                 hr = PathConcat(sczCachedDirectory, pMspPackage->rgPayloads[0].pPayload->sczFilePath, &sczMspPath);
                 ExitOnFailure(hr, "Failed to build MSP path.");
@@ -1860,7 +1860,7 @@ static void RegisterSourceDirectory(
     MSIINSTALLCONTEXT dwContext = pPackage->fPerMachine ? MSIINSTALLCONTEXT_MACHINE : MSIINSTALLCONTEXT_USERUNMANAGED;
 
     hr = PathGetDirectory(wzMsiPath, &sczMsiDirectory);
-    ExitOnFailure1(hr, "Failed to get directory for path: %ls", wzMsiPath);
+    ExitOnFailure(hr, "Failed to get directory for path: %ls", wzMsiPath);
 
     hr = WiuSourceListAddSourceEx(pPackage->Msi.sczProductCode, NULL, dwContext, MSICODE_PRODUCT, sczMsiDirectory, 1);
     if (FAILED(hr))

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -180,7 +180,7 @@ extern "C" HRESULT MspEngineDetectInitialize(
 
                     // Note that we do add superseded and obsolete MSP packages. Package Detect and Plan will sort them out later.
                     hr = AddDetectedTargetProduct(pPackages, pMspPackage, pPackages->rgPatchInfo[iPatchInfo].dwOrder, pPossibleTargetProduct->wzProductCode, pPossibleTargetProduct->context);
-                    ExitOnFailure1(hr, "Failed to add target product code to package: %ls", pMspPackage->sczId);
+                    ExitOnFailure(hr, "Failed to add target product code to package: %ls", pMspPackage->sczId);
                 }
                 // TODO: should we log something for this error case?
             }
@@ -257,7 +257,7 @@ extern "C" HRESULT MspEngineDetectPackage(
                 pTargetProduct->patchPackageState = BOOTSTRAPPER_PACKAGE_STATE_ABSENT;
                 hr = S_OK;
             }
-            ExitOnFailure2(hr, "Failed to get patch information for patch code: %ls, target product code: %ls", pPackage->Msp.sczPatchCode, pTargetProduct->wzTargetProductCode);
+            ExitOnFailure(hr, "Failed to get patch information for patch code: %ls, target product code: %ls", pPackage->Msp.sczPatchCode, pTargetProduct->wzTargetProductCode);
 
             if (pPackage->currentState > pTargetProduct->patchPackageState)
             {
@@ -489,7 +489,7 @@ extern "C" HRESULT MspEngineExecutePackage(
         if (BOOTSTRAPPER_ACTION_STATE_INSTALL == pExecuteAction->mspTarget.action)
         {
             hr = CacheGetCompletedPath(pMspPackage->fPerMachine, pMspPackage->sczCacheId, &sczCachedDirectory);
-            ExitOnFailure1(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
+            ExitOnFailure(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
 
             // Best effort to set the execute package cache folder variable.
             VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
@@ -526,7 +526,7 @@ extern "C" HRESULT MspEngineExecutePackage(
     if (pExecuteAction->mspTarget.sczLogPath && *pExecuteAction->mspTarget.sczLogPath)
     {
         hr = WiuEnableLog(dwLogMode, pExecuteAction->mspTarget.sczLogPath, 0);
-        ExitOnFailure2(hr, "Failed to enable logging for package: %ls to: %ls", pExecuteAction->mspTarget.pPackage->sczId, pExecuteAction->mspTarget.sczLogPath);
+        ExitOnFailure(hr, "Failed to enable logging for package: %ls to: %ls", pExecuteAction->mspTarget.pPackage->sczId, pExecuteAction->mspTarget.sczLogPath);
     }
 
     // set up properties
@@ -685,7 +685,7 @@ static HRESULT GetPossibleTargetProductCodes(
                 {
                     hr = S_OK;
                 }
-                ExitOnFailure1(hr, "Failed to enumerate all products to patch related to upgrade code: %ls", pTargetCode->sczTargetCode);
+                ExitOnFailure(hr, "Failed to enumerate all products to patch related to upgrade code: %ls", pTargetCode->sczTargetCode);
             }
             else
             {

--- a/src/burn/engine/msuengine.cpp
+++ b/src/burn/engine/msuengine.cpp
@@ -304,7 +304,7 @@ extern "C" HRESULT MsuEngineExecutePackage(
     case BOOTSTRAPPER_ACTION_STATE_INSTALL:
         // get cached MSU path
         hr = CacheGetCompletedPath(TRUE, pExecuteAction->msuPackage.pPackage->sczCacheId, &sczCachedDirectory);
-        ExitOnFailure1(hr, "Failed to get cached path for package: %ls", pExecuteAction->msuPackage.pPackage->sczId);
+        ExitOnFailure(hr, "Failed to get cached path for package: %ls", pExecuteAction->msuPackage.pPackage->sczId);
 
         // Best effort to set the execute package cache folder variable.
         VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
@@ -346,7 +346,7 @@ extern "C" HRESULT MsuEngineExecutePackage(
     si.cb = sizeof(si);
     if (!::CreateProcessW(sczWusaPath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to CreateProcess on path: %ls", sczWusaPath);
+        ExitWithLastError(hr, "Failed to CreateProcess on path: %ls", sczWusaPath);
     }
 
     do
@@ -362,7 +362,7 @@ extern "C" HRESULT MsuEngineExecutePackage(
         hr = ProcWaitForCompletion(pi.hProcess, 500, &dwExitCode);
         if (HRESULT_FROM_WIN32(WAIT_TIMEOUT) != hr)
         {
-            ExitOnFailure1(hr, "Failed to wait for executable to complete: %ls", sczWusaPath);
+            ExitOnFailure(hr, "Failed to wait for executable to complete: %ls", sczWusaPath);
         }
     } while (HRESULT_FROM_WIN32(WAIT_TIMEOUT) == hr);
 

--- a/src/burn/engine/netfxchainer.cpp
+++ b/src/burn/engine/netfxchainer.cpp
@@ -49,20 +49,20 @@ static HRESULT CreateNetFxChainer(
     ExitOnNull(pChainer, hr, E_OUTOFMEMORY, "Failed to allocate memory for NetFxChainer struct.");
 
     pChainer->hEventChaineeSend = ::CreateEvent(NULL, FALSE, FALSE, wzEventName);
-    ExitOnNullWithLastError1(pChainer->hEventChaineeSend, hr, "Failed to create event: %ls", wzEventName);
+    ExitOnNullWithLastError(pChainer->hEventChaineeSend, hr, "Failed to create event: %ls", wzEventName);
 
     hr = StrAllocFormatted(&sczName, L"%ls_send", wzEventName);
     ExitOnFailure(hr, "failed to allocate memory for event name");
 
     pChainer->hEventChainerSend = ::CreateEvent(NULL, FALSE, FALSE, sczName);
-    ExitOnNullWithLastError1(pChainer->hEventChainerSend, hr, "Failed to create event: %ls", sczName);
+    ExitOnNullWithLastError(pChainer->hEventChainerSend, hr, "Failed to create event: %ls", sczName);
 
     hr = StrAllocFormatted(&sczName, L"%ls_mutex", wzEventName);
     ExitOnFailure(hr, "failed to allocate memory for mutex name");
 
     // Create the mutex, we initially own
     pChainer->hMutex = ::CreateMutex(NULL, TRUE, sczName);
-    ExitOnNullWithLastError1(pChainer->hMutex, hr, "Failed to create mutex: %ls", sczName);
+    ExitOnNullWithLastError(pChainer->hMutex, hr, "Failed to create mutex: %ls", sczName);
 
     pChainer->hSection = ::CreateFileMapping(INVALID_HANDLE_VALUE,
                                    NULL, // security attributes
@@ -70,14 +70,14 @@ static HRESULT CreateNetFxChainer(
                                    0, // high-order DWORD of maximum size
                                    NETFXDATA_SIZE, // low-order DWORD of maximum size
                                    wzSectionName);
-    ExitOnNullWithLastError1(pChainer->hSection, hr, "Failed to memory map cabinet file: %ls", wzSectionName);
+    ExitOnNullWithLastError(pChainer->hSection, hr, "Failed to memory map cabinet file: %ls", wzSectionName);
 
     pChainer->pData = reinterpret_cast<NetFxDataStructure*>(::MapViewOfFile(pChainer->hSection,
                                                                           FILE_MAP_WRITE,
                                                                           0, 0, // offsets
                                                                           0 // map entire file
                                                                           ));
-    ExitOnNullWithLastError1(pChainer->pData, hr, "Failed to MapViewOfFile for %ls.", wzSectionName);
+    ExitOnNullWithLastError(pChainer->pData, hr, "Failed to MapViewOfFile for %ls.", wzSectionName);
 
     // Initialize the shared memory
     hr = ::StringCchCopyW(pChainer->pData->szEventName, countof(pChainer->pData->szEventName), wzEventName);
@@ -388,7 +388,7 @@ extern "C" HRESULT NetFxRunChainer(
     si.cb = sizeof(si);
     if (!::CreateProcessW(wzExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to CreateProcess on path: %ls", wzExecutablePath);
+        ExitWithLastError(hr, "Failed to CreateProcess on path: %ls", wzExecutablePath);
     }
 
     HANDLE handles[2] = { pi.hProcess, pNetfxChainer->hEventChaineeSend };

--- a/src/burn/engine/package.cpp
+++ b/src/burn/engine/package.cpp
@@ -138,7 +138,7 @@ extern "C" HRESULT PackagesParseFromXml(
             else
             {
                 hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid cache type: %ls", scz);
+                ExitOnFailure(hr, "Invalid cache type: %ls", scz);
             }
         }
         ExitOnFailure(hr, "Failed to get @Cache.");
@@ -196,7 +196,7 @@ extern "C" HRESULT PackagesParseFromXml(
             ExitOnFailure(hr, "Failed to get @RollbackBoundaryForward.");
 
             hr =  FindRollbackBoundaryById(pPackages, scz, &pPackage->pRollbackBoundaryForward);
-            ExitOnFailure1(hr, "Failed to find forward transaction boundary: %ls", scz);
+            ExitOnFailure(hr, "Failed to find forward transaction boundary: %ls", scz);
         }
 
         // @RollbackBoundaryBackward
@@ -206,7 +206,7 @@ extern "C" HRESULT PackagesParseFromXml(
             ExitOnFailure(hr, "Failed to get @RollbackBoundaryBackward.");
 
             hr =  FindRollbackBoundaryById(pPackages, scz, &pPackage->pRollbackBoundaryBackward);
-            ExitOnFailure1(hr, "Failed to find backward transaction boundary: %ls", scz);
+            ExitOnFailure(hr, "Failed to find backward transaction boundary: %ls", scz);
         }
 
         // read type specific attributes

--- a/src/burn/engine/payload.cpp
+++ b/src/burn/engine/payload.cpp
@@ -93,7 +93,7 @@ extern "C" HRESULT PayloadsParseFromXml(
         else
         {
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Invalid value for @Packaging: %ls", scz);
+            ExitOnFailure(hr, "Invalid value for @Packaging: %ls", scz);
         }
 
         // @Container
@@ -106,7 +106,7 @@ extern "C" HRESULT PayloadsParseFromXml(
 
                 // find container
                 hr = ContainerFindById(pContainers, scz, &pPayload->pContainer);
-                ExitOnFailure1(hr, "Failed to to find container: %ls", scz);
+                ExitOnFailure(hr, "Failed to to find container: %ls", scz);
             }
         }
 
@@ -246,7 +246,7 @@ extern "C" HRESULT PayloadExtractFromContainer(
 
         // find payload by stream name
         hr = FindEmbeddedBySourcePath(pPayloads, pContainer, sczStreamName, &pPayload);
-        ExitOnFailure1(hr, "Failed to find embedded payload: %ls", sczStreamName);
+        ExitOnFailure(hr, "Failed to find embedded payload: %ls", sczStreamName);
 
         // make file path
         hr = PathConcat(wzTargetDir, pPayload->sczFilePath, &pPayload->sczLocalFilePath);
@@ -278,7 +278,7 @@ extern "C" HRESULT PayloadExtractFromContainer(
             if (BURN_PAYLOAD_STATE_ACQUIRED > pPayload->state)
             {
                 hr = E_INVALIDDATA;
-                ExitOnRootFailure1(hr, "Payload was not found in container: %ls", pPayload->sczKey);
+                ExitOnRootFailure(hr, "Payload was not found in container: %ls", pPayload->sczKey);
             }
         }
     }

--- a/src/burn/engine/plan.cpp
+++ b/src/burn/engine/plan.cpp
@@ -479,7 +479,7 @@ extern "C" HRESULT PlanPackages(
 
             // Add the compatible package to the list.
             hr = MsiEngineAddCompatiblePackage(pPackages, pPackage, &pCompatiblePackage);
-            ExitOnFailure1(hr, "Failed to add compatible package for package: %ls", pPackage->sczId);
+            ExitOnFailure(hr, "Failed to add compatible package for package: %ls", pPackage->sczId);
 
             // Plan to load the compatible package into the elevated engine before its needed.
             hr = PlanAppendExecuteAction(pPlan, &pAction);
@@ -882,7 +882,7 @@ static HRESULT ProcessPackage(
     {
         // Make sure the package is properly ref-counted even if no plan is requested.
         hr = DependencyPlanPackageBegin(fBundlePerMachine, pPackage, pPlan);
-        ExitOnFailure1(hr, "Failed to begin plan dependency actions for package: %ls", pPackage->sczId);
+        ExitOnFailure(hr, "Failed to begin plan dependency actions for package: %ls", pPackage->sczId);
 
         // All packages that have cacheType set to always should be cached if the bundle is going to be present.
         if (BURN_CACHE_TYPE_ALWAYS == pPackage->cacheType && BOOTSTRAPPER_ACTION_INSTALL <= pPlan->action)
@@ -904,7 +904,7 @@ static HRESULT ProcessPackage(
         ExitOnFailure(hr, "Failed to plan package dependency actions.");
 
         hr = DependencyPlanPackageComplete(pPackage, pPlan);
-        ExitOnFailure1(hr, "Failed to complete plan dependency actions for package: %ls", pPackage->sczId);
+        ExitOnFailure(hr, "Failed to complete plan dependency actions for package: %ls", pPackage->sczId);
     }
 
     // Add the checkpoint after each package and dependency registration action.
@@ -1045,11 +1045,11 @@ extern "C" HRESULT PlanExecutePackage(
         hr = E_UNEXPECTED;
         ExitOnFailure(hr, "Invalid package type.");
     }
-    ExitOnFailure1(hr, "Failed to calculate plan actions for package: %ls", pPackage->sczId);
+    ExitOnFailure(hr, "Failed to calculate plan actions for package: %ls", pPackage->sczId);
 
     // Calculate package states based on reference count and plan certain dependency actions prior to planning the package execute action.
     hr = DependencyPlanPackageBegin(fPerMachine, pPackage, pPlan);
-    ExitOnFailure1(hr, "Failed to begin plan dependency actions for package: %ls", pPackage->sczId);
+    ExitOnFailure(hr, "Failed to begin plan dependency actions for package: %ls", pPackage->sczId);
 
     // All packages that have cacheType set to always should be cached if the bundle is going to be present.
     if (BURN_CACHE_TYPE_ALWAYS == pPackage->cacheType && BOOTSTRAPPER_ACTION_INSTALL <= pPlan->action)
@@ -1135,11 +1135,11 @@ extern "C" HRESULT PlanExecutePackage(
         hr = E_UNEXPECTED;
         ExitOnFailure(hr, "Invalid package type.");
     }
-    ExitOnFailure1(hr, "Failed to add plan actions for package: %ls", pPackage->sczId);
+    ExitOnFailure(hr, "Failed to add plan actions for package: %ls", pPackage->sczId);
 
     // Plan certain dependency actions after planning the package execute action.
     hr = DependencyPlanPackageComplete(pPackage, pPlan);
-    ExitOnFailure1(hr, "Failed to complete plan dependency actions for package: %ls", pPackage->sczId);
+    ExitOnFailure(hr, "Failed to complete plan dependency actions for package: %ls", pPackage->sczId);
 
     // If we are going to take any action on this package, add progress for it.
     if (BOOTSTRAPPER_ACTION_STATE_NONE != pPackage->execute || BOOTSTRAPPER_ACTION_STATE_NONE != pPackage->rollback)
@@ -1270,7 +1270,7 @@ extern "C" HRESULT PlanRelatedBundlesBegin(
             break;
         default:
             hr = E_UNEXPECTED;
-            ExitOnFailure1(hr, "Unexpected relation type encountered during plan: %d", pRelatedBundle->relationType);
+            ExitOnFailure(hr, "Unexpected relation type encountered during plan: %d", pRelatedBundle->relationType);
             break;
         }
 
@@ -1295,7 +1295,7 @@ extern "C" HRESULT PlanRelatedBundlesBegin(
                 const BURN_DEPENDENCY_PROVIDER* pProvider = pRelatedBundle->package.rgDependencyProviders;
 
                 hr = DepDependencyArrayAlloc(&pPlan->rgPlannedProviders, &pPlan->cPlannedProviders, pProvider->sczKey, pProvider->sczDisplayName);
-                ExitOnFailure1(hr, "Failed to add the package provider key \"%ls\" to the planned list.", pProvider->sczKey);
+                ExitOnFailure(hr, "Failed to add the package provider key \"%ls\" to the planned list.", pProvider->sczKey);
             }
         }
     }
@@ -1378,7 +1378,7 @@ extern "C" HRESULT PlanRelatedBundlesComplete(
             hr = DictKeyExists(sdProviderKeys, pProvider->sczKey);
             if (E_NOTFOUND != hr)
             {
-                ExitOnFailure1(hr, "Failed to check the dictionary for a related bundle provider key: \"%ls\".", pProvider->sczKey);
+                ExitOnFailure(hr, "Failed to check the dictionary for a related bundle provider key: \"%ls\".", pProvider->sczKey);
                 // Key found, so there is an embedded bundle with the same provider key that will be executed.  So this related bundle should not be added to the plan
                 LogId(REPORT_STANDARD, MSG_PLAN_SKIPPED_RELATED_BUNDLE_EMBEDDED_BUNDLE_NEWER, pRelatedBundle->package.sczId, LoggingRelationTypeToString(pRelatedBundle->relationType), pProvider->sczKey);
                 continue;
@@ -1412,13 +1412,13 @@ extern "C" HRESULT PlanRelatedBundlesComplete(
         if (BOOTSTRAPPER_REQUEST_STATE_NONE != pRelatedBundle->package.requested)
         {
             hr = ExeEnginePlanCalculatePackage(&pRelatedBundle->package);
-            ExitOnFailure1(hr, "Failed to calcuate plan for related bundle: %ls", pRelatedBundle->package.sczId);
+            ExitOnFailure(hr, "Failed to calcuate plan for related bundle: %ls", pRelatedBundle->package.sczId);
 
             // Calculate package states based on reference count for addon and patch related bundles.
             if (BOOTSTRAPPER_RELATION_ADDON == pRelatedBundle->relationType || BOOTSTRAPPER_RELATION_PATCH == pRelatedBundle->relationType)
             {
                 hr = DependencyPlanPackageBegin(pRegistration->fPerMachine, &pRelatedBundle->package, pPlan);
-                ExitOnFailure1(hr, "Failed to begin plan dependency actions to  package: %ls", pRelatedBundle->package.sczId);
+                ExitOnFailure(hr, "Failed to begin plan dependency actions to  package: %ls", pRelatedBundle->package.sczId);
 
                 // If uninstalling a related bundle, make sure the bundle is uninstalled after removing registration.
                 if (pdwInsertIndex && BOOTSTRAPPER_ACTION_UNINSTALL == pPlan->action)
@@ -1428,13 +1428,13 @@ extern "C" HRESULT PlanRelatedBundlesComplete(
             }
 
             hr = ExeEnginePlanAddPackage(pdwInsertIndex, &pRelatedBundle->package, pPlan, pLog, pVariables, *phSyncpointEvent, FALSE);
-            ExitOnFailure1(hr, "Failed to add to plan related bundle: %ls", pRelatedBundle->package.sczId);
+            ExitOnFailure(hr, "Failed to add to plan related bundle: %ls", pRelatedBundle->package.sczId);
 
             // Calculate package states based on reference count for addon and patch related bundles.
             if (BOOTSTRAPPER_RELATION_ADDON == pRelatedBundle->relationType || BOOTSTRAPPER_RELATION_PATCH == pRelatedBundle->relationType)
             {
                 hr = DependencyPlanPackageComplete(&pRelatedBundle->package, pPlan);
-                ExitOnFailure1(hr, "Failed to complete plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
+                ExitOnFailure(hr, "Failed to complete plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
             }
 
             // If we are going to take any action on this package, add progress for it.
@@ -1456,13 +1456,13 @@ extern "C" HRESULT PlanRelatedBundlesComplete(
         {
             // Make sure the package is properly ref-counted even if no plan is requested.
             hr = DependencyPlanPackageBegin(pRegistration->fPerMachine, &pRelatedBundle->package, pPlan);
-            ExitOnFailure1(hr, "Failed to begin plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
+            ExitOnFailure(hr, "Failed to begin plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
 
             hr = DependencyPlanPackage(pdwInsertIndex, &pRelatedBundle->package, pPlan);
             ExitOnFailure(hr, "Failed to plan related bundle package provider actions.");
 
             hr = DependencyPlanPackageComplete(&pRelatedBundle->package, pPlan);
-            ExitOnFailure1(hr, "Failed to complete plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
+            ExitOnFailure(hr, "Failed to complete plan dependency actions for related bundle package: %ls", pRelatedBundle->package.sczId);
         }
     }
 
@@ -2123,7 +2123,7 @@ static HRESULT AddCacheSlipstreamMsps(
         AssertSz(BURN_PACKAGE_TYPE_MSP == pMspPackage->type, "Only MSP packages can be slipstream patches.");
 
         hr = AddCachePackage(pPlan, pMspPackage, &hIgnored);
-        ExitOnFailure1(hr, "Failed to plan slipstream MSP: %ls", pMspPackage->sczId);
+        ExitOnFailure(hr, "Failed to plan slipstream MSP: %ls", pMspPackage->sczId);
     }
 
 LExit:

--- a/src/burn/engine/precomp.h
+++ b/src/burn/engine/precomp.h
@@ -15,9 +15,9 @@
 
 
 #define ExitTrace LogErrorString
-#define ExitTrace1 LogErrorString
-#define ExitTrace2 LogErrorString
-#define ExitTrace3 LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
+#define ExitTrace LogErrorString
 
 #include <wixver.h>
 

--- a/src/burn/engine/registration.cpp
+++ b/src/burn/engine/registration.cpp
@@ -134,7 +134,7 @@ extern "C" HRESULT RegistrationParseFromXml(
     ExitOnFailure(hr, "Failed to get @Version.");
 
     hr = FileVersionFromStringEx(scz, 0, &pRegistration->qwVersion);
-    ExitOnFailure1(hr, "Failed to parse @Version: %ls", scz);
+    ExitOnFailure(hr, "Failed to parse @Version: %ls", scz);
 
     // @ProviderKey
     hr = XmlGetAttributeEx(pixnRegistrationNode, L"ProviderKey", &pRegistration->sczProviderKey);
@@ -247,7 +247,7 @@ extern "C" HRESULT RegistrationParseFromXml(
             else
             {
                 hr = E_UNEXPECTED;
-                ExitOnRootFailure1(hr, "Invalid modify disabled type: %ls", scz);
+                ExitOnRootFailure(hr, "Invalid modify disabled type: %ls", scz);
             }
         }
         else if (E_NOTFOUND == hr)
@@ -602,7 +602,7 @@ extern "C" HRESULT RegistrationSessionBegin(
                         , pRegistration->sczCacheExecutablePath
 #endif
                         );
-        ExitOnFailure1(hr, "Failed to cache bundle from path: %ls", wzEngineWorkingPath);
+        ExitOnFailure(hr, "Failed to cache bundle from path: %ls", wzEngineWorkingPath);
     }
 
     // create registration key
@@ -614,112 +614,112 @@ extern "C" HRESULT RegistrationSessionBegin(
     {
         // Upgrade information
         hr = RegWriteString(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_CACHE_PATH, pRegistration->sczCacheExecutablePath);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_CACHE_PATH);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_CACHE_PATH);
 
         hr = RegWriteStringArray(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_UPGRADE_CODE, pRegistration->rgsczUpgradeCodes, pRegistration->cUpgradeCodes);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_UPGRADE_CODE);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_UPGRADE_CODE);
 
         hr = RegWriteStringArray(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_ADDON_CODE, pRegistration->rgsczAddonCodes, pRegistration->cAddonCodes);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_ADDON_CODE);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_ADDON_CODE);
 
         hr = RegWriteStringArray(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_DETECT_CODE, pRegistration->rgsczDetectCodes, pRegistration->cDetectCodes);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_DETECT_CODE);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_DETECT_CODE);
 
         hr = RegWriteStringArray(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_PATCH_CODE, pRegistration->rgsczPatchCodes, pRegistration->cPatchCodes);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_PATCH_CODE);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_PATCH_CODE);
 
         hr = RegWriteStringFormatted(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_VERSION, L"%hu.%hu.%hu.%hu", (WORD)(pRegistration->qwVersion >> 48), (WORD)(pRegistration->qwVersion >> 32), (WORD)(pRegistration->qwVersion >> 16), (WORD)(pRegistration->qwVersion));
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_VERSION);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_VERSION);
 
         if (pRegistration->sczProviderKey)
         {
             hr = RegWriteString(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_PROVIDER_KEY, pRegistration->sczProviderKey);
-            ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_PROVIDER_KEY);
+            ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_PROVIDER_KEY);
         }
 
         if (pRegistration->sczTag)
         {
             hr = RegWriteString(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_TAG, pRegistration->sczTag);
-            ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_TAG);
+            ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_TAG);
         }
 
         hr = RegWriteStringFormatted(hkRegistration, BURN_REGISTRATION_REGISTRY_ENGINE_VERSION, L"%hs", szVerMajorMinorBuild);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_ENGINE_VERSION);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_ENGINE_VERSION);
 
         // DisplayIcon: [path to exe] and ",0" to refer to the first icon in the executable.
         hr = RegWriteStringFormatted(hkRegistration, REGISTRY_BUNDLE_DISPLAY_ICON, L"%s,0", pRegistration->sczCacheExecutablePath);
-        ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_DISPLAY_ICON);
+        ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_DISPLAY_ICON);
 
         // DisplayName: provided by UI
         hr = GetBundleName(pRegistration, pVariables, &sczDisplayName);
         hr = RegWriteString(hkRegistration, BURN_REGISTRATION_REGISTRY_BUNDLE_DISPLAY_NAME, SUCCEEDED(hr) ? sczDisplayName : pRegistration->sczDisplayName);
-        ExitOnFailure1(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_DISPLAY_NAME);
+        ExitOnFailure(hr, "Failed to write %ls value.", BURN_REGISTRATION_REGISTRY_BUNDLE_DISPLAY_NAME);
 
         // DisplayVersion: provided by UI
         if (pRegistration->sczDisplayVersion)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_DISPLAY_VERSION, pRegistration->sczDisplayVersion);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_DISPLAY_VERSION);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_DISPLAY_VERSION);
         }
 
         // Publisher: provided by UI
         if (pRegistration->sczPublisher)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_PUBLISHER, pRegistration->sczPublisher);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PUBLISHER);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PUBLISHER);
         }
 
         // HelpLink: provided by UI
         if (pRegistration->sczHelpLink)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_HELP_LINK, pRegistration->sczHelpLink);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_HELP_LINK);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_HELP_LINK);
         }
 
         // HelpTelephone: provided by UI
         if (pRegistration->sczHelpTelephone)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_HELP_TELEPHONE, pRegistration->sczHelpTelephone);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_HELP_TELEPHONE);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_HELP_TELEPHONE);
         }
 
         // URLInfoAbout, provided by UI
         if (pRegistration->sczAboutUrl)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_URL_INFO_ABOUT, pRegistration->sczAboutUrl);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_URL_INFO_ABOUT);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_URL_INFO_ABOUT);
         }
 
         // URLUpdateInfo, provided by UI
         if (pRegistration->sczUpdateUrl)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_URL_UPDATE_INFO, pRegistration->sczUpdateUrl);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_URL_UPDATE_INFO);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_URL_UPDATE_INFO);
         }
 
         // ParentDisplayName
         if (pRegistration->sczParentDisplayName)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_PARENT_DISPLAY_NAME, pRegistration->sczParentDisplayName);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PARENT_DISPLAY_NAME);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PARENT_DISPLAY_NAME);
 
             // Need to write the ParentKeyName but can be set to anything.
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_PARENT_KEY_NAME, pRegistration->sczParentDisplayName);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PARENT_KEY_NAME);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_PARENT_KEY_NAME);
         }
 
         // Comments, provided by UI
         if (pRegistration->sczComments)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_COMMENTS, pRegistration->sczComments);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_COMMENTS);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_COMMENTS);
         }
 
         // Contact, provided by UI
         if (pRegistration->sczContact)
         {
             hr = RegWriteString(hkRegistration, REGISTRY_BUNDLE_CONTACT, pRegistration->sczContact);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_CONTACT);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_CONTACT);
         }
 
         // InstallLocation: provided by UI
@@ -729,43 +729,43 @@ extern "C" HRESULT RegistrationSessionBegin(
         if (BURN_REGISTRATION_MODIFY_DISABLE == pRegistration->modify)
         {
             hr = RegWriteNumber(hkRegistration, REGISTRY_BUNDLE_NO_MODIFY, 1);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_MODIFY);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_MODIFY);
         }
         else if (BURN_REGISTRATION_MODIFY_DISABLE_BUTTON != pRegistration->modify) // if support modify (aka: did not disable anything)
         {
             // ModifyPath: [path to exe] /modify
             hr = RegWriteStringFormatted(hkRegistration, REGISTRY_BUNDLE_MODIFY_PATH, L"\"%ls\" /modify", pRegistration->sczCacheExecutablePath);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_MODIFY_PATH);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_MODIFY_PATH);
 
             // NoElevateOnModify: 1
             hr = RegWriteNumber(hkRegistration, REGISTRY_BUNDLE_NO_ELEVATE_ON_MODIFY, 1);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_ELEVATE_ON_MODIFY);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_ELEVATE_ON_MODIFY);
         }
 
         // NoRemove: should this be allowed?
         if (pRegistration->fNoRemoveDefined)
         {
             hr = RegWriteNumber(hkRegistration, REGISTRY_BUNDLE_NO_REMOVE, (DWORD)pRegistration->fNoRemove);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_REMOVE);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_NO_REMOVE);
         }
 
         // Conditionally hide the ARP entry.
         if (!pRegistration->fRegisterArp)
         {
             hr = RegWriteNumber(hkRegistration, REGISTRY_BUNDLE_SYSTEM_COMPONENT, 1);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_SYSTEM_COMPONENT);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_SYSTEM_COMPONENT);
         }
 
         // QuietUninstallString: [path to exe] /uninstall /quiet
         hr = RegWriteStringFormatted(hkRegistration, REGISTRY_BUNDLE_QUIET_UNINSTALL_STRING, L"\"%ls\" /uninstall /quiet", pRegistration->sczCacheExecutablePath);
-        ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_QUIET_UNINSTALL_STRING);
+        ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_QUIET_UNINSTALL_STRING);
 
         // UninstallString, [path to exe]
         // If the modify button is to be disabled, we'll add "/modify" to the uninstall string because the button is "Uninstall/Change". Otherwise,
         // it's just the "Uninstall" button so we add "/uninstall" to make the program just go away.
         LPCWSTR wzUninstallParameters = (BURN_REGISTRATION_MODIFY_DISABLE_BUTTON == pRegistration->modify) ? L"/modify" : L" /uninstall";
         hr = RegWriteStringFormatted(hkRegistration, REGISTRY_BUNDLE_UNINSTALL_STRING, L"\"%ls\" %ls", pRegistration->sczCacheExecutablePath, wzUninstallParameters);
-        ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_UNINSTALL_STRING);
+        ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_UNINSTALL_STRING);
 
         if (pRegistration->softwareTags.cSoftwareTags)
         {
@@ -798,7 +798,7 @@ extern "C" HRESULT RegistrationSessionBegin(
             }
 
             hr = RegWriteNumber(hkRegistration, REGISTRY_BUNDLE_ESTIMATED_SIZE, dwSize);
-            ExitOnFailure1(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_ESTIMATED_SIZE);
+            ExitOnFailure(hr, "Failed to write %ls value.", REGISTRY_BUNDLE_ESTIMATED_SIZE);
         }
     }
 
@@ -909,7 +909,7 @@ extern "C" HRESULT RegistrationSessionEnd(
         hr = RegDelete(pRegistration->hkRoot, pRegistration->sczRegistrationKey, REG_KEY_DEFAULT, FALSE);
         if (E_FILENOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed to delete registration key: %ls", pRegistration->sczRegistrationKey);
+            ExitOnFailure(hr, "Failed to delete registration key: %ls", pRegistration->sczRegistrationKey);
         }
 
         CacheRemoveBundle(pRegistration->fPerMachine, pRegistration->sczId);
@@ -952,7 +952,7 @@ extern "C" HRESULT RegistrationSaveState(
         // TODO: should we log that the bundle's cache folder was not present so the state file wasn't created either?
         hr = S_OK;
     }
-    ExitOnFailure1(hr, "Failed to write state to file: %ls", pRegistration->sczStateFile);
+    ExitOnFailure(hr, "Failed to write state to file: %ls", pRegistration->sczStateFile);
 
 LExit:
     return hr;
@@ -1297,7 +1297,7 @@ static HRESULT ParseRelatedCodes(
         else
         {
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Invalid value for @Action: %ls", sczAction);
+            ExitOnFailure(hr, "Invalid value for @Action: %ls", sczAction);
         }
     }
 
@@ -1350,7 +1350,7 @@ static HRESULT WriteSoftwareTags(
     LPWSTR sczPath = NULL;
 
     hr = PathGetKnownFolder(fPerMachine ? CSIDL_COMMON_APPDATA : CSIDL_LOCAL_APPDATA, &sczRootFolder);
-    ExitOnFailure1(hr, "Failed to find local %hs appdata directory.", fPerMachine ? "per-machine" : "per-user");
+    ExitOnFailure(hr, "Failed to find local %hs appdata directory.", fPerMachine ? "per-machine" : "per-user");
 
     for (DWORD iTag = 0; iTag < pSoftwareTags->cSoftwareTags; ++iTag)
     {
@@ -1363,10 +1363,10 @@ static HRESULT WriteSoftwareTags(
         ExitOnFailure(hr, "Failed to allocate regid folder path.");
 
         hr = DirEnsureExists(sczRegidFolder, NULL);
-        ExitOnFailure1(hr, "Failed to create regid folder: %ls", sczRegidFolder);
+        ExitOnFailure(hr, "Failed to create regid folder: %ls", sczRegidFolder);
 
         hr = FileWrite(sczPath, FILE_ATTRIBUTE_NORMAL, reinterpret_cast<LPBYTE>(pSoftwareTag->sczTag), lstrlenA(pSoftwareTag->sczTag), NULL);
-        ExitOnFailure1(hr, "Failed to write tag xml to file: %ls", sczPath);
+        ExitOnFailure(hr, "Failed to write tag xml to file: %ls", sczPath);
     }
 
 LExit:
@@ -1388,7 +1388,7 @@ static HRESULT RemoveSoftwareTags(
     LPWSTR sczPath = NULL;
 
     hr = PathGetKnownFolder(fPerMachine ? CSIDL_COMMON_APPDATA : CSIDL_LOCAL_APPDATA, &sczRootFolder);
-    ExitOnFailure1(hr, "Failed to find local %hs appdata directory.", fPerMachine ? "per-machine" : "per-user");
+    ExitOnFailure(hr, "Failed to find local %hs appdata directory.", fPerMachine ? "per-machine" : "per-user");
 
     for (DWORD iTag = 0; iTag < pSoftwareTags->cSoftwareTags; ++iTag)
     {
@@ -1430,37 +1430,37 @@ static HRESULT WriteUpdateRegistration(
     ExitOnFailure(hr, "Failed to create the key for update registration.");
 
     hr = RegWriteString(hkKey, L"ThisVersionInstalled", L"Y");
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"ThisVersionInstalled");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"ThisVersionInstalled");
 
     hr = RegWriteString(hkKey, L"PackageName", pRegistration->sczDisplayName);
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"PackageName");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"PackageName");
 
     hr = RegWriteString(hkKey, L"PackageVersion", pRegistration->sczDisplayVersion);
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"PackageVersion");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"PackageVersion");
 
     hr = RegWriteString(hkKey, L"Publisher", pRegistration->sczPublisher);
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"Publisher");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"Publisher");
 
     if (pRegistration->update.sczDepartment)
     {
         hr = RegWriteString(hkKey, L"PublishingGroup", pRegistration->update.sczDepartment);
-        ExitOnFailure1(hr, "Failed to write %ls value.", L"PublishingGroup");
+        ExitOnFailure(hr, "Failed to write %ls value.", L"PublishingGroup");
     }
 
     hr = RegWriteString(hkKey, L"ReleaseType", pRegistration->update.sczClassification);
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"ReleaseType");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"ReleaseType");
 
     hr = RegWriteStringVariable(hkKey, pVariables, VARIABLE_LOGONUSER, L"InstalledBy");
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"InstalledBy");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"InstalledBy");
 
     hr = RegWriteStringVariable(hkKey, pVariables, VARIABLE_DATE, L"InstalledDate");
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"InstalledDate");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"InstalledDate");
 
     hr = RegWriteStringVariable(hkKey, pVariables, VARIABLE_INSTALLERNAME, L"InstallerName");
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"InstallerName");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"InstallerName");
 
     hr = RegWriteStringVariable(hkKey, pVariables, VARIABLE_INSTALLERVERSION, L"InstallerVersion");
-    ExitOnFailure1(hr, "Failed to write %ls value.", L"InstallerVersion");
+    ExitOnFailure(hr, "Failed to write %ls value.", L"InstallerVersion");
 
 LExit:
     ReleaseRegKey(hkKey);
@@ -1507,7 +1507,7 @@ static HRESULT RemoveUpdateRegistration(
         hr = RegDelete(pRegistration->hkRoot, sczKey, REG_KEY_DEFAULT, FALSE);
         if (E_FILENOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed to remove update registration key: %ls", sczKey);
+            ExitOnFailure(hr, "Failed to remove update registration key: %ls", sczKey);
         }
     }
 
@@ -1529,10 +1529,10 @@ static HRESULT RegWriteStringVariable(
     LPWSTR sczValue = NULL;
 
     hr = VariableGetString(pVariables, wzVariable, &sczValue);
-    ExitOnFailure1(hr, "Failed to get the %ls variable.", wzVariable);
+    ExitOnFailure(hr, "Failed to get the %ls variable.", wzVariable);
 
     hr = RegWriteString(hk, wzName, sczValue);
-    ExitOnFailure1(hr, "Failed to write %ls value.", wzName);
+    ExitOnFailure(hr, "Failed to write %ls value.", wzName);
 
 LExit:
     StrSecureZeroFreeString(sczValue);

--- a/src/burn/engine/relatedbundle.cpp
+++ b/src/burn/engine/relatedbundle.cpp
@@ -117,7 +117,7 @@ static HRESULT LoadIfRelatedBundle(
     BOOTSTRAPPER_RELATION_TYPE relationType = BOOTSTRAPPER_RELATION_NONE;
 
     hr = RegOpen(hkUninstallKey, sczRelatedBundleId, KEY_READ, &hkBundleId);
-    ExitOnFailure1(hr, "Failed to open uninstall key for potential related bundle: %ls", sczRelatedBundleId);
+    ExitOnFailure(hr, "Failed to open uninstall key for potential related bundle: %ls", sczRelatedBundleId);
 
     hr = DetermineRelationType(hkBundleId, pRegistration, &relationType);
     if (FAILED(hr) || BOOTSTRAPPER_RELATION_NONE == relationType)
@@ -133,7 +133,7 @@ static HRESULT LoadIfRelatedBundle(
         BURN_RELATED_BUNDLE* pRelatedBundle = pRelatedBundles->rgRelatedBundles + pRelatedBundles->cRelatedBundles;
 
         hr = LoadRelatedBundleFromKey(sczRelatedBundleId, hkBundleId, fPerMachine, relationType, pRelatedBundle);
-        ExitOnFailure1(hr, "Failed to initialize package from related bundle id: %ls", sczRelatedBundleId);
+        ExitOnFailure(hr, "Failed to initialize package from related bundle id: %ls", sczRelatedBundleId);
 
         ++pRelatedBundles->cRelatedBundles;
     }
@@ -186,7 +186,7 @@ static HRESULT DetermineRelationType(
     if (SUCCEEDED(hr))
     {
         hr = DictCreateStringListFromArray(&sdUpgradeCodes, rgsczUpgradeCodes, cUpgradeCodes, DICT_FLAG_CASEINSENSITIVE);
-        ExitOnFailure1(hr, "Failed to create string dictionary for %hs.", "upgrade codes");
+        ExitOnFailure(hr, "Failed to create string dictionary for %hs.", "upgrade codes");
 
         // Upgrade relationship: when their upgrade codes match our upgrade codes.
         hr = DictCompareStringListToArray(sdUpgradeCodes, const_cast<LPCWSTR*>(pRegistration->rgsczUpgradeCodes), pRegistration->cUpgradeCodes);
@@ -253,7 +253,7 @@ static HRESULT DetermineRelationType(
     if (SUCCEEDED(hr))
     {
         hr = DictCreateStringListFromArray(&sdAddonCodes, rgsczAddonCodes, cAddonCodes, DICT_FLAG_CASEINSENSITIVE);
-        ExitOnFailure1(hr, "Failed to create string dictionary for %hs.", "addon codes");
+        ExitOnFailure(hr, "Failed to create string dictionary for %hs.", "addon codes");
 
         // Addon relationship: when their addon codes match our detect codes.
         hr = DictCompareStringListToArray(sdAddonCodes, const_cast<LPCWSTR*>(pRegistration->rgsczDetectCodes), pRegistration->cDetectCodes);
@@ -292,7 +292,7 @@ static HRESULT DetermineRelationType(
     if (SUCCEEDED(hr))
     {
         hr = DictCreateStringListFromArray(&sdPatchCodes, rgsczPatchCodes, cPatchCodes, DICT_FLAG_CASEINSENSITIVE);
-        ExitOnFailure1(hr, "Failed to create string dictionary for %hs.", "patch codes");
+        ExitOnFailure(hr, "Failed to create string dictionary for %hs.", "patch codes");
 
         // Patch relationship: when their patch codes match our detect codes.
         hr = DictCompareStringListToArray(sdPatchCodes, const_cast<LPCWSTR*>(pRegistration->rgsczDetectCodes), pRegistration->cDetectCodes);
@@ -331,7 +331,7 @@ static HRESULT DetermineRelationType(
     if (SUCCEEDED(hr))
     {
         hr = DictCreateStringListFromArray(&sdDetectCodes, rgsczDetectCodes, cDetectCodes, DICT_FLAG_CASEINSENSITIVE);
-        ExitOnFailure1(hr, "Failed to create string dictionary for %hs.", "detect codes");
+        ExitOnFailure(hr, "Failed to create string dictionary for %hs.", "detect codes");
 
         // Detect relationship: when their detect codes match our detect codes.
         hr = DictCompareStringListToArray(sdDetectCodes, const_cast<LPCWSTR*>(pRegistration->rgsczDetectCodes), pRegistration->cDetectCodes);
@@ -419,28 +419,28 @@ static HRESULT LoadRelatedBundleFromKey(
     }
 
     hr = RegReadVersion(hkBundleId, BURN_REGISTRATION_REGISTRY_BUNDLE_VERSION, &pRelatedBundle->qwVersion);
-    ExitOnFailure1(hr, "Failed to read version from registry for bundle: %ls", wzRelatedBundleId);
+    ExitOnFailure(hr, "Failed to read version from registry for bundle: %ls", wzRelatedBundleId);
 
     hr = RegReadString(hkBundleId, BURN_REGISTRATION_REGISTRY_BUNDLE_CACHE_PATH, &sczCachePath);
-    ExitOnFailure1(hr, "Failed to read cache path from registry for bundle: %ls", wzRelatedBundleId);
+    ExitOnFailure(hr, "Failed to read cache path from registry for bundle: %ls", wzRelatedBundleId);
 
     hr = FileSize(sczCachePath, reinterpret_cast<LONGLONG *>(&qwFileSize));
-    ExitOnFailure1(hr, "Failed to get size of pseudo bundle: %ls", sczCachePath);
+    ExitOnFailure(hr, "Failed to get size of pseudo bundle: %ls", sczCachePath);
 
     hr = RegReadString(hkBundleId, BURN_REGISTRATION_REGISTRY_BUNDLE_PROVIDER_KEY, &dependencyProvider.sczKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to read provider key from registry for bundle: %ls", wzRelatedBundleId);
+        ExitOnFailure(hr, "Failed to read provider key from registry for bundle: %ls", wzRelatedBundleId);
 
         dependencyProvider.fImported = TRUE;
 
         hr = FileVersionToStringEx(pRelatedBundle->qwVersion, &dependencyProvider.sczVersion);
-        ExitOnFailure1(hr, "Failed to copy version for bundle: %ls", wzRelatedBundleId);
+        ExitOnFailure(hr, "Failed to copy version for bundle: %ls", wzRelatedBundleId);
 
         hr = RegReadString(hkBundleId, BURN_REGISTRATION_REGISTRY_BUNDLE_DISPLAY_NAME, &dependencyProvider.sczDisplayName);
         if (E_FILENOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed to copy display name for bundle: %ls", wzRelatedBundleId);
+            ExitOnFailure(hr, "Failed to copy display name for bundle: %ls", wzRelatedBundleId);
         }
     }
 
@@ -449,7 +449,7 @@ static HRESULT LoadRelatedBundleFromKey(
     {
         hr = S_OK;
     }
-    ExitOnFailure1(hr, "Failed to read tag from registry for bundle: %ls", wzRelatedBundleId);
+    ExitOnFailure(hr, "Failed to read tag from registry for bundle: %ls", wzRelatedBundleId);
 
     pRelatedBundle->relationType = relationType;
 
@@ -458,7 +458,7 @@ static HRESULT LoadRelatedBundleFromKey(
                                 L"-quiet", L"-repair -quiet", L"-uninstall -quiet",
                                 (dependencyProvider.sczKey && *dependencyProvider.sczKey) ? &dependencyProvider : NULL,
                                 NULL, 0);
-    ExitOnFailure1(hr, "Failed to initialize related bundle to represent bundle: %ls", wzRelatedBundleId);
+    ExitOnFailure(hr, "Failed to initialize related bundle to represent bundle: %ls", wzRelatedBundleId);
 
 LExit:
     DependencyUninitialize(&dependencyProvider);

--- a/src/burn/engine/search.cpp
+++ b/src/burn/engine/search.cpp
@@ -138,7 +138,7 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, bstrNodeName, -1, L"FileSearch", -1))
@@ -168,7 +168,7 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, bstrNodeName, -1, L"RegistrySearch", -1))
@@ -198,7 +198,7 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Root: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Root: %ls", scz);
             }
 
             // @Key
@@ -256,13 +256,13 @@ extern "C" HRESULT SearchesParseFromXml(
                 else
                 {
                     hr = E_INVALIDARG;
-                    ExitOnFailure1(hr, "Invalid value for @VariableType: %ls", scz);
+                    ExitOnFailure(hr, "Invalid value for @VariableType: %ls", scz);
                 }
             }
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, bstrNodeName, -1, L"MsiComponentSearch", -1))
@@ -299,7 +299,7 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, bstrNodeName, -1, L"MsiProductSearch", -1))
@@ -355,7 +355,7 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, bstrNodeName, -1, L"MsiFeatureSearch", -1))
@@ -381,13 +381,13 @@ extern "C" HRESULT SearchesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else
         {
             hr = E_UNEXPECTED;
-            ExitOnFailure1(hr, "Unexpected element name: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Unexpected element name: %ls", bstrNodeName);
         }
 
         // prepare next iteration
@@ -423,11 +423,11 @@ extern "C" HRESULT SearchesExecute(
             hr = ConditionEvaluate(pVariables, pSearch->sczCondition, &f);
             if (E_INVALIDDATA == hr)
             {
-                TraceError2(hr, "Failed to parse search condition. Id = '%ls', Condition = '%ls'", pSearch->sczKey, pSearch->sczCondition);
+                TraceError(hr, "Failed to parse search condition. Id = '%ls', Condition = '%ls'", pSearch->sczKey, pSearch->sczCondition);
                 hr = S_OK;
                 continue;
             }
-            ExitOnFailure2(hr, "Failed to evaluate search condition. Id = '%ls', Condition = '%ls'", pSearch->sczKey, pSearch->sczCondition);
+            ExitOnFailure(hr, "Failed to evaluate search condition. Id = '%ls', Condition = '%ls'", pSearch->sczKey, pSearch->sczCondition);
 
             if (!f)
             {
@@ -494,7 +494,7 @@ extern "C" HRESULT SearchesExecute(
 
         if (FAILED(hr))
         {
-            TraceError1(hr, "Search failed. Id = '%ls'", pSearch->sczKey);
+            TraceError(hr, "Search failed. Id = '%ls'", pSearch->sczKey);
             continue;
         }
     }
@@ -580,7 +580,7 @@ static HRESULT DirectorySearchExists(
 
     // else must have found a file.
     // What if there is a hidden variable in sczPath?
-    ExitOnFailure2(hr, "Failed while searching directory search: %ls, for path: %ls", pSearch->sczKey, sczPath);
+    ExitOnFailure(hr, "Failed while searching directory search: %ls, for path: %ls", pSearch->sczKey, sczPath);
 
     // set variable
     hr = VariableSetNumeric(pVariables, pSearch->sczVariable, fExists, FALSE);
@@ -625,7 +625,7 @@ static HRESULT DirectorySearchPath(
         LogStringLine(REPORT_STANDARD, "Directory search: %ls, did not find path: %ls, reason: 0x%x", pSearch->sczKey, sczPath, hr);
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure2(hr, "Failed while searching directory search: %ls, for path: %ls", pSearch->sczKey, sczPath);
+    ExitOnFailure(hr, "Failed while searching directory search: %ls, for path: %ls", pSearch->sczKey, sczPath);
 
 LExit:
     StrSecureZeroFreeString(sczPath);
@@ -659,7 +659,7 @@ static HRESULT FileSearchExists(
         }
         else
         {
-            ExitOnWin32Error1(er, hr, "Failed get to file attributes. '%ls'", pSearch->DirectorySearch.sczPath);
+            ExitOnWin32Error(er, hr, "Failed get to file attributes. '%ls'", pSearch->DirectorySearch.sczPath);
         }
     }
     else if (FILE_ATTRIBUTE_DIRECTORY != (dwAttributes & FILE_ATTRIBUTE_DIRECTORY))
@@ -741,7 +741,7 @@ static HRESULT FileSearchPath(
         LogStringLine(REPORT_STANDARD, "File search: %ls, did not find path: %ls", pSearch->sczKey, sczPath);
         ExitFunction1(hr = S_OK);
     }
-    ExitOnFailure2(hr, "Failed while searching file search: %ls, for path: %ls", pSearch->sczKey, sczPath);
+    ExitOnFailure(hr, "Failed while searching file search: %ls, for path: %ls", pSearch->sczKey, sczPath);
 
 LExit:
     StrSecureZeroFreeString(sczPath);
@@ -788,7 +788,7 @@ static HRESULT RegistrySearchExists(
     else
     {
         // What if there is a hidden variable in sczKey?
-        ExitOnFailure1(hr, "Failed to open registry key. Key = '%ls'", sczKey);
+        ExitOnFailure(hr, "Failed to open registry key. Key = '%ls'", sczKey);
     }
 
     if (fExists && pSearch->RegistrySearch.sczValue)
@@ -936,7 +936,7 @@ static HRESULT RegistrySearchValue(
         hr = BVariantSetString(&value, (LPCWSTR)pData, 0);
         break;
     default:
-        ExitOnFailure1(hr = E_NOTIMPL, "Unsupported registry key value type. Type = '%u'", dwType);
+        ExitOnFailure(hr = E_NOTIMPL, "Unsupported registry key value type. Type = '%u'", dwType);
     }
     ExitOnFailure(hr, "Failed to read registry value.");
 
@@ -1006,7 +1006,7 @@ static HRESULT MsiComponentSearch(
     else if (INSTALLSTATE_ABSENT != is && INSTALLSTATE_LOCAL != is && INSTALLSTATE_SOURCE != is)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Failed to get component path: %d", is);
+        ExitOnFailure(hr, "Failed to get component path: %d", is);
     }
 
     // set variable
@@ -1078,7 +1078,7 @@ static HRESULT MsiProductSearch(
         wzProperty = INSTALLPROPERTY_ASSIGNMENTTYPE;
         break;
     default:
-        ExitOnFailure1(hr = E_NOTIMPL, "Unsupported product search type: %u", pSearch->MsiProductSearch.Type);
+        ExitOnFailure(hr = E_NOTIMPL, "Unsupported product search type: %u", pSearch->MsiProductSearch.Type);
     }
 
     // format guid string

--- a/src/burn/engine/section.cpp
+++ b/src/burn/engine/section.cpp
@@ -69,7 +69,7 @@ extern "C" HRESULT SectionInitialize(
     ExitOnFailure(hr, "Failed to get path to engine process.");
 
     pSection->hEngineFile = ::CreateFileW(sczPath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    ExitOnInvalidHandleWithLastError1(pSection->hEngineFile, hr, "Failed to open handle to engine process path: %ls", sczPath);
+    ExitOnInvalidHandleWithLastError(pSection->hEngineFile, hr, "Failed to open handle to engine process path: %ls", sczPath);
 
     //
     // First, make sure we have a valid DOS signature.
@@ -150,12 +150,12 @@ extern "C" HRESULT SectionInitialize(
         // read section
         if (!::ReadFile(pSection->hEngineFile, &sectionHeader, sizeof(IMAGE_SECTION_HEADER), &cbRead, NULL))
         {
-            ExitWithLastError1(hr, "Failed to read image section header, index: %u", i);
+            ExitWithLastError(hr, "Failed to read image section header, index: %u", i);
         }
         if (sizeof(IMAGE_SECTION_HEADER) > cbRead)
         {
             hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
-            ExitOnRootFailure1(hr, "Failed to read complete image section header, index: %u", i);
+            ExitOnRootFailure(hr, "Failed to read complete image section header, index: %u", i);
         }
 
         // compare header name
@@ -181,7 +181,7 @@ extern "C" HRESULT SectionInitialize(
     if (sizeof(BURN_SECTION_HEADER) > sectionHeader.SizeOfRawData)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
-        ExitOnRootFailure1(hr, "Failed to read section info, data to short: %u", sectionHeader.SizeOfRawData);
+        ExitOnRootFailure(hr, "Failed to read section info, data to short: %u", sectionHeader.SizeOfRawData);
     }
 
     // allocate buffer for section info
@@ -213,7 +213,7 @@ extern "C" HRESULT SectionInitialize(
     if (BURN_SECTION_VERSION != pBurnSectionHeader->dwVersion)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
-        ExitOnRootFailure1(hr, "Failed to read section info, unsupported version: %08x", pBurnSectionHeader->dwVersion);
+        ExitOnRootFailure(hr, "Failed to read section info, unsupported version: %08x", pBurnSectionHeader->dwVersion);
     }
 
     hr = FileSizeByHandle(pSection->hEngineFile, &llSize);
@@ -283,7 +283,7 @@ extern "C" HRESULT SectionGetAttachedContainerInfo(
     if (iContainerIndex >= pSection->cContainers)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
-        ExitOnRootFailure1(hr, "Failed to find container info, too few elements: %u", pSection->cContainers);
+        ExitOnRootFailure(hr, "Failed to find container info, too few elements: %u", pSection->cContainers);
     }
     else if (dwExpectedType != pSection->dwFormat)
     {

--- a/src/burn/engine/splashscreen.cpp
+++ b/src/burn/engine/splashscreen.cpp
@@ -98,7 +98,7 @@ extern "C" HRESULT SplashScreenDisplayError(
     hr = StrAllocFromError(&sczDisplayString, hrError, NULL);
     ExitOnFailure(hr, "Failed to allocate string to display error message");
 
-    Trace1(REPORT_STANDARD, "Error message displayed because: %ls", sczDisplayString);
+    Trace(REPORT_STANDARD, "Error message displayed because: %ls", sczDisplayString);
 
     if (BOOTSTRAPPER_DISPLAY_NONE == display || BOOTSTRAPPER_DISPLAY_PASSIVE == display || BOOTSTRAPPER_DISPLAY_EMBEDDED == display)
     {

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -281,7 +281,7 @@ extern "C" HRESULT VariableInitialize(
         BUILT_IN_VARIABLE_DECLARATION* pBuiltInVariable = &vrgBuiltInVariables[i];
 
         hr = AddBuiltInVariable(pVariables, pBuiltInVariable->wzVariable, pBuiltInVariable->pfnInitialize, pBuiltInVariable->dwpInitializeData, pBuiltInVariable->fPersist);
-        ExitOnFailure1(hr, "Failed to add built-in variable: %ls.", pBuiltInVariable->wzVariable);
+        ExitOnFailure(hr, "Failed to add built-in variable: %ls.", pBuiltInVariable->wzVariable);
     }
 
 LExit:
@@ -373,7 +373,7 @@ extern "C" HRESULT VariablesParseFromXml(
             else
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Invalid value for @Type: %ls", scz);
+                ExitOnFailure(hr, "Invalid value for @Type: %ls", scz);
             }
         }
         else
@@ -392,25 +392,25 @@ extern "C" HRESULT VariablesParseFromXml(
 
         // find existing variable
         hr = FindVariableIndexByName(pVariables, sczId, &iVariable);
-        ExitOnFailure1(hr, "Failed to find variable value '%ls'.", sczId);
+        ExitOnFailure(hr, "Failed to find variable value '%ls'.", sczId);
 
         // insert element if not found
         if (S_FALSE == hr)
         {
             hr = InsertVariable(pVariables, sczId, iVariable);
-            ExitOnFailure1(hr, "Failed to insert variable '%ls'.", sczId);
+            ExitOnFailure(hr, "Failed to insert variable '%ls'.", sczId);
         }
         else if (pVariables->rgVariables[iVariable].fBuiltIn)
         {
             hr = E_INVALIDARG;
-            ExitOnRootFailure1(hr, "Attempt to set built-in variable value: %ls", sczId);
+            ExitOnRootFailure(hr, "Attempt to set built-in variable value: %ls", sczId);
         }
         pVariables->rgVariables[iVariable].fHidden = fHidden;
         pVariables->rgVariables[iVariable].fPersisted = fPersisted;
 
         // update variable value
         hr = BVariantCopy(&value, &pVariables->rgVariables[iVariable].Value);
-        ExitOnFailure1(hr, "Failed to set value of variable: %ls", sczId);
+        ExitOnFailure(hr, "Failed to set value of variable: %ls", sczId);
 
         hr = BVariantSetEncryption(&pVariables->rgVariables[iVariable].Value, fHidden);
         ExitOnFailure(hr, "Failed to set variant encryption");
@@ -515,10 +515,10 @@ extern "C" HRESULT VariableGetNumeric(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value of variable: %ls", wzVariable);
 
     hr = BVariantGetNumeric(&pVariable->Value, pllValue);
-    ExitOnFailure1(hr, "Failed to get value as numeric for variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value as numeric for variable: %ls", wzVariable);
 
 LExit:
     ::LeaveCriticalSection(&pVariables->csAccess);
@@ -547,10 +547,10 @@ extern "C" HRESULT VariableGetString(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value of variable: %ls", wzVariable);
 
     hr = BVariantGetString(&pVariable->Value, psczValue);
-    ExitOnFailure1(hr, "Failed to get value as string for variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value as string for variable: %ls", wzVariable);
 
 LExit:
     ::LeaveCriticalSection(&pVariables->csAccess);
@@ -579,10 +579,10 @@ extern "C" HRESULT VariableGetVersion(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value of variable: %ls", wzVariable);
 
     hr = BVariantGetVersion(&pVariable->Value, pqwValue);
-    ExitOnFailure1(hr, "Failed to get value as version for variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value as version for variable: %ls", wzVariable);
 
 LExit:
     ::LeaveCriticalSection(&pVariables->csAccess);
@@ -606,10 +606,10 @@ extern "C" HRESULT VariableGetVariant(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get value of variable: %ls", wzVariable);
 
     hr = BVariantCopy(&pVariable->Value, pValue);
-    ExitOnFailure1(hr, "Failed to copy value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to copy value of variable: %ls", wzVariable);
 
 LExit:
     ::LeaveCriticalSection(&pVariables->csAccess);
@@ -639,7 +639,7 @@ extern "C" HRESULT VariableGetFormatted(
     {
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get variable: %ls", wzVariable);
 
     // Non-builtin strings may need to get expanded... non-strings and builtin
     // variables are never expanded.
@@ -648,12 +648,12 @@ extern "C" HRESULT VariableGetFormatted(
         hr = BVariantGetString(&pVariable->Value, &scz);
         ExitOnFailure(hr, "Failed to get unformatted string");
         hr = VariableFormatString(pVariables, scz, psczValue, NULL);
-        ExitOnFailure2(hr, "Failed to format value '%ls' of variable: %ls", pVariable->fHidden ? L"*****" : pVariable->Value.sczValue, wzVariable);
+        ExitOnFailure(hr, "Failed to format value '%ls' of variable: %ls", pVariable->fHidden ? L"*****" : pVariable->Value.sczValue, wzVariable);
     }
     else
     {
         hr = BVariantGetString(&pVariable->Value, psczValue);
-        ExitOnFailure1(hr, "Failed to get value as string for variable: %ls", wzVariable);
+        ExitOnFailure(hr, "Failed to get value as string for variable: %ls", wzVariable);
     }
 
 LExit:
@@ -1159,7 +1159,7 @@ static HRESULT FormatString(
                 if (fObfuscateHiddenVariables)
                 {
                     hr = IsVariableHidden(pVariables, scz, &fHidden);
-                    ExitOnFailure1(hr, "Failed to determine variable visibility: '%ls'.", scz);
+                    ExitOnFailure(hr, "Failed to determine variable visibility: '%ls'.", scz);
                 }
 
                 if (fHidden)
@@ -1323,7 +1323,7 @@ static HRESULT GetVariable(
     BURN_VARIABLE* pVariable = NULL;
 
     hr = FindVariableIndexByName(pVariables, wzVariable, &iVariable);
-    ExitOnFailure1(hr, "Failed to find variable value '%ls'.", wzVariable);
+    ExitOnFailure(hr, "Failed to find variable value '%ls'.", wzVariable);
 
     if (S_FALSE == hr)
     {
@@ -1336,7 +1336,7 @@ static HRESULT GetVariable(
     if (BURN_VARIANT_TYPE_NONE == pVariable->Value.Type && pVariable->fBuiltIn)
     {
         hr = pVariable->pfnInitialize(pVariable->dwpInitializeData, &pVariable->Value);
-        ExitOnFailure1(hr, "Failed to initialize built-in variable value '%ls'.", wzVariable);
+        ExitOnFailure(hr, "Failed to initialize built-in variable value '%ls'.", wzVariable);
     }
 
     *ppVariable = pVariable;
@@ -1459,13 +1459,13 @@ static HRESULT SetVariableValue(
     ::EnterCriticalSection(&pVariables->csAccess);
 
     hr = FindVariableIndexByName(pVariables, wzVariable, &iVariable);
-    ExitOnFailure1(hr, "Failed to find variable value '%ls'.", wzVariable);
+    ExitOnFailure(hr, "Failed to find variable value '%ls'.", wzVariable);
 
     // insert element if not found
     if (S_FALSE == hr)
     {
         hr = InsertVariable(pVariables, wzVariable, iVariable);
-        ExitOnFailure1(hr, "Failed to insert variable '%ls'.", wzVariable);
+        ExitOnFailure(hr, "Failed to insert variable '%ls'.", wzVariable);
     }
     else if (pVariables->rgVariables[iVariable].fBuiltIn) // built-in variables must be overridden
     {
@@ -1477,7 +1477,7 @@ static HRESULT SetVariableValue(
         else
         {
             hr = E_INVALIDARG;
-            ExitOnRootFailure1(hr, "Attempt to set built-in variable value: %ls", wzVariable);
+            ExitOnRootFailure(hr, "Attempt to set built-in variable value: %ls", wzVariable);
         }
     }
     else // must *not* be a built-in variable so caller should not have tried to override it as a built-in.
@@ -1529,7 +1529,7 @@ static HRESULT SetVariableValue(
 
     // update variable value
     hr = BVariantCopy(pVariant, &pVariables->rgVariables[iVariable].Value);
-    ExitOnFailure1(hr, "Failed to set value of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to set value of variable: %ls", wzVariable);
 
 LExit:
     ::LeaveCriticalSection(&pVariables->csAccess);
@@ -2232,7 +2232,7 @@ static HRESULT Get64bitFolderFromRegistry(
     ExitOnFailure(hr, "Failed to open Windows folder key.");
 
     hr = RegReadString(hkFolders, wzFolderValue, psczPath);
-    ExitOnFailure1(hr, "Failed to read folder path for '%ls'.", wzFolderValue);
+    ExitOnFailure(hr, "Failed to read folder path for '%ls'.", wzFolderValue);
 
     hr = PathBackslashTerminate(psczPath);
     ExitOnFailure(hr, "Failed to ensure path was backslash terminated.");
@@ -2263,7 +2263,7 @@ static HRESULT IsVariableHidden(
         hr = S_OK;
         ExitFunction();
     }
-    ExitOnFailure1(hr, "Failed to get visibility of variable: %ls", wzVariable);
+    ExitOnFailure(hr, "Failed to get visibility of variable: %ls", wzVariable);
 
     *pfHidden = pVariable->fHidden;
 

--- a/src/burn/engine/variant.cpp
+++ b/src/burn/engine/variant.cpp
@@ -431,7 +431,7 @@ static HRESULT BVariantEncryptString(
     if ((MAXDWORD - extraNeeded) < cbData)
     {
         hr = E_INVALIDDATA;
-        ExitOnFailure1(hr, "The string is too big: size %u", cbData);
+        ExitOnFailure(hr, "The string is too big: size %u", cbData);
     }
     else if (0 < extraNeeded)
     {

--- a/src/ext/BalExtension/mba/host/host.cpp
+++ b/src/ext/BalExtension/mba/host/host.cpp
@@ -273,7 +273,7 @@ static HRESULT CheckSupportedFrameworks(
     ExitOnFailure(hr, "Failed to initialize XML.");
 
     hr = XmlLoadDocumentFromFile(wzConfigPath, &pixdManifest);
-    ExitOnFailure1(hr, "Failed to load bootstrapper config file from path: %ls", wzConfigPath);
+    ExitOnFailure(hr, "Failed to load bootstrapper config file from path: %ls", wzConfigPath);
 
     hr = XmlSelectNodes(pixdManifest, L"/configuration/wix.bootstrapper/host/supportedFramework", &pNodeList);
     ExitOnFailure(hr, "Failed to select all supportedFramework elements.");
@@ -320,7 +320,7 @@ static HRESULT CheckSupportedFrameworks(
     if (fUpdatedManifest)
     {
         hr = XmlSaveDocument(pixdManifest, wzConfigPath);
-        ExitOnFailure1(hr, "Failed to save updated manifest over config file: %ls", wzConfigPath);
+        ExitOnFailure(hr, "Failed to save updated manifest over config file: %ls", wzConfigPath);
     }
 
 LExit:
@@ -377,7 +377,7 @@ static HRESULT UpdateSupportedRuntime(
     ExitOnFailure(hr, "Failed to create supportedRuntime element.");
 
     hr = XmlSetAttribute(pixnSupportedRuntime, L"version", sczSupportedRuntimeVersion);
-    ExitOnFailure1(hr, "Failed to set supportedRuntime/@version to '%ls'.", sczSupportedRuntimeVersion);
+    ExitOnFailure(hr, "Failed to set supportedRuntime/@version to '%ls'.", sczSupportedRuntimeVersion);
 
     *pfUpdatedManifest = TRUE;
 
@@ -434,7 +434,7 @@ static HRESULT GetCLRHost(
             ExitOnRootFailure(hr, "Failed to create instance of ICLRMetaHostPolicy.");
 
             hr = SHCreateStreamOnFileEx(wzConfigPath, STGM_READ | STGM_SHARE_DENY_WRITE, 0, FALSE, NULL, &pCfgStream);
-            ExitOnFailure1(hr, "Failed to load bootstrapper config file from path: %ls", wzConfigPath);
+            ExitOnFailure(hr, "Failed to load bootstrapper config file from path: %ls", wzConfigPath);
 
             hr = pCLRMetaHostPolicy->GetRequestedRuntime(METAHOST_POLICY_HIGHCOMPAT, NULL, pCfgStream, NULL, &cchVersion, NULL, NULL, NULL, IID_ICLRRuntimeInfo, reinterpret_cast<LPVOID*>(&pCLRRuntimeInfo));
             ExitOnRootFailure(hr, "Failed to get the CLR runtime info using the application configuration file path.");
@@ -571,7 +571,7 @@ static HRESULT CreatePrerequisiteBA(
     ExitOnNullWithLastError(hModule, hr, "Failed to load pre-requisite BA DLL.");
 
     PFN_MBAPREQ_BOOTSTRAPPER_APPLICATION_CREATE pfnCreate = reinterpret_cast<PFN_MBAPREQ_BOOTSTRAPPER_APPLICATION_CREATE>(::GetProcAddress(hModule, "MbaPrereqBootstrapperApplicationCreate"));
-    ExitOnNullWithLastError1(pfnCreate, hr, "Failed to get MbaPrereqBootstrapperApplicationCreate entry-point from: %ls", sczMbapreqPath);
+    ExitOnNullWithLastError(pfnCreate, hr, "Failed to get MbaPrereqBootstrapperApplicationCreate entry-point from: %ls", sczMbapreqPath);
 
     hr = pfnCreate(hrHostInitialization, pEngine, pCommand, &pApp);
     ExitOnFailure(hr, "Failed to create prequisite bootstrapper app.");

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -1154,10 +1154,10 @@ private: // privates
         LPCWSTR wzLocFileName = m_fPrereq ? L"mbapreq.wxl" : L"thm.wxl";
 
         hr = LocProbeForFile(wzModulePath, wzLocFileName, wzLanguage, &sczLocPath);
-        BalExitOnFailure2(hr, "Failed to probe for loc file: %ls in path: %ls", wzLocFileName, wzModulePath);
+        BalExitOnFailure(hr, "Failed to probe for loc file: %ls in path: %ls", wzLocFileName, wzModulePath);
 
         hr = LocLoadFromFile(sczLocPath, &m_pWixLoc);
-        BalExitOnFailure1(hr, "Failed to load loc file from path: %ls", sczLocPath);
+        BalExitOnFailure(hr, "Failed to load loc file from path: %ls", sczLocPath);
 
         if (WIX_LOCALIZATION_LANGUAGE_NOT_SET != m_pWixLoc->dwLangId)
         {
@@ -1168,7 +1168,7 @@ private: // privates
         ExitOnFailure(hr, "Failed to initialize confirm message loc identifier.");
 
         hr = LocLocalizeString(m_pWixLoc, &m_sczConfirmCloseMessage);
-        BalExitOnFailure1(hr, "Failed to localize confirm close message: %ls", m_sczConfirmCloseMessage);
+        BalExitOnFailure(hr, "Failed to localize confirm close message: %ls", m_sczConfirmCloseMessage);
 
     LExit:
         ReleaseStr(sczLocPath);
@@ -1188,13 +1188,13 @@ private: // privates
         LPWSTR sczCaption = NULL;
 
         hr = LocProbeForFile(wzModulePath, wzThemeFileName, wzLanguage, &sczThemePath);
-        BalExitOnFailure2(hr, "Failed to probe for theme file: %ls in path: %ls", wzThemeFileName, wzModulePath);
+        BalExitOnFailure(hr, "Failed to probe for theme file: %ls in path: %ls", wzThemeFileName, wzModulePath);
 
         hr = ThemeLoadFromFile(sczThemePath, &m_pTheme);
-        BalExitOnFailure1(hr, "Failed to load theme from path: %ls", sczThemePath);
+        BalExitOnFailure(hr, "Failed to load theme from path: %ls", sczThemePath);
 
         hr = ThemeLocalize(m_pTheme, m_pWixLoc);
-        BalExitOnFailure1(hr, "Failed to localize theme: %ls", sczThemePath);
+        BalExitOnFailure(hr, "Failed to localize theme: %ls", sczThemePath);
 
         // Update the caption if there are any formatted strings in it.
         // If the wix developer is showing a hidden variable in the UI, then obviously they don't care about keeping it safe
@@ -1249,7 +1249,7 @@ private: // privates
                 ExitOnFailure(hr, "Failed to get @Name.");
 
                 hr = DictAddKey(m_sdOverridableVariables, scz);
-                ExitOnFailure1(hr, "Failed to add \"%ls\" to the string dictionary.", scz);
+                ExitOnFailure(hr, "Failed to add \"%ls\" to the string dictionary.", scz);
 
                 // prepare next iteration
                 ReleaseNullObject(pNode);
@@ -1321,7 +1321,7 @@ private: // privates
         pPrereqPackage->sczPackageId = m_sczPrereqPackage;
         pPrereqPackage->fAlwaysInstall = TRUE;
         hr = DictAddValue(m_shPrereqSupportPackages, pPrereqPackage);
-        ExitOnFailure1(hr, "Failed to add \"%ls\" to the prerequisite package dictionary.", pPrereqPackage->sczPackageId);
+        ExitOnFailure(hr, "Failed to add \"%ls\" to the prerequisite package dictionary.", pPrereqPackage->sczPackageId);
 
         for (DWORD i = 0; i < cNodes; ++i)
         {
@@ -1344,7 +1344,7 @@ private: // privates
             }
             else if (E_NOTFOUND != hr)
             {
-                ExitOnFailure1(hr, "Failed to check if \"%ls\" was in the prerequisite package dictionary.", scz);
+                ExitOnFailure(hr, "Failed to check if \"%ls\" was in the prerequisite package dictionary.", scz);
             }
 
             hr = BalInfoFindPackageById(&m_Bundle.packages, scz, &pPackage);
@@ -1353,7 +1353,7 @@ private: // privates
                 pPrereqPackage = &m_rgPrereqPackages[i + 1];
                 pPrereqPackage->sczPackageId = pPackage->sczId;
                 hr = DictAddValue(m_shPrereqSupportPackages, pPrereqPackage);
-                ExitOnFailure1(hr, "Failed to add \"%ls\" to the prerequisite package dictionary.", pPrereqPackage->sczPackageId);
+                ExitOnFailure(hr, "Failed to add \"%ls\" to the prerequisite package dictionary.", pPrereqPackage->sczPackageId);
             }
             else
             {
@@ -2496,15 +2496,15 @@ private: // privates
         URI_PROTOCOL protocol = URI_PROTOCOL_UNKNOWN;
 
         hr = StrAllocString(&sczLicenseUrl, m_sczLicenseUrl, 0);
-        BalExitOnFailure1(hr, "Failed to copy license URL: %ls", m_sczLicenseUrl);
+        BalExitOnFailure(hr, "Failed to copy license URL: %ls", m_sczLicenseUrl);
 
         hr = LocLocalizeString(m_pWixLoc, &sczLicenseUrl);
-        BalExitOnFailure1(hr, "Failed to localize license URL: %ls", m_sczLicenseUrl);
+        BalExitOnFailure(hr, "Failed to localize license URL: %ls", m_sczLicenseUrl);
         
         // Assume there is no hidden variables to be formatted
         // so don't worry about securely freeing it.
         hr = BalFormatString(sczLicenseUrl, &sczLicenseUrl);
-        BalExitOnFailure1(hr, "Failed to get formatted license URL: %ls", m_sczLicenseUrl);
+        BalExitOnFailure(hr, "Failed to get formatted license URL: %ls", m_sczLicenseUrl);
 
         hr = UriProtocol(sczLicenseUrl, &protocol);
         if (FAILED(hr) || URI_PROTOCOL_UNKNOWN == protocol)
@@ -2548,21 +2548,21 @@ private: // privates
         int nCmdShow = SW_SHOWNORMAL;
 
         hr = BalGetStringVariable(WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH, &sczUnformattedLaunchTarget);
-        BalExitOnFailure1(hr, "Failed to get launch target variable '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH);
+        BalExitOnFailure(hr, "Failed to get launch target variable '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH);
 
         hr = BalFormatString(sczUnformattedLaunchTarget, &sczLaunchTarget);
-        BalExitOnFailure1(hr, "Failed to format launch target variable: %ls", sczUnformattedLaunchTarget);
+        BalExitOnFailure(hr, "Failed to format launch target variable: %ls", sczUnformattedLaunchTarget);
 
         if (BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_TARGET_ELEVATED_ID))
         {
             hr = BalGetStringVariable(WIXSTDBA_VARIABLE_LAUNCH_TARGET_ELEVATED_ID, &sczLaunchTargetElevatedId);
-            BalExitOnFailure1(hr, "Failed to get launch target elevated id '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_TARGET_ELEVATED_ID);
+            BalExitOnFailure(hr, "Failed to get launch target elevated id '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_TARGET_ELEVATED_ID);
         }
 
         if (BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_ARGUMENTS))
         {
             hr = BalGetStringVariable(WIXSTDBA_VARIABLE_LAUNCH_ARGUMENTS, &sczUnformattedArguments);
-            BalExitOnFailure1(hr, "Failed to get launch arguments '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_ARGUMENTS);
+            BalExitOnFailure(hr, "Failed to get launch arguments '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_ARGUMENTS);
         }
 
         if (BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_HIDDEN))
@@ -2587,11 +2587,11 @@ private: // privates
             if (sczUnformattedArguments)
             {
                 hr = BalFormatString(sczUnformattedArguments, &sczArguments);
-                BalExitOnFailure1(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
+                BalExitOnFailure(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
             }
 
             hr = ShelExec(sczLaunchTarget, sczArguments, L"open", NULL, nCmdShow, m_hWnd, NULL);
-            BalExitOnFailure1(hr, "Failed to launch target: %ls", sczLaunchTarget);
+            BalExitOnFailure(hr, "Failed to launch target: %ls", sczLaunchTarget);
 
             ::PostMessageW(m_hWnd, WM_CLOSE, 0, 0);
         }
@@ -2630,10 +2630,10 @@ private: // privates
         LPWSTR sczLogFile = NULL;
 
         hr = BalGetStringVariable(m_Bundle.sczLogVariable, &sczLogFile);
-        BalExitOnFailure1(hr, "Failed to get log file variable '%ls'.", m_Bundle.sczLogVariable);
+        BalExitOnFailure(hr, "Failed to get log file variable '%ls'.", m_Bundle.sczLogVariable);
 
         hr = ShelExec(L"notepad.exe", sczLogFile, L"open", NULL, SW_SHOWDEFAULT, m_hWnd, NULL);
-        BalExitOnFailure1(hr, "Failed to open log file target: %ls", sczLogFile);
+        BalExitOnFailure(hr, "Failed to open log file target: %ls", sczLogFile);
 
     LExit:
         ReleaseStr(sczLogFile);
@@ -2784,7 +2784,7 @@ private: // privates
 
                 hr = E_WIXSTDBA_CONDITION_FAILED;
                 // todo: remove in WiX v4, in case people are relying on v3.x logging behavior
-                BalExitOnFailure1(hr, "Bundle condition evaluated to false: %ls", pCondition->sczCondition);
+                BalExitOnFailure(hr, "Bundle condition evaluated to false: %ls", pCondition->sczCondition);
             }
         }
 
@@ -2804,7 +2804,7 @@ private: // privates
         if (m_fTaskbarButtonOK)
         {
             hr = m_pTaskbarList->SetProgressValue(m_hWnd, dwOverallPercentage, 100UL);
-            BalExitOnFailure1(hr, "Failed to set taskbar button progress to: %d%%.", dwOverallPercentage);
+            BalExitOnFailure(hr, "Failed to set taskbar button progress to: %d%%.", dwOverallPercentage);
         }
 
     LExit:
@@ -2821,7 +2821,7 @@ private: // privates
         if (m_fTaskbarButtonOK)
         {
             hr = m_pTaskbarList->SetProgressState(m_hWnd, tbpFlags);
-            BalExitOnFailure1(hr, "Failed to set taskbar button state.", tbpFlags);
+            BalExitOnFailure(hr, "Failed to set taskbar button state.", tbpFlags);
         }
 
     LExit:
@@ -2864,7 +2864,7 @@ private: // privates
         if (m_hBAFModule)
         {
             PFN_BOOTSTRAPPER_BA_FUNCTION_CREATE pfnBAFunctionCreate = reinterpret_cast<PFN_BOOTSTRAPPER_BA_FUNCTION_CREATE>(::GetProcAddress(m_hBAFModule, "CreateBootstrapperBAFunction"));
-            BalExitOnNullWithLastError1(pfnBAFunctionCreate, hr, "Failed to get CreateBootstrapperBAFunction entry-point from: %ls", sczBafPath);
+            BalExitOnNullWithLastError(pfnBAFunctionCreate, hr, "Failed to get CreateBootstrapperBAFunction entry-point from: %ls", sczBafPath);
 
             hr = pfnBAFunctionCreate(m_pEngine, m_hBAFModule, &m_pBAFunction);
             BalExitOnFailure(hr, "Failed to create BA function.");

--- a/src/ext/ComPlusExtension/ca/cpexec/cpappexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cpappexec.cpp
@@ -92,11 +92,11 @@ HRESULT CpiConfigureApplications(
         {
         case atCreate:
             hr = CreateApplication(&attrs);
-            ExitOnFailure1(hr, "Failed to create application, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create application, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemoveApplication(&attrs);
-            ExitOnFailure1(hr, "Failed to remove application, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove application, key: %S", attrs.pwzKey);
             break;
         }
 

--- a/src/ext/ComPlusExtension/ca/cpexec/cpapproleexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cpapproleexec.cpp
@@ -116,11 +116,11 @@ HRESULT CpiConfigureApplicationRoles(
         {
         case atCreate:
             hr = CreateApplicationRole(&attrs);
-            ExitOnFailure1(hr, "Failed to create application role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create application role, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemoveApplicationRole(&attrs);
-            ExitOnFailure1(hr, "Failed to remove application role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove application role, key: %S", attrs.pwzKey);
             break;
         }
 
@@ -260,11 +260,11 @@ HRESULT CpiConfigureUsersInApplicationRoles(
         {
         case atCreate:
             hr = CreateUsersInApplicationRole(&attrs);
-            ExitOnFailure1(hr, "Failed to create user in application role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create user in application role, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemoveUsersInApplicationRole(&attrs);
-            ExitOnFailure1(hr, "Failed to remove user from application role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove user from application role, key: %S", attrs.pwzKey);
             break;
         }
 

--- a/src/ext/ComPlusExtension/ca/cpexec/cpasmexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cpasmexec.cpp
@@ -321,11 +321,11 @@ HRESULT CpiConfigureAssemblies(
         {
         case atCreate:
             hr = RegisterAssembly(&attrs);
-            ExitOnFailure1(hr, "Failed to register assembly, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to register assembly, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = UnregisterAssembly(&attrs);
-            ExitOnFailure1(hr, "Failed to unregister assembly, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to unregister assembly, key: %S", attrs.pwzKey);
             break;
         default:
             hr = S_OK;
@@ -1557,7 +1557,7 @@ static HRESULT ConfigureRoleAssignments(
         {
             // find existing role
             hr = CpiFindCollectionObjectByName(piRoleColl, pItm->wzRoleName, NULL);
-            ExitOnFailure1(hr, "Failed to find role, key: %S", pItm->wzKey);
+            ExitOnFailure(hr, "Failed to find role, key: %S", pItm->wzKey);
 
             if (S_OK == hr)
                 continue; // role already exists
@@ -1568,7 +1568,7 @@ static HRESULT ConfigureRoleAssignments(
 
             // role name
             hr = CpiPutCollectionObjectValue(piRoleObj, L"Name", pItm->wzRoleName);
-            ExitOnFailure1(hr, "Failed to set role name property, key: %S", pItm->wzKey);
+            ExitOnFailure(hr, "Failed to set role name property, key: %S", pItm->wzKey);
 
             // clean up
             ReleaseNullObject(piRoleObj);
@@ -1577,7 +1577,7 @@ static HRESULT ConfigureRoleAssignments(
         {
             // remove role
             hr = CpiRemoveCollectionObject(piRoleColl, NULL, pItm->wzRoleName, FALSE);
-            ExitOnFailure1(hr, "Failed to remove role, key: %S", pItm->wzKey);
+            ExitOnFailure(hr, "Failed to remove role, key: %S", pItm->wzKey);
         }
     }
 

--- a/src/ext/ComPlusExtension/ca/cpexec/cpexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cpexec.cpp
@@ -62,7 +62,7 @@ extern "C" UINT __stdcall ComPlusPrepare(MSIHANDLE hInstall)
     // create rollback file
     hRollbackFile = ::CreateFileW(pwzData, GENERIC_WRITE, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to create rollback file, name: %S", pwzData);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to create rollback file, name: %S", pwzData);
 
     hr = S_OK;
 
@@ -156,7 +156,7 @@ extern "C" UINT __stdcall ComPlusInstallExecute(MSIHANDLE hInstall)
 
     hRollbackFile = ::CreateFileW(pwzRollbackFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
 
     // create partitions
     hr = CpiConfigurePartitions(&pwzData, hRollbackFile);
@@ -262,7 +262,7 @@ extern "C" UINT __stdcall ComPlusInstallExecuteCommit(MSIHANDLE hInstall)
 
     hRollbackFile = ::CreateFileW(pwzRollbackFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
 
     if (INVALID_SET_FILE_POINTER == ::SetFilePointer(hRollbackFile, 0, NULL, FILE_END))
         ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to set file pointer");
@@ -350,7 +350,7 @@ extern "C" UINT __stdcall ComPlusRollbackInstallExecute(MSIHANDLE hInstall)
 
     hRollbackFile = ::CreateFileW(pwzRollbackFileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
 
     // read rollback data (execute)
     hr = CpiReadRollbackDataList(hRollbackFile, &prdPartitions);
@@ -497,7 +497,7 @@ extern "C" UINT __stdcall ComPlusUninstallExecute(MSIHANDLE hInstall)
 
     hRollbackFile = ::CreateFileW(pwzRollbackFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
 
     // delete subscriptions
     hr = CpiConfigureSubscriptions(&pwzData, hRollbackFile);
@@ -613,7 +613,7 @@ extern "C" UINT __stdcall ComPlusRollbackUninstallExecute(MSIHANDLE hInstall)
 
     hRollbackFile = ::CreateFileW(pwzRollbackFileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_TEMPORARY, NULL);
     if (INVALID_HANDLE_VALUE == hRollbackFile)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(::GetLastError()), "Failed to open rollback file, name: %S", pwzRollbackFileName);
 
     // read rollback data
     hr = CpiReadRollbackDataList(hRollbackFile, &prdSubscriptions);

--- a/src/ext/ComPlusExtension/ca/cpexec/cppartexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cppartexec.cpp
@@ -113,11 +113,11 @@ HRESULT CpiConfigurePartitions(
         {
         case atCreate:
             hr = CreatePartition(&attrs);
-            ExitOnFailure1(hr, "Failed to create partition, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create partition, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemovePartition(&attrs);
-            ExitOnFailure1(hr, "Failed to remove partition, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove partition, key: %S", attrs.pwzKey);
             break;
         }
 
@@ -257,11 +257,11 @@ HRESULT CpiConfigurePartitionUsers(
         {
         case atCreate:
             hr = CreatePartitionUser(&attrs);
-            ExitOnFailure1(hr, "Failed to create partition user, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create partition user, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemovePartitionUser(&attrs);
-            ExitOnFailure1(hr, "Failed to remove partition user, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove partition user, key: %S", attrs.pwzKey);
             break;
         }
 
@@ -328,11 +328,11 @@ HRESULT CpiRollbackConfigurePartitionUsers(
         {
         case atCreate:
             hr = CreatePartitionUser(&attrs);
-            ExitOnFailure1(hr, "Failed to create partition user, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create partition user, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemovePartitionUser(&attrs);
-            ExitOnFailure1(hr, "Failed to remove partition user, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove partition user, key: %S", attrs.pwzKey);
             break;
         }
 

--- a/src/ext/ComPlusExtension/ca/cpexec/cppartroleexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cppartroleexec.cpp
@@ -91,11 +91,11 @@ HRESULT CpiConfigureUsersInPartitionRoles(
         {
         case atCreate:
             hr = CreateUserInPartitionRole(&attrs);
-            ExitOnFailure1(hr, "Failed to add user to partition role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to add user to partition role, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemoveUserInPartitionRole(&attrs);
-            ExitOnFailure1(hr, "Failed to remove user from partition role, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove user from partition role, key: %S", attrs.pwzKey);
             break;
         }
 

--- a/src/ext/ComPlusExtension/ca/cpexec/cpsubsexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cpsubsexec.cpp
@@ -96,11 +96,11 @@ HRESULT CpiConfigureSubscriptions(
         {
         case atCreate:
             hr = CreateSubscription(&attrs);
-            ExitOnFailure1(hr, "Failed to create subscription, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to create subscription, key: %S", attrs.pwzKey);
             break;
         case atRemove:
             hr = RemoveSubscription(&attrs);
-            ExitOnFailure1(hr, "Failed to remove subscription, key: %S", attrs.pwzKey);
+            ExitOnFailure(hr, "Failed to remove subscription, key: %S", attrs.pwzKey);
             break;
         }
 
@@ -331,7 +331,7 @@ static HRESULT CreateSubscription(
                         }
                     }
                     else
-                        ExitOnFailure1(hr, "Failed to get SID for account, account: '%S'", pItm->pwzValue);
+                        ExitOnFailure(hr, "Failed to get SID for account, account: '%S'", pItm->pwzValue);
                 }
                 else if (FAILED(hr))
                 {
@@ -350,7 +350,7 @@ static HRESULT CreateSubscription(
 
         // set property
         hr = CpiPutCollectionObjectValue(piSubsObj, pItm->wzName, pItm->pwzValue);
-        ExitOnFailure1(hr, "Failed to set object property value, name: %S", pItm->wzName);
+        ExitOnFailure(hr, "Failed to set object property value, name: %S", pItm->wzName);
     }
 
     // save changes

--- a/src/ext/ComPlusExtension/ca/cpexec/cputilexec.cpp
+++ b/src/ext/ComPlusExtension/ca/cpexec/cputilexec.cpp
@@ -462,7 +462,7 @@ HRESULT CpiPutCollectionObjectValues(
     {
         // set property
         hr = CpiPutCollectionObjectValue(piObj, pItm->wzName, pItm->pwzValue);
-        ExitOnFailure1(hr, "Failed to set object property value, name: %S", pItm->wzName);
+        ExitOnFailure(hr, "Failed to set object property value, name: %S", pItm->wzName);
     }
 
     hr = S_OK;
@@ -1783,14 +1783,14 @@ static HRESULT CreateSidFromDomainRidPair(
         if (ccb < dwLengthRequired)
         {
             pSid = (PSID)::HeapReAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, *ppSid, dwLengthRequired);
-            ExitOnNull1(pSid, hr, E_OUTOFMEMORY, "Failed to reallocate buffer for SID, len: %d", dwLengthRequired);
+            ExitOnNull(pSid, hr, E_OUTOFMEMORY, "Failed to reallocate buffer for SID, len: %d", dwLengthRequired);
             *ppSid = pSid;
         }
     }
     else
     {
         *ppSid = (PSID)::HeapAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, dwLengthRequired);
-        ExitOnNull1(*ppSid, hr, E_OUTOFMEMORY, "Failed to allocate buffer for SID, len: %d", dwLengthRequired);
+        ExitOnNull(*ppSid, hr, E_OUTOFMEMORY, "Failed to allocate buffer for SID, len: %d", dwLengthRequired);
     }
 
     ::InitializeSid(*ppSid, ::GetSidIdentifierAuthority(pDomainSid), ucSubAuthorityCount + (UCHAR)1);

--- a/src/ext/ComPlusExtension/ca/cpsched/cpapprolesched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cpapprolesched.cpp
@@ -152,7 +152,7 @@ HRESULT CpiApplicationRolesRead(
         hr = CpiApplicationFindByKey(pAppList, pwzData, &pItm->pApplication);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find application, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find application, key: %S", pwzData);
 
         // get name
         hr = WcaGetRecordFormattedString(hRec, arqName, &pwzData);
@@ -218,7 +218,7 @@ HRESULT CpiApplicationRolesVerifyInstall(
 
         // if the role is referensed and is not a locater, it must be installed
         if (pItm->fReferencedForInstall && pItm->fHasComponent && !CpiWillBeInstalled(pItm->isInstalled, pItm->isAction))
-            MessageExitOnFailure1(hr = E_FAIL, msierrComPlusApplicationRoleDependency, "An application role is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
+            MessageExitOnFailure(hr = E_FAIL, msierrComPlusApplicationRoleDependency, "An application role is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
 
         // role is a locater
         if (!pItm->fHasComponent)
@@ -229,7 +229,7 @@ HRESULT CpiApplicationRolesVerifyInstall(
 
             // if the role was not found
             if (S_FALSE == hr)
-                MessageExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusApplicationRoleNotFound, "An application role required by this installation was not found, key: %S", pItm->wzKey);
+                MessageExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusApplicationRoleNotFound, "An application role required by this installation was not found, key: %S", pItm->wzKey);
         }
 
         // role is supposed to be created
@@ -246,7 +246,7 @@ HRESULT CpiApplicationRolesVerifyInstall(
                     switch (er)
                     {
                     case IDABORT:
-                        ExitOnFailure1(hr = E_FAIL, "An application with a conflictiong name exists, key: %S", pItm->wzKey);
+                        ExitOnFailure(hr = E_FAIL, "An application with a conflictiong name exists, key: %S", pItm->wzKey);
                         break;
                     case IDRETRY:
                         break;
@@ -357,7 +357,7 @@ HRESULT CpiApplicationRolesInstall(
 
         // add to action data
         hr = AddApplicationRoleToActionData(pItm, iActionType, COST_APPLICATION_ROLE_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add application role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add application role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -404,7 +404,7 @@ HRESULT CpiApplicationRolesUninstall(
 
         // add to action data
         hr = AddApplicationRoleToActionData(pItm, iActionType, COST_APPLICATION_ROLE_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add application role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add application role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -515,7 +515,7 @@ HRESULT CpiUsersInApplicationRolesInstall(
 
         // add to action data
         hr = AddUserInApplicationRoleToActionData(pItm, iActionType, COST_USER_IN_APPLICATION_ROLE_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add user in application role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add user in application role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -562,7 +562,7 @@ HRESULT CpiUsersInApplicationRolesUninstall(
 
         // add to action data
         hr = AddUserInApplicationRoleToActionData(pItm, iActionType, COST_USER_IN_APPLICATION_ROLE_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add user in application role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add user in application role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -635,7 +635,7 @@ static HRESULT TrusteesInApplicationRolesRead(
         hr = CpiApplicationRoleFindByKey(pAppRoleList, pwzData, &pItm->pApplicationRole);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find application role, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find application role, key: %S", pwzData);
 
         // get user domain
         hr = WcaGetRecordFormattedString(hRec, tiarqDomain, &pwzDomain);

--- a/src/ext/ComPlusExtension/ca/cpsched/cpappsched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cpappsched.cpp
@@ -180,7 +180,7 @@ HRESULT CpiApplicationsRead(
             if (pwzData && *pwzData)
             {
                 hr = CpiPartitionFindByKey(pPartList, pwzData, &pItm->pPartition);
-                ExitOnFailure1(hr, "Failed to find partition, key: %S", pwzData);
+                ExitOnFailure(hr, "Failed to find partition, key: %S", pwzData);
             }
         }
 
@@ -191,7 +191,7 @@ HRESULT CpiApplicationsRead(
         if (pwzData && *pwzData)
         {
             hr = PcaGuidToRegFormat(pwzData, pItm->wzID, countof(pItm->wzID));
-            ExitOnFailure2(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
+            ExitOnFailure(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
         }
 
         // get name
@@ -201,11 +201,11 @@ HRESULT CpiApplicationsRead(
 
         // if application is a locater, either an id or a name must be provided
         if (!pItm->fHasComponent && !*pItm->wzID && !*pItm->wzName)
-            ExitOnFailure1(hr = E_FAIL, "An application locater must have either an id or a name associated, key: %S", pItm->wzKey);
+            ExitOnFailure(hr = E_FAIL, "An application locater must have either an id or a name associated, key: %S", pItm->wzKey);
 
         // if application is not a locater, an name must be provided
         if (pItm->fHasComponent && !*pItm->wzName)
-            ExitOnFailure1(hr = E_FAIL, "An application must have a name associated, key: %S", pItm->wzKey);
+            ExitOnFailure(hr = E_FAIL, "An application must have a name associated, key: %S", pItm->wzKey);
 
         // get properties
         if (CpiTableExists(cptComPlusApplicationProperty) && pItm->fHasComponent)
@@ -268,7 +268,7 @@ HRESULT CpiApplicationsVerifyInstall(
 
         // if the application is referensed and is not a locater, it must be installed
         if (pItm->fReferencedForInstall && pItm->fHasComponent && !CpiWillBeInstalled(pItm->isInstalled, pItm->isAction))
-            MessageExitOnFailure1(hr = E_FAIL, msierrComPlusApplicationDependency, "An application is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
+            MessageExitOnFailure(hr = E_FAIL, msierrComPlusApplicationDependency, "An application is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
 
         // application is supposed to exist
         if (!pItm->fHasComponent || CpiIsInstalled(pItm->isInstalled))
@@ -293,7 +293,7 @@ HRESULT CpiApplicationsVerifyInstall(
             {
                 // if the application is a locater, this is an error
                 if (!pItm->fHasComponent)
-                    MessageExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusApplicationNotFound, "An application required by this installation was not found, key: %S", pItm->wzKey);
+                    MessageExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusApplicationNotFound, "An application required by this installation was not found, key: %S", pItm->wzKey);
 
                 // create a new id if one is missing
                 if (!*pItm->wzID)
@@ -348,7 +348,7 @@ HRESULT CpiApplicationsVerifyInstall(
                 {
                 case IDCANCEL:
                 case IDABORT:
-                    ExitOnFailure1(hr = E_FAIL, "An application with a conflictiong name or id exists, key: %S", pItm->wzKey);
+                    ExitOnFailure(hr = E_FAIL, "An application with a conflictiong name or id exists, key: %S", pItm->wzKey);
                     break;
                 case IDRETRY:
                     break;
@@ -491,7 +491,7 @@ HRESULT CpiApplicationsInstall(
 
         // add to action data
         hr = AddApplicationToActionData(pItm, iActionType, COST_APPLICATION_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add applicaton to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add applicaton to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -538,7 +538,7 @@ HRESULT CpiApplicationsUninstall(
 
         // add to action data
         hr = AddApplicationToActionData(pItm, iActionType, COST_APPLICATION_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add applicaton to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add applicaton to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics

--- a/src/ext/ComPlusExtension/ca/cpsched/cpasmsched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cpasmsched.cpp
@@ -421,7 +421,7 @@ HRESULT CpiAssembliesVerifyInstall(
 
         // if the assembly is referensed, it must be installed
         if ((pItm->fReferencedForInstall || pItm->iRoleAssignmentsInstallCount) && !CpiWillBeInstalled(pItm->isInstalled, pItm->isAction))
-            MessageExitOnFailure1(hr = E_FAIL, msierrComPlusAssemblyDependency, "An assembly is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
+            MessageExitOnFailure(hr = E_FAIL, msierrComPlusAssemblyDependency, "An assembly is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
     }
 
     hr = S_OK;
@@ -516,7 +516,7 @@ HRESULT CpiAssembliesInstall(
 
         // add to action data
         hr = AddAssemblyToActionData(pItm, TRUE, iActionType, COST_ASSEMBLY_REGISTER, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -563,7 +563,7 @@ HRESULT CpiAssembliesUninstall(
 
         // add to action data
         hr = AddAssemblyToActionData(pItm, FALSE, iActionType, COST_ASSEMBLY_UNREGISTER, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -635,7 +635,7 @@ HRESULT CpiRoleAssignmentsInstall(
 
         // add to action data
         hr = AddRoleAssignmentsToActionData(pItm, TRUE, iActionType, COST_ROLLASSIGNMENT_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
 
         // add progress tics
         if (piProgress)
@@ -682,7 +682,7 @@ HRESULT CpiRoleAssignmentsUninstall(
 
         // add to action data
         hr = AddRoleAssignmentsToActionData(pItm, FALSE, iActionType, COST_ROLLASSIGNMENT_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add assembly to custom action data, key: %S", pItm->wzKey);
 
         // add progress tics
         if (piProgress)
@@ -1015,7 +1015,7 @@ static HRESULT AssembliesRead(
             hr = CpiApplicationFindByKey(pAppList, pwzData, &pItm->pApplication);
             if (S_FALSE == hr)
                 hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-            ExitOnFailure1(hr, "Failed to find application, key: %S", pwzData);
+            ExitOnFailure(hr, "Failed to find application, key: %S", pwzData);
         }
 
         // get tlb path
@@ -1134,7 +1134,7 @@ static HRESULT SwapDependentModules(
                 if (0 == lstrcmpW(pdcItm->pwzKey, pDep->wzSecondKey))
                 {
                     // circular dependency found
-                    ExitOnFailure1(hr = E_FAIL, "Circular module dependency found, key: %S", pDep->wzSecondKey);
+                    ExitOnFailure(hr = E_FAIL, "Circular module dependency found, key: %S", pDep->wzSecondKey);
                 }
             }
 
@@ -1150,7 +1150,7 @@ static HRESULT SwapDependentModules(
             if (S_FALSE == hr)
             {
                 // not found
-                ExitOnFailure1(hr = E_FAIL, "Module dependency not found, key: %S", pDep->wzSecondKey);
+                ExitOnFailure(hr = E_FAIL, "Module dependency not found, key: %S", pDep->wzSecondKey);
             }
 
             // if this item in turn has dependencies, they have to be swaped first
@@ -1297,7 +1297,7 @@ static HRESULT SwapDependentAssemblies(
                 if (0 == lstrcmpW(pdcItm->pwzKey, pDep->wzSecondKey))
                 {
                     // circular dependency found
-                    ExitOnFailure1(hr = E_FAIL, "Circular assembly dependency found, key: %S", pDep->wzSecondKey);
+                    ExitOnFailure(hr = E_FAIL, "Circular assembly dependency found, key: %S", pDep->wzSecondKey);
                 }
             }
 
@@ -1313,14 +1313,14 @@ static HRESULT SwapDependentAssemblies(
             if (S_FALSE == hr)
             {
                 // not found
-                ExitOnFailure1(hr = E_FAIL, "Assembly dependency not found, key: %S", pDep->wzSecondKey);
+                ExitOnFailure(hr = E_FAIL, "Assembly dependency not found, key: %S", pDep->wzSecondKey);
             }
 
             // if the root item belongs to a module, this item must also belong to the same module
             if (*pItm->wzModule)
             {
                 if (0 != lstrcmpW(pDepItm->wzModule, pItm->wzModule))
-                    ExitOnFailure2(hr = E_FAIL, "An assembly dependency can only exist between two assemblies not belonging to modules, or belonging to the same module. assembly: %S, required assembly: %S", pItm->wzKey, pDepItm->wzKey);
+                    ExitOnFailure(hr = E_FAIL, "An assembly dependency can only exist between two assemblies not belonging to modules, or belonging to the same module. assembly: %S, required assembly: %S", pItm->wzKey, pDepItm->wzKey);
             }
 
             // if this item in turn has dependencies, they have to be swaped first
@@ -1600,7 +1600,7 @@ static HRESULT MethodsRead(
 
         // either an index or a name must be provided
         if (!*pItm->wzIndex && !*pItm->wzName)
-            ExitOnFailure1(hr = E_FAIL, "A method must have either an index or a name associated, key: %S", pItm->wzKey);
+            ExitOnFailure(hr = E_FAIL, "A method must have either an index or a name associated, key: %S", pItm->wzKey);
 
         // read properties
         if (CpiTableExists(cptComPlusMethodProperty))
@@ -1708,7 +1708,7 @@ static HRESULT RoleAssignmentsRead(
         hr = CpiApplicationRoleFindByKey(pAppRoleList, pwzData, &pItm->pApplicationRole);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find application, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find application, key: %S", pwzData);
 
         // set references & increment counters
         if (WcaIsInstalling(pItm->isInstalled, pItm->isAction))
@@ -1793,14 +1793,14 @@ static HRESULT AddAssemblyToActionData(
     //
     int iCompCount = (atCreate == iActionType || (atRemove == iActionType && 0 == (pItm->iAttributes & aaDotNetAssembly))) ? pItm->iComponentCount : 0;
     hr = WcaWriteIntegerToCaData(iCompCount, ppwzActionData);
-    ExitOnFailure1(hr, "Failed to add component count to custom action data, key: %S", pItm->wzKey);
+    ExitOnFailure(hr, "Failed to add component count to custom action data, key: %S", pItm->wzKey);
 
     if (iCompCount)
     {
         for (CPI_COMPONENT* pComp = pItm->pComponents; pComp; pComp = pComp->pNext)
         {
             hr = AddComponentToActionData(pComp, fInstall, atCreate == iActionType, FALSE, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add component to custom action data, component: %S", pComp->wzKey);
+            ExitOnFailure(hr, "Failed to add component to custom action data, component: %S", pComp->wzKey);
         }
     }
 
@@ -1848,7 +1848,7 @@ static HRESULT AddRoleAssignmentsToActionData(
     for (CPI_COMPONENT* pComp = pItm->pComponents; pComp; pComp = pComp->pNext)
     {
         hr = AddComponentToActionData(pComp, fInstall, FALSE, TRUE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add component to custom action data, component: %S", pComp->wzKey);
+        ExitOnFailure(hr, "Failed to add component to custom action data, component: %S", pComp->wzKey);
     }
 
     hr = S_OK;
@@ -1889,7 +1889,7 @@ static HRESULT AddComponentToActionData(
         for (CPI_INTERFACE* pIntf = pItm->pInterfaces; pIntf; pIntf = pIntf->pNext)
         {
             hr = AddInterfaceToActionData(pIntf, fInstall, fProps, fRoles, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add interface custom action data, interface: %S", pIntf->wzKey);
+            ExitOnFailure(hr, "Failed to add interface custom action data, interface: %S", pIntf->wzKey);
         }
     }
 
@@ -1928,7 +1928,7 @@ static HRESULT AddInterfaceToActionData(
     for (CPI_METHOD* pMeth = pItm->pMethods; pMeth; pMeth = pMeth->pNext)
     {
         hr = AddMethodToActionData(pMeth, fInstall, fProps, fRoles, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add method custom action data, method: %S", pMeth->wzKey);
+        ExitOnFailure(hr, "Failed to add method custom action data, method: %S", pMeth->wzKey);
     }
 
     hr = S_OK;
@@ -1992,10 +1992,10 @@ static HRESULT AddRolesToActionData(
                 continue;
 
             hr = WcaWriteStringToCaData(pRole->pApplicationRole->wzKey, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add key to custom action data, role: %S", pRole->wzKey);
+            ExitOnFailure(hr, "Failed to add key to custom action data, role: %S", pRole->wzKey);
 
             hr = WcaWriteStringToCaData(pRole->pApplicationRole->wzName, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add role name to custom action data, role: %S", pRole->wzKey);
+            ExitOnFailure(hr, "Failed to add role name to custom action data, role: %S", pRole->wzKey);
         }
     }
 

--- a/src/ext/ComPlusExtension/ca/cpsched/cppartrolesched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cppartrolesched.cpp
@@ -97,7 +97,7 @@ HRESULT CpiPartitionRolesRead(
         hr = CpiPartitionFindByKey(pPartList, pwzData, &pItm->pPartition);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find partition, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find partition, key: %S", pwzData);
 
         // get name
         hr = WcaGetRecordFormattedString(hRec, prqName, &pwzData);
@@ -222,7 +222,7 @@ HRESULT CpiUsersInPartitionRolesInstall(
 
         // add to action data
         hr = AddUserInPartitionRoleToActionData(pItm, iActionType, COST_USER_IN_APPLICATION_ROLE_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add user in partition role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add user in partition role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -269,7 +269,7 @@ HRESULT CpiUsersInPartitionRolesUninstall(
 
         // add to action data
         hr = AddUserInPartitionRoleToActionData(pItm, iActionType, COST_USER_IN_APPLICATION_ROLE_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add user in partition role to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add user in partition role to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -340,7 +340,7 @@ static HRESULT TrusteesInPartitionRolesRead(
         ExitOnFailure(hr, "Failed to get partition role");
 
         hr = CpiPartitionRoleFindByKey(pPartRoleList, pwzData, &pItm->pPartitionRole);
-        ExitOnFailure1(hr, "Failed to find partition role, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find partition role, key: %S", pwzData);
 
         // get user domain
         hr = WcaGetRecordFormattedString(hRec, tiprqDomain, &pwzDomain);

--- a/src/ext/ComPlusExtension/ca/cpsched/cppartsched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cppartsched.cpp
@@ -138,7 +138,7 @@ HRESULT CpiPartitionsRead(
         if (pwzData && *pwzData)
         {
             hr = PcaGuidToRegFormat(pwzData, pItm->wzID, countof(pItm->wzID));
-            ExitOnFailure2(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
+            ExitOnFailure(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
         }
 
         // get name
@@ -148,11 +148,11 @@ HRESULT CpiPartitionsRead(
 
         // if partition is a locater, either an id or a name must be provided
         if (!pItm->fHasComponent && !*pItm->wzID && !*pItm->wzName)
-            ExitOnFailure1(hr = E_FAIL, "A partition locater must have either an id or a name associated, key: %S", pItm->wzKey);
+            ExitOnFailure(hr = E_FAIL, "A partition locater must have either an id or a name associated, key: %S", pItm->wzKey);
 
         // if partition is not a locater, an name must be provided
         if (pItm->fHasComponent && !*pItm->wzName)
-            ExitOnFailure1(hr = E_FAIL, "A partition must have a name associated, key: %S", pItm->wzKey);
+            ExitOnFailure(hr = E_FAIL, "A partition must have a name associated, key: %S", pItm->wzKey);
 
         // get properties
         if (CpiTableExists(cptComPlusPartitionProperty) && pItm->fHasComponent)
@@ -205,7 +205,7 @@ HRESULT CpiPartitionsVerifyInstall(
 
         // if the partition is referensed and is not a locater, it must be installed
         if (pItm->fReferencedForInstall && pItm->fHasComponent && !CpiWillBeInstalled(pItm->isInstalled, pItm->isAction))
-            MessageExitOnFailure1(hr = E_FAIL, msierrComPlusPartitionDependency, "A partition is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
+            MessageExitOnFailure(hr = E_FAIL, msierrComPlusPartitionDependency, "A partition is used by another entity being installed, but is not installed itself, key: %S", pItm->wzKey);
 
         // get partitions collection
         if (!piPartColl)
@@ -237,7 +237,7 @@ HRESULT CpiPartitionsVerifyInstall(
             {
                 // if the application is a locater, this is an error
                 if (!pItm->fHasComponent)
-                    MessageExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusPartitionNotFound, "A partition required by this installation was not found, key: %S", pItm->wzKey);
+                    MessageExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), msierrComPlusPartitionNotFound, "A partition required by this installation was not found, key: %S", pItm->wzKey);
 
                 // create a new id if one is missing
                 if (!*pItm->wzID)
@@ -292,7 +292,7 @@ HRESULT CpiPartitionsVerifyInstall(
                 {
                 case IDCANCEL:
                 case IDABORT:
-                    ExitOnFailure1(hr = E_FAIL, "A partition with a conflictiong name or id exists, key: %S", pItm->wzKey);
+                    ExitOnFailure(hr = E_FAIL, "A partition with a conflictiong name or id exists, key: %S", pItm->wzKey);
                     break;
                 case IDRETRY:
                     break;
@@ -441,7 +441,7 @@ HRESULT CpiPartitionsInstall(
 
         // add to action data
         hr = AddPartitionToActionData(pItm, iActionType, COST_PARTITION_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add partition to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add partition to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -488,7 +488,7 @@ HRESULT CpiPartitionsUninstall(
 
         // add to action data
         hr = AddPartitionToActionData(pItm, iActionType, COST_PARTITION_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add partition to custom action data, key:", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add partition to custom action data, key:", pItm->wzKey);
     }
 
     // add progress tics
@@ -686,7 +686,7 @@ HRESULT CpiPartitionUsersRead(
         hr = CpiPartitionFindByKey(pPartList, pwzData, &pItm->pPartition);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find partition, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find partition, key: %S", pwzData);
 
         // get user domain
         hr = WcaGetRecordFormattedString(hRec, puqDomain, &pwzDomain);
@@ -773,7 +773,7 @@ HRESULT CpiPartitionUsersInstall(
 
         // add to action data
         hr = AddPartitionUserToActionData(pItm, iActionType, COST_PARTITION_USER_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add partition user to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add partition user to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -820,7 +820,7 @@ HRESULT CpiPartitionUsersUninstall(
 
         // add to action data
         hr = AddPartitionUserToActionData(pItm, iActionType, COST_PARTITION_USER_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add partition user to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add partition user to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics

--- a/src/ext/ComPlusExtension/ca/cpsched/cpsubssched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cpsubssched.cpp
@@ -140,7 +140,7 @@ HRESULT CpiSubscriptionsRead(
         if (S_FALSE == hr)
         {
             // component not found
-            ExitOnFailure1(hr = E_FAIL, "Failed to find component, key: %S", pwzData);
+            ExitOnFailure(hr = E_FAIL, "Failed to find component, key: %S", pwzData);
         }
 
         // get id
@@ -150,7 +150,7 @@ HRESULT CpiSubscriptionsRead(
         if (pwzData && *pwzData)
         {
             hr = PcaGuidToRegFormat(pwzData, pItm->wzID, countof(pItm->wzID));
-            ExitOnFailure2(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
+            ExitOnFailure(hr, "Failed to parse id guid value, key: %S, value: '%S'", pItm->wzKey, pwzData);
         }
 
         // get name
@@ -298,7 +298,7 @@ HRESULT CpiSubscriptionsVerifyInstall(
                 {
                 case IDCANCEL:
                 case IDABORT:
-                    ExitOnFailure1(hr = E_FAIL, "A subscription with a conflictiong name or id exists, key: %S", pItm->wzKey);
+                    ExitOnFailure(hr = E_FAIL, "A subscription with a conflictiong name or id exists, key: %S", pItm->wzKey);
                     break;
                 case IDRETRY:
                     break;
@@ -439,7 +439,7 @@ HRESULT CpiSubscriptionsInstall(
 
         // add to action data
         hr = AddSubscriptionToActionData(pItm, iActionType, COST_SUBSCRIPTION_CREATE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add subscription to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add subscription to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics
@@ -486,7 +486,7 @@ HRESULT CpiSubscriptionsUninstall(
 
         // add to action data
         hr = AddSubscriptionToActionData(pItm, iActionType, COST_SUBSCRIPTION_DELETE, ppwzActionData);
-        ExitOnFailure1(hr, "Failed to add subscription to custom action data, key: %S", pItm->wzKey);
+        ExitOnFailure(hr, "Failed to add subscription to custom action data, key: %S", pItm->wzKey);
     }
 
     // add progress tics

--- a/src/ext/ComPlusExtension/ca/cpsched/cputilsched.cpp
+++ b/src/ext/ComPlusExtension/ca/cpsched/cputilsched.cpp
@@ -608,7 +608,7 @@ HRESULT CpiPropertiesRead(
         ExitOnFailure(hr, "Failed to find property definition");
 
         if (S_FALSE == hr)
-            ExitOnFailure2(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Unknown property, key: %S, property: %S", pwzKey, pItm->wzName);
+            ExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Unknown property, key: %S, property: %S", pwzKey, pItm->wzName);
 
         // check version, ignore if catalog version is too low
         if (iVersionNT < pPropDef->iMinVersionNT)
@@ -677,10 +677,10 @@ HRESULT CpiAddPropertiesToActionData(
         for (CPI_PROPERTY* pProp = pPropList; pProp; pProp = pProp->pNext)
         {
             hr = WcaWriteStringToCaData(pProp->wzName, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add property name to custom action data, name: %S", pProp->wzName);
+            ExitOnFailure(hr, "Failed to add property name to custom action data, name: %S", pProp->wzName);
 
             hr = WcaWriteStringToCaData(pProp->pwzValue, ppwzActionData);
-            ExitOnFailure1(hr, "Failed to add property value to custom action data, name: %S", pProp->wzName);
+            ExitOnFailure(hr, "Failed to add property value to custom action data, name: %S", pProp->wzName);
         }
     }
 
@@ -870,7 +870,7 @@ static HRESULT GetUserAccountName(
     // fetch record
     hr = WcaFetchSingleRecord(hView, &hRec);
     if (S_FALSE == hr)
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "User not found, key: %S", pwzKey);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "User not found, key: %S", pwzKey);
     ExitOnFailure(hr, "Failed to fetch user record");
 
     // get user domain

--- a/src/ext/DependencyExtension/ca/wixdepca.cpp
+++ b/src/ext/DependencyExtension/ca/wixdepca.cpp
@@ -199,7 +199,7 @@ static HRESULT EnsureRequiredDependencies(
         hr = DepCheckDependency(hkHive, sczProviderKey, sczMinVersion, sczMaxVersion, iAttributes, sdDependencies, &rgDependencies, &cDependencies);
         if (E_NOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed dependency check for %ls.", sczId);
+            ExitOnFailure(hr, "Failed dependency check for %ls.", sczId);
         }
     }
 
@@ -216,7 +216,7 @@ static HRESULT EnsureRequiredDependencies(
     if (0 < cDependencies)
     {
         hr = CreateDependencyRecord(msierrDependencyMissingDependencies, rgDependencies, cDependencies, &hDependencyRec);
-        ExitOnFailure1(hr, "Failed to create the dependency record for message %d.", msierrDependencyMissingDependencies);
+        ExitOnFailure(hr, "Failed to create the dependency record for message %d.", msierrDependencyMissingDependencies);
 
         // Send a yes/no message with a warning icon since continuing could be detrimental.
         // This is sent as a USER message to better detect whether a user or dependency-aware bootstrapper is responding
@@ -247,7 +247,7 @@ static HRESULT EnsureRequiredDependencies(
             ExitFunction1(hr = S_OK);
 
         default:
-            ExitOnFailure1(hr = E_UNEXPECTED, "Unexpected message response %d from user or bootstrapper application.", er);
+            ExitOnFailure(hr = E_UNEXPECTED, "Unexpected message response %d from user or bootstrapper application.", er);
         }
     }
 
@@ -349,7 +349,7 @@ static HRESULT EnsureAbsentDependents(
 
         // Check the registry to see if the provider has any dependents registered.
         hr = DepCheckDependents(hkHive, sczProviderKey, iAttributes, sdIgnoredDependents, &rgDependents, &cDependents);
-        ExitOnFailure1(hr, "Failed dependents check for %ls.", sczId);
+        ExitOnFailure(hr, "Failed dependents check for %ls.", sczId);
     }
 
     if (E_NOMOREITEMS != hr)
@@ -365,7 +365,7 @@ static HRESULT EnsureAbsentDependents(
     if (0 < cDependents)
     {
         hr = CreateDependencyRecord(msierrDependencyHasDependents, rgDependents, cDependents, &hDependencyRec);
-        ExitOnFailure1(hr, "Failed to create the dependency record for message %d.", msierrDependencyHasDependents);
+        ExitOnFailure(hr, "Failed to create the dependency record for message %d.", msierrDependencyHasDependents);
 
         // Send a yes/no message with a warning icon since continuing could be detrimental.
         // This is sent as a USER message to better detect whether a user or dependency-aware bootstrapper is responding
@@ -397,7 +397,7 @@ static HRESULT EnsureAbsentDependents(
 
         default:
             hr = E_UNEXPECTED;
-            ExitOnFailure1(hr, "Unexpected message response %d from user or bootstrapper application.", er);
+            ExitOnFailure(hr, "Unexpected message response %d from user or bootstrapper application.", er);
         }
     }
 
@@ -433,7 +433,7 @@ static HRESULT SplitIgnoredDependents(
     for (LPCWSTR wzToken = ::wcstok_s(sczIgnoreDependencies, wzDelim, &wzContext); wzToken; wzToken = ::wcstok_s(NULL, wzDelim, &wzContext))
     {
         hr = DictAddKey(*psdIgnoredDependents, wzToken);
-        ExitOnFailure1(hr, "Failed to ignored dependency \"%ls\" to the string dictionary.", wzToken);
+        ExitOnFailure(hr, "Failed to ignored dependency \"%ls\" to the string dictionary.", wzToken);
     }
 
 LExit:
@@ -496,10 +496,10 @@ static HRESULT CreateDependencyRecord(
         }
 
         er = ::MsiRecordSetStringW(hRec, ++iParam, pDependency->sczKey);
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(er), "Failed to set the dependency key \"%ls\" into the message record.", pDependency->sczKey);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(er), "Failed to set the dependency key \"%ls\" into the message record.", pDependency->sczKey);
 
         er = ::MsiRecordSetStringW(hRec, ++iParam, pDependency->sczName);
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(er), "Failed to set the dependency name \"%ls\" into the message record.", pDependency->sczName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(er), "Failed to set the dependency name \"%ls\" into the message record.", pDependency->sczName);
     }
 
     // Only assign the out parameter if successful to this point.

--- a/src/ext/FirewallExtension/ca/firewall.cpp
+++ b/src/ext/FirewallExtension/ca/firewall.cpp
@@ -332,13 +332,13 @@ static HRESULT CreateFwRuleObject(
     if (bstrRemoteAddresses && *bstrRemoteAddresses)
     {
         hr = pNetFwRule->put_RemoteAddresses(bstrRemoteAddresses);
-        ExitOnFailure1(hr, "failed to set exception remote addresses '%ls'", bstrRemoteAddresses);
+        ExitOnFailure(hr, "failed to set exception remote addresses '%ls'", bstrRemoteAddresses);
     }
 
     if (bstrDescription && *bstrDescription)
     {
         hr = pNetFwRule->put_Description(bstrDescription);
-        ExitOnFailure1(hr, "failed to set exception description '%ls'", bstrDescription);
+        ExitOnFailure(hr, "failed to set exception description '%ls'", bstrDescription);
     }
 
     *ppNetFwRule = pNetFwRule;
@@ -700,7 +700,7 @@ static HRESULT AddPortExceptionOnCurrentProfile(
     if (bstrRemoteAddresses && *bstrRemoteAddresses)
     {
         hr = pfwPort->put_RemoteAddresses(bstrRemoteAddresses);
-        ExitOnFailure1(hr, "failed to set exception remote addresses '%ls'", bstrRemoteAddresses);
+        ExitOnFailure(hr, "failed to set exception remote addresses '%ls'", bstrRemoteAddresses);
     }
 
     hr = pfwPort->put_Name(bstrName);
@@ -830,7 +830,7 @@ static HRESULT RemovePortExceptionFromCurrentProfile(
     ExitOnFailure(hr, "failed to get open ports");
 
     hr = pfwPorts->Remove(iPort, static_cast<NET_FW_IP_PROTOCOL>(iProtocol));
-    ExitOnFailure2(hr, "failed to remove open port %d, protocol %d", iPort, iProtocol);
+    ExitOnFailure(hr, "failed to remove open port %d, protocol %d", iPort, iProtocol);
 
 LExit:
     return fIgnoreFailures ? S_OK : hr;
@@ -1043,13 +1043,13 @@ extern "C" UINT __stdcall ExecFirewallExceptions(
             case WCA_TODO_REINSTALL:
                 WcaLog(LOGMSG_STANDARD, "Installing firewall exception2 %ls on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
                 hr = AddPortException(fSupportProfiles, pwzName, iProfile, pwzRemoteAddresses, fIgnoreFailures, pwzPort, iProtocol, pwzDescription);
-                ExitOnFailure3(hr, "failed to add/update port exception for name '%ls' on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
+                ExitOnFailure(hr, "failed to add/update port exception for name '%ls' on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
                 break;
 
             case WCA_TODO_UNINSTALL:
                 WcaLog(LOGMSG_STANDARD, "Uninstalling firewall exception2 %ls on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
                 hr = RemovePortException(fSupportProfiles, pwzName, pwzPort, iProtocol, fIgnoreFailures);
-                ExitOnFailure3(hr, "failed to remove port exception for name '%ls' on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
+                ExitOnFailure(hr, "failed to remove port exception for name '%ls' on port %ls, protocol %d", pwzName, pwzPort, iProtocol);
                 break;
             }
             break;
@@ -1061,13 +1061,13 @@ extern "C" UINT __stdcall ExecFirewallExceptions(
             case WCA_TODO_REINSTALL:
                 WcaLog(LOGMSG_STANDARD, "Installing firewall exception2 %ls (%ls)", pwzName, pwzFile);
                 hr = AddApplicationException(fSupportProfiles, pwzFile, pwzName, iProfile, pwzRemoteAddresses, fIgnoreFailures, pwzPort, iProtocol, pwzDescription);
-                ExitOnFailure2(hr, "failed to add/update application exception for name '%ls', file '%ls'", pwzName, pwzFile);
+                ExitOnFailure(hr, "failed to add/update application exception for name '%ls', file '%ls'", pwzName, pwzFile);
                 break;
 
             case WCA_TODO_UNINSTALL:
                 WcaLog(LOGMSG_STANDARD, "Uninstalling firewall exception2 %ls (%ls)", pwzName, pwzFile);
                 hr = RemoveApplicationException(fSupportProfiles, pwzName, pwzFile, fIgnoreFailures, pwzPort, iProtocol);
-                ExitOnFailure2(hr, "failed to remove application exception for name '%ls', file '%ls'", pwzName, pwzFile);
+                ExitOnFailure(hr, "failed to remove application exception for name '%ls', file '%ls'", pwzName, pwzFile);
                 break;
             }
             break;

--- a/src/ext/GamingExtension/ca/gaming.cpp
+++ b/src/ext/GamingExtension/ca/gaming.cpp
@@ -67,7 +67,7 @@ extern "C" HRESULT ExtractXMLFromGDFBinary(
 
     // HGLOBAL from LoadResource() needs to be copied for CreateStreamOnHGlobal() to work
     hgResourceCopy = ::GlobalAlloc(GMEM_MOVEABLE, dwGDFXMLSize);
-    ExitOnNullDebugTrace1(hgResourceCopy, hr, E_OUTOFMEMORY, "failed to GlobalAlloc %ls", sczGDFBinPath);
+    ExitOnNullDebugTrace(hgResourceCopy, hr, E_OUTOFMEMORY, "failed to GlobalAlloc %ls", sczGDFBinPath);
 
     LPVOID pCopy = ::GlobalLock(hgResourceCopy);
     ExitOnNullWithLastError(pCopy, hr, "failed to global lock");
@@ -245,7 +245,7 @@ extern "C" HRESULT SaveShortcut(
         cch = ::GetFullPathNameW(sczLaunchPath, countof(strFullPath), strFullPath, &strExePart);
         if (0 == cch)
         {
-            ExitWithLastError1(hr, "Failed to get full path for string: %ls", sczLaunchPath);
+            ExitWithLastError(hr, "Failed to get full path for string: %ls", sczLaunchPath);
         }
 
         if (strExePart) 
@@ -687,13 +687,13 @@ extern "C" HRESULT __stdcall SchedGameExplorer(
 
         // turn that into the path to the target file
         hr = StrAllocFormatted(&pwzFormattedFile, L"[#%s]", pwzFileId);
-        ExitOnFailure1(hr, "failed to format file string for file: %ls", pwzFileId);
+        ExitOnFailure(hr, "failed to format file string for file: %ls", pwzFileId);
         hr = WcaGetFormattedString(pwzFormattedFile, &pwzGamePath);
-        ExitOnFailure1(hr, "failed to get formatted string for file: %ls", pwzFileId);
+        ExitOnFailure(hr, "failed to get formatted string for file: %ls", pwzFileId);
 
         // and then get the directory part of the path
         hr = PathGetDirectory(pwzGamePath, &pwzGameDir);
-        ExitOnFailure1(hr, "failed to get path for file: %ls", pwzGamePath);
+        ExitOnFailure(hr, "failed to get path for file: %ls", pwzGamePath);
 
         // get component and its install/action states
         hr = WcaGetRecordString(hRec, egqComponent, &pwzComponentId);
@@ -720,21 +720,21 @@ extern "C" HRESULT __stdcall SchedGameExplorer(
         {
             // write custom action data: operation, instance guid, path, directory
             hr = WcaWriteIntegerToCaData(todo, &pwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write Game Explorer operation to custom action data for instance id: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to write Game Explorer operation to custom action data for instance id: %ls", pwzInstanceId);
 
             hr = WcaWriteStringToCaData(pwzInstanceId, &pwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write custom action data for instance id: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to write custom action data for instance id: %ls", pwzInstanceId);
 
             hr = WcaWriteStringToCaData(pwzGamePath, &pwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write game path to custom action data for instance id: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to write game path to custom action data for instance id: %ls", pwzInstanceId);
 
             hr = WcaWriteStringToCaData(pwzGameDir, &pwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write game install directory to custom action data for instance id: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to write game install directory to custom action data for instance id: %ls", pwzInstanceId);
         }
         else
         {
             hr = WriteGameExplorerRegistry(pwzInstanceId, pwzComponentId, pwzGamePath, pwzGameDir);
-            ExitOnFailure1(hr, "failed to write registry rows for game id: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to write registry rows for game id: %ls", pwzInstanceId);
         }
     }
 
@@ -875,7 +875,7 @@ extern "C" UINT __stdcall ExecGameExplorer(
 
             // convert from LPWSTRs to BSTRs and GUIDs, which are what IGameExplorer wants
             hr = ::CLSIDFromString(pwzInstanceId, &guidInstanceId);
-            ExitOnFailure1(hr, "couldn't convert invalid GUID string '%ls'", pwzInstanceId);
+            ExitOnFailure(hr, "couldn't convert invalid GUID string '%ls'", pwzInstanceId);
 
             bstrGamePath = ::SysAllocString(pwzGamePath);
             ExitOnNull(bstrGamePath, hr, E_OUTOFMEMORY, "failed SysAllocString for bstrGamePath");
@@ -907,11 +907,11 @@ extern "C" UINT __stdcall ExecGameExplorer(
                 case WCA_TODO_INSTALL:
                 case WCA_TODO_REINSTALL:
                     hr = piGameExplorer2->InstallGame(bstrGamePath, bstrGameDir, GIS_ALL_USERS);
-                    ExitOnFailure1(hr, "failed to install game: %ls", bstrGamePath);
+                    ExitOnFailure(hr, "failed to install game: %ls", bstrGamePath);
                     break;
                 case WCA_TODO_UNINSTALL:
                     hr = piGameExplorer2->UninstallGame(bstrGamePath);
-                    ExitOnFailure1(hr, "failed to remove game instance: %ls", pwzInstanceId);
+                    ExitOnFailure(hr, "failed to remove game instance: %ls", pwzInstanceId);
                     break;
                 }
             }
@@ -921,14 +921,14 @@ extern "C" UINT __stdcall ExecGameExplorer(
                 {
                 case WCA_TODO_INSTALL:
                     hr = piGameExplorer->VerifyAccess(bstrGamePath, &fHasAccess);
-                    ExitOnFailure1(hr, "failed to verify game access: %ls", pwzInstanceId);
+                    ExitOnFailure(hr, "failed to verify game access: %ls", pwzInstanceId);
 
                     if (SUCCEEDED(hr) && fHasAccess)
                     {
                         WcaLog(LOGMSG_STANDARD, "Adding game: %ls, %ls", bstrGamePath, bstrGameDir);
                         hr = piGameExplorer->AddGame(bstrGamePath, bstrGameDir, GIS_ALL_USERS, &guidInstanceId);
                     }
-                    ExitOnFailure1(hr, "failed to add game instance: %ls", pwzInstanceId);
+                    ExitOnFailure(hr, "failed to add game instance: %ls", pwzInstanceId);
 
                     if (fIsV2GDF)
                     {
@@ -938,11 +938,11 @@ extern "C" UINT __stdcall ExecGameExplorer(
                     break;
                 case WCA_TODO_REINSTALL:
                     hr = piGameExplorer->UpdateGame(guidInstanceId);
-                    ExitOnFailure1(hr, "failed to update game instance: %ls", pwzInstanceId);
+                    ExitOnFailure(hr, "failed to update game instance: %ls", pwzInstanceId);
                     break;
                 case WCA_TODO_UNINSTALL:
                     hr = piGameExplorer->RemoveGame(guidInstanceId);
-                    ExitOnFailure1(hr, "failed to remove game instance: %ls", pwzInstanceId);
+                    ExitOnFailure(hr, "failed to remove game instance: %ls", pwzInstanceId);
                     if (fIsV2GDF)
                     {
                         hr = RemoveShorcuts(pwzInstanceId, GIS_ALL_USERS);
@@ -954,7 +954,7 @@ extern "C" UINT __stdcall ExecGameExplorer(
 
             // Tick the progress bar along for this game
             hr = WcaProgressMessage(COST_GAMEEXPLORER, FALSE);
-            ExitOnFailure1(hr, "failed to tick progress bar for game instance: %ls", pwzInstanceId);
+            ExitOnFailure(hr, "failed to tick progress bar for game instance: %ls", pwzInstanceId);
         }
     }
 

--- a/src/ext/HttpExtension/ca/wixhttpca.cpp
+++ b/src/ext/HttpExtension/ca/wixhttpca.cpp
@@ -146,12 +146,12 @@ static UINT SchedHttpUrlReservations(
             {
                 hQueryReq = ::MsiCreateRecord(1);
                 hr = WcaSetRecordString(hQueryReq, 1, sczId);
-                ExitOnFailure1(hr, "Failed to create record for querying WixHttpUrlAce table for reservation %ls", sczId);
+                ExitOnFailure(hr, "Failed to create record for querying WixHttpUrlAce table for reservation %ls", sczId);
 
                 hr = WcaOpenView(vcsHttpUrlAceQuery, &hAceView);
-                ExitOnFailure1(hr, "Failed to open view on WixHttpUrlAce table for reservation %ls", sczId);
+                ExitOnFailure(hr, "Failed to open view on WixHttpUrlAce table for reservation %ls", sczId);
                 hr = WcaExecuteView(hAceView, hQueryReq);
-                ExitOnFailure1(hr, "Failed to execute view on WixHttpUrlAce table for reservation %ls", sczId);
+                ExitOnFailure(hr, "Failed to execute view on WixHttpUrlAce table for reservation %ls", sczId);
 
                 while (S_OK == (hr = WcaFetchRecord(hAceView, &hRec)))
                 {
@@ -179,7 +179,7 @@ static UINT SchedHttpUrlReservations(
         }
 
         hr = GetUrlReservation(sczUrl, &sczExistingSDDL);
-        ExitOnFailure1(hr, "Failed to get the existing SDDL for %ls", sczUrl);
+        ExitOnFailure(hr, "Failed to get the existing SDDL for %ls", sczUrl);
 
         hr = WriteHttpUrlReservation(todoComponent, sczUrl, sczExistingSDDL ? sczExistingSDDL : L"", iHandleExisting, &sczRollbackCustomActionData);
         ExitOnFailure(hr, "Failed to write URL Reservation to rollback custom action data.");
@@ -260,7 +260,7 @@ static HRESULT AppendUrlAce(
     else
     {
         hr = AclGetAccountSidStringEx(NULL, wzSecurityPrincipal, &sczSid);
-        ExitOnFailure1(hr, "Failed to lookup the SID for account %ls", wzSecurityPrincipal);
+        ExitOnFailure(hr, "Failed to lookup the SID for account %ls", wzSecurityPrincipal);
 
         wzSid = sczSid;
     }
@@ -402,7 +402,7 @@ extern "C" UINT __stdcall ExecHttpUrlReservations(
                 }
                 else
                 {
-                    ExitOnFailure1(hr, "Failed to remove reservation for URL '%ls'", sczUrl);
+                    ExitOnFailure(hr, "Failed to remove reservation for URL '%ls'", sczUrl);
                 }
             }
         }
@@ -422,7 +422,7 @@ extern "C" UINT __stdcall ExecHttpUrlReservations(
                 }
                 else
                 {
-                    ExitOnFailure2(hr, "Failed to add reservation for URL '%ls' with SDDL '%ls'", sczUrl, sczSDDL);
+                    ExitOnFailure(hr, "Failed to add reservation for URL '%ls' with SDDL '%ls'", sczUrl, sczSDDL);
                 }
             }
         }
@@ -462,7 +462,7 @@ static HRESULT AddUrlReservation(
     {
         hr = HRESULT_FROM_WIN32(er);
     }
-    ExitOnFailure2(hr, "Failed to add URL reservation: %ls, ACL: %ls", wzUrl, wzSddl);
+    ExitOnFailure(hr, "Failed to add URL reservation: %ls, ACL: %ls", wzUrl, wzSddl);
 
 LExit:
     return hr;
@@ -529,7 +529,7 @@ static HRESULT RemoveUrlReservation(
     {
         hr = HRESULT_FROM_WIN32(er);
     }
-    ExitOnFailure1(hr, "Failed to remove URL reservation: %ls", wzUrl);
+    ExitOnFailure(hr, "Failed to remove URL reservation: %ls", wzUrl);
 
 LExit:
     return hr;

--- a/src/ext/MsmqExtension/ca/mqexec/mqqueueexec.cpp
+++ b/src/ext/MsmqExtension/ca/mqexec/mqqueueexec.cpp
@@ -193,11 +193,11 @@ HRESULT MqiCreateMessageQueues(
 
         // progress message
         hr = PcaActionDataMessage(1, attrs.pwzPathName);
-        ExitOnFailure1(hr, "Failed to send progress messages, key: %S", attrs.pwzKey);
+        ExitOnFailure(hr, "Failed to send progress messages, key: %S", attrs.pwzKey);
 
         // create message queue
         hr = CreateMessageQueue(&attrs);
-        ExitOnFailure1(hr, "Failed to create message queue, key: %S", attrs.pwzKey);
+        ExitOnFailure(hr, "Failed to create message queue, key: %S", attrs.pwzKey);
 
         // progress tics
         hr = WcaProgressMessage(COST_MESSAGE_QUEUE_CREATE, FALSE);
@@ -272,7 +272,7 @@ HRESULT MqiDeleteMessageQueues(
 
         // progress message
         hr = PcaActionDataMessage(1, attrs.pwzPathName);
-        ExitOnFailure1(hr, "Failed to send progress messages, key: %S", attrs.pwzKey);
+        ExitOnFailure(hr, "Failed to send progress messages, key: %S", attrs.pwzKey);
 
         // create message queue
         hr = DeleteMessageQueue(&attrs);

--- a/src/ext/MsmqExtension/ca/mqexec/mqutilexec.cpp
+++ b/src/ext/MsmqExtension/ca/mqexec/mqutilexec.cpp
@@ -335,14 +335,14 @@ static HRESULT CreateSidFromDomainRidPair(
         if (ccb < dwLengthRequired)
         {
             pSid = (PSID)::HeapReAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, *ppSid, dwLengthRequired);
-            ExitOnNull1(pSid, hr, E_OUTOFMEMORY, "Failed to reallocate buffer for SID, len: %d", dwLengthRequired);
+            ExitOnNull(pSid, hr, E_OUTOFMEMORY, "Failed to reallocate buffer for SID, len: %d", dwLengthRequired);
             *ppSid = pSid;
         }
     }
     else
     {
         *ppSid = (PSID)::HeapAlloc(::GetProcessHeap(), HEAP_ZERO_MEMORY, dwLengthRequired);
-        ExitOnNull1(*ppSid, hr, E_OUTOFMEMORY, "Failed to allocate buffer for SID, len: %d", dwLengthRequired);
+        ExitOnNull(*ppSid, hr, E_OUTOFMEMORY, "Failed to allocate buffer for SID, len: %d", dwLengthRequired);
     }
 
     ::InitializeSid(*ppSid, ::GetSidIdentifierAuthority(pDomainSid), ucSubAuthorityCount + (UCHAR)1);

--- a/src/ext/MsmqExtension/ca/mqsched/mqqueuesched.cpp
+++ b/src/ext/MsmqExtension/ca/mqsched/mqqueuesched.cpp
@@ -525,7 +525,7 @@ static HRESULT MessageQueueTrusteePermissionsRead(
         hr = MqiMessageQueueFindByKey(pMessageQueueList, pwzData, &pItm->pMessageQueue);
         if (S_FALSE == hr)
             hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        ExitOnFailure1(hr, "Failed to find message queue, key: %S", pwzData);
+        ExitOnFailure(hr, "Failed to find message queue, key: %S", pwzData);
 
         // get user domain
         hr = WcaGetRecordFormattedString(hRec, mqpqDomain, &pwzData);

--- a/src/ext/SettingsEngineExtension/ca/cfg.cpp
+++ b/src/ext/SettingsEngineExtension/ca/cfg.cpp
@@ -261,13 +261,13 @@ extern "C" UINT __stdcall ExecCfgProducts(
         case WCA_TODO_REINSTALL:
             WcaLog(LOGMSG_STANDARD, "Installing cfg product %ls version %ls, public key %ls", sczName, sczVersion, sczPublicKey);
             hr = CfgAdminRegisterProduct(cdhAdmin, sczName, sczVersion, sczPublicKey);
-            ExitOnFailure3(hr, "failed to install cfg product: name '%ls' version %ls, public key %ls", sczName, sczVersion, sczPublicKey);
+            ExitOnFailure(hr, "failed to install cfg product: name '%ls' version %ls, public key %ls", sczName, sczVersion, sczPublicKey);
             break;
 
         case WCA_TODO_UNINSTALL:
             WcaLog(LOGMSG_STANDARD, "Uninstalling cfg product %ls version %ls, public key %d", sczName, sczVersion, sczPublicKey);
             hr = CfgAdminUnregisterProduct(cdhAdmin, sczName, sczVersion, sczPublicKey);
-            ExitOnFailure3(hr, "failed to remove cfg product: name '%ls' version %ls, public key %ls", sczName, sczVersion, sczPublicKey);
+            ExitOnFailure(hr, "failed to remove cfg product: name '%ls' version %ls, public key %ls", sczName, sczVersion, sczPublicKey);
             break;
         }
     }

--- a/src/ext/ca/serverca/scaexec/scacertexec.cpp
+++ b/src/ext/ca/serverca/scaexec/scacertexec.cpp
@@ -187,7 +187,7 @@ static HRESULT ExecuteCertificateOperation(
 
     // Open the right store.
     hCertStore = ::CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, NULL, dwStoreLocation, pwzStore);
-    MessageExitOnNullWithLastError1(hCertStore, hr, msierrCERTFailedOpen, "Failed to open certificate store: %ls", pwzStore);
+    MessageExitOnNullWithLastError(hCertStore, hr, msierrCERTFailedOpen, "Failed to open certificate store: %ls", pwzStore);
 
     if (SCA_ACTION_INSTALL == saAction) // install operations need more data
     {
@@ -258,7 +258,7 @@ static HRESULT InstallCertificatePackage(
 
     if (!::CryptQueryObject(CERT_QUERY_OBJECT_BLOB, &blob, CERT_QUERY_CONTENT_FLAG_ALL, CERT_QUERY_FORMAT_FLAG_ALL, 0, &dwEncodingType, &dwContentType, &dwFormatType, NULL, NULL, (LPCVOID*)&pCertContext))
     {
-        ExitWithLastError1(hr, "Failed to parse the certificate blob: %ls", wzName);
+        ExitWithLastError(hr, "Failed to parse the certificate blob: %ls", wzName);
     }
 
     hr = StrAllocFormatted(&pwzUniqueName, L"%s_wixCert_%d", wzName, ++iUniqueId);

--- a/src/ext/ca/serverca/scaexec/scaexec.cpp
+++ b/src/ext/ca/serverca/scaexec/scaexec.cpp
@@ -83,7 +83,7 @@ extern "C" UINT __stdcall StartMetabaseTransaction(MSIHANDLE hInstall)
             WcaLog(LOGMSG_STANDARD, "Failed to save metabase before backing up - continuing");
             hr = S_OK;
         }
-        MessageExitOnFailure1(hr, msierrIISFailedStartTransaction, "failed to begin metabase transaction: '%ls'", pwzData);
+        MessageExitOnFailure(hr, msierrIISFailedStartTransaction, "failed to begin metabase transaction: '%ls'", pwzData);
     }
     hr = WcaProgressMessage(COST_IIS_TRANSACTIONS, FALSE);
 LExit:
@@ -136,10 +136,10 @@ extern "C" UINT __stdcall RollbackMetabaseTransaction(MSIHANDLE hInstall)
     ExitOnFailure(hr, "failed to get CustomActionData");
 
     hr = piMetabase->Restore(pwzData, MD_BACKUP_HIGHEST_VERSION, 0);
-    ExitOnFailure1(hr, "failed to rollback metabase transaction: '%ls'", pwzData);
+    ExitOnFailure(hr, "failed to rollback metabase transaction: '%ls'", pwzData);
 
     hr = piMetabase->DeleteBackup(pwzData, MD_BACKUP_HIGHEST_VERSION);
-    ExitOnFailure1(hr, "failed to cleanup metabase transaction '%ls', continuing", pwzData);
+    ExitOnFailure(hr, "failed to cleanup metabase transaction '%ls', continuing", pwzData);
 
 LExit:
     ReleaseStr(pwzData);
@@ -191,7 +191,7 @@ extern "C" UINT __stdcall CommitMetabaseTransaction(MSIHANDLE hInstall)
     ExitOnFailure(hr, "failed to get CustomActionData");
 
     hr = piMetabase->DeleteBackup(pwzData, MD_BACKUP_HIGHEST_VERSION);
-    ExitOnFailure1(hr, "failed to cleanup metabase transaction: '%ls'", pwzData);
+    ExitOnFailure(hr, "failed to cleanup metabase transaction: '%ls'", pwzData);
 
 LExit:
     ReleaseStr(pwzData);
@@ -235,7 +235,7 @@ static HRESULT CreateMetabaseKey(__in LPWSTR* ppwzCustomActionData, __in IMSAdmi
         WcaLog(LOGMSG_STANDARD, "failed to open root key, retrying %d time(s)...", i);
         hr = piMetabase->OpenKey(METADATA_MASTER_ROOT_HANDLE, L"/LM", METADATA_PERMISSION_WRITE, 10, &mhRoot);
     }
-    MessageExitOnFailure1(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", L"/LM");
+    MessageExitOnFailure(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", L"/LM");
 
     pwzKey = pwzData + 3;
 
@@ -247,7 +247,7 @@ static HRESULT CreateMetabaseKey(__in LPWSTR* ppwzCustomActionData, __in IMSAdmi
         WcaLog(LOGMSG_VERBOSE, "Key `%ls` already existed, continuing.", pwzData);
         hr = S_OK;
     }
-    MessageExitOnFailure1(hr, msierrIISFailedCreateKey, "failed to create metabase key: %ls", pwzKey);
+    MessageExitOnFailure(hr, msierrIISFailedCreateKey, "failed to create metabase key: %ls", pwzKey);
 
     hr = WcaProgressMessage(COST_IIS_CREATEKEY, FALSE);
 
@@ -342,11 +342,11 @@ static HRESULT WriteMetabaseValue(__in LPWSTR* ppwzCustomActionData, __in IMSAdm
         WcaLog(LOGMSG_STANDARD, "failed to open '%ls' key, retrying %d time(s)...", pwzKey, i);
         hr = piMetabase->OpenKey(METADATA_MASTER_ROOT_HANDLE, L"/LM", METADATA_PERMISSION_WRITE, 10, &mhKey);
     }
-    MessageExitOnFailure1(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", pwzKey);
+    MessageExitOnFailure(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", pwzKey);
 
     if (lstrlenW(pwzKey) < 3)
     {
-        ExitOnFailure1(hr = E_INVALIDARG, "Key didn't begin with \"/LM\" as expected - key value: %ls", pwzKey);
+        ExitOnFailure(hr = E_INVALIDARG, "Key didn't begin with \"/LM\" as expected - key value: %ls", pwzKey);
     }
 
     hr = piMetabase->SetData(mhKey, pwzKey + 3, &mr); // pwzKey + 3 to skip "/LM" that was used to open the key.
@@ -391,7 +391,7 @@ static HRESULT WriteMetabaseValue(__in LPWSTR* ppwzCustomActionData, __in IMSAdm
             hr = hrOldValue;
         }
     }
-    MessageExitOnFailure1(hr, msierrIISFailedWriteData, "failed to write data to metabase key: %ls", pwzKey);
+    MessageExitOnFailure(hr, msierrIISFailedWriteData, "failed to write data to metabase key: %ls", pwzKey);
 
     hr = WcaProgressMessage(COST_IIS_WRITEVALUE, FALSE);
 
@@ -448,11 +448,11 @@ static HRESULT DeleteMetabaseValue(__in LPWSTR* ppwzCustomActionData, __in IMSAd
         WcaLog(LOGMSG_STANDARD, "failed to open '%ls' key, retrying %d time(s)...", pwzKey, i);
         hr = piMetabase->OpenKey(METADATA_MASTER_ROOT_HANDLE, L"/LM", METADATA_PERMISSION_WRITE, 10, &mhKey);
     }
-    MessageExitOnFailure1(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", pwzKey);
+    MessageExitOnFailure(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", pwzKey);
 
     if (lstrlenW(pwzKey) < 3)
     {
-        ExitOnFailure1(hr = E_INVALIDARG, "Key didn't begin with \"/LM\" as expected - key value: %ls", pwzKey);
+        ExitOnFailure(hr = E_INVALIDARG, "Key didn't begin with \"/LM\" as expected - key value: %ls", pwzKey);
     }
 
     hr = piMetabase->DeleteData(mhKey, pwzKey + 3, dwIdentifier, dwDataType); // pwzKey + 3 to skip "/LM" that was used to open the key.
@@ -460,7 +460,7 @@ static HRESULT DeleteMetabaseValue(__in LPWSTR* ppwzCustomActionData, __in IMSAd
     {
         hr = S_OK;
     }
-    MessageExitOnFailure2(hr, msierrIISFailedDeleteValue, "failed to delete value %d from metabase key: %ls", dwIdentifier, pwzKey);
+    MessageExitOnFailure(hr, msierrIISFailedDeleteValue, "failed to delete value %d from metabase key: %ls", dwIdentifier, pwzKey);
 
     hr = WcaProgressMessage(COST_IIS_DELETEVALUE, FALSE);
 LExit:
@@ -518,7 +518,7 @@ static HRESULT DeleteAspApp(__in LPWSTR* ppwzCustomActionData, __in IMSAdminBase
         WcaLog(LOGMSG_VERBOSE, "No independent COM+ application found associated with %ls. It either doesn't exist, or was already removed - continuing", pwzRoot);
         ExitFunction1(hr = S_OK);
     }
-    MessageExitOnFailure1(hr, msierrIISFailedDeleteApp, "failed to get GUID for application at path: %ls", pwzRoot);
+    MessageExitOnFailure(hr, msierrIISFailedDeleteApp, "failed to get GUID for application at path: %ls", pwzRoot);
 
     WcaLog(LOGMSG_VERBOSE, "Deleting ASP App (used query: %ls) with GUID: %ls", pwzRoot, (LPWSTR)(mr.pbMDData));
 
@@ -630,7 +630,7 @@ static HRESULT CreateAspApp(__in LPWSTR* ppwzCustomActionData, __in IWamAdmin* p
     WcaLog(LOGMSG_VERBOSE, "Creating ASP App: %ls", pwzRoot);
 
     hr = piWam->AppCreate(pwzRoot, fInProc);
-    MessageExitOnFailure1(hr, msierrIISFailedCreateApp, "failed to create web application: %ls", pwzRoot);
+    MessageExitOnFailure(hr, msierrIISFailedCreateApp, "failed to create web application: %ls", pwzRoot);
 
     hr = WcaProgressMessage(COST_IIS_CREATEAPP, FALSE);
 LExit:
@@ -664,7 +664,7 @@ static HRESULT DeleteMetabaseKey(__in LPWSTR *ppwzCustomActionData, __in IMSAdmi
         WcaLog(LOGMSG_STANDARD, "failed to open root key, retrying %d time(s)...", i);
         hr = piMetabase->OpenKey(METADATA_MASTER_ROOT_HANDLE, L"/LM", METADATA_PERMISSION_WRITE, 10, &mhRoot);
     }
-    MessageExitOnFailure1(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", L"/LM");
+    MessageExitOnFailure(hr, msierrIISFailedOpenKey, "failed to open metabase key: %ls", L"/LM");
 
     pwzKey = pwzData + 3;
 
@@ -676,7 +676,7 @@ static HRESULT DeleteMetabaseKey(__in LPWSTR *ppwzCustomActionData, __in IMSAdmi
         WcaLog(LOGMSG_STANDARD, "Key `%ls` did not exist, continuing.", pwzData);
         hr = S_OK;
     }
-    MessageExitOnFailure1(hr, msierrIISFailedDeleteKey, "failed to delete metabase key: %ls", pwzData);
+    MessageExitOnFailure(hr, msierrIISFailedDeleteKey, "failed to delete metabase key: %ls", pwzData);
 
     hr = WcaProgressMessage(COST_IIS_DELETEKEY, FALSE);
 LExit:
@@ -821,7 +821,7 @@ extern "C" UINT __stdcall WriteMetabaseChanges(MSIHANDLE hInstall)
             ExitOnFailure(hr, "failed to delete metabase value");
             break;
         default:
-            ExitOnFailure1(hr = E_UNEXPECTED, "Unexpected metabase action specified: %d", maAction);
+            ExitOnFailure(hr = E_UNEXPECTED, "Unexpected metabase action specified: %d", maAction);
             break;
         }
     }
@@ -919,90 +919,90 @@ extern "C" UINT __stdcall CreateDatabase(MSIHANDLE hInstall)
 
     pwz = pwzData;
     hr = WcaReadStringFromCaData(&pwz, &pwzDatabaseKey); // SQL Server
-    ExitOnFailure1(hr, "failed to read database key from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read database key from custom action data: %ls", pwz);
     hr = WcaReadStringFromCaData(&pwz, &pwzServer); // SQL Server
-    ExitOnFailure1(hr, "failed to read server from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read server from custom action data: %ls", pwz);
     hr = WcaReadStringFromCaData(&pwz, &pwzInstance); // SQL Server Instance
-    ExitOnFailure1(hr, "failed to read server instance from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read server instance from custom action data: %ls", pwz);
     hr = WcaReadStringFromCaData(&pwz, &pwzDatabase); // SQL Database
-    ExitOnFailure1(hr, "failed to read server instance from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read server instance from custom action data: %ls", pwz);
     hr = WcaReadIntegerFromCaData(&pwz, &iAttributes);
-    ExitOnFailure1(hr, "failed to read attributes from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read attributes from custom action data: %ls", pwz);
     hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int *>(&fIntegratedAuth)); // Integrated Windows Authentication?
-    ExitOnFailure1(hr, "failed to read integrated auth flag from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read integrated auth flag from custom action data: %ls", pwz);
     hr = WcaReadStringFromCaData(&pwz, &pwzUser); // SQL User
-    ExitOnFailure1(hr, "failed to read user from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read user from custom action data: %ls", pwz);
     hr = WcaReadStringFromCaData(&pwz, &pwzPassword); // SQL User Password
-    ExitOnFailure1(hr, "failed to read user from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read user from custom action data: %ls", pwz);
 
     // db file spec
     hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int *>(&fHaveDbFileSpec));
-    ExitOnFailure1(hr, "failed to read db file spec from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read db file spec from custom action data: %ls", pwz);
 
     if (fHaveDbFileSpec)
     {
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read db file spec name from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read db file spec name from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfDb.wzName, countof(sfDb.wzName), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy db file spec name: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy db file spec name: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read db file spec filename from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read db file spec filename from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfDb.wzFilename, countof(sfDb.wzFilename), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy db file spec filename: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy db file spec filename: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read db file spec size from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read db file spec size from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfDb.wzSize, countof(sfDb.wzSize), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy db file spec size value: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy db file spec size value: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read db file spec max size from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read db file spec max size from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfDb.wzMaxSize, countof(sfDb.wzMaxSize), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy db file spec max size: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy db file spec max size: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read db file spec grow from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read db file spec grow from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfDb.wzGrow, countof(sfDb.wzGrow), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy db file spec grow value: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy db file spec grow value: %ls", pwzTemp);
     }
 
     // log file spec
     hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int *>(&fHaveLogFileSpec));
-    ExitOnFailure1(hr, "failed to read log file spec from custom action data: %ls", pwz);
+    ExitOnFailure(hr, "failed to read log file spec from custom action data: %ls", pwz);
     if (fHaveLogFileSpec)
     {
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read log file spec name from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read log file spec name from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfLog.wzName, countof(sfDb.wzName), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy log file spec name: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy log file spec name: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read log file spec filename from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read log file spec filename from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfLog.wzFilename, countof(sfDb.wzFilename), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy log file spec filename: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy log file spec filename: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read log file spec size from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read log file spec size from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfLog.wzSize, countof(sfDb.wzSize), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy log file spec size value: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy log file spec size value: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read log file spec max size from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read log file spec max size from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfLog.wzMaxSize, countof(sfDb.wzMaxSize), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy log file spec max size: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy log file spec max size: %ls", pwzTemp);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzTemp);
-        ExitOnFailure1(hr, "failed to read log file spec grow from custom action data: %ls", pwz);
+        ExitOnFailure(hr, "failed to read log file spec grow from custom action data: %ls", pwz);
         hr = ::StringCchCopyW(sfLog.wzGrow, countof(sfDb.wzGrow), pwzTemp);
-        ExitOnFailure1(hr, "failed to copy log file spec grow value: %ls", pwzTemp);
+        ExitOnFailure(hr, "failed to copy log file spec grow value: %ls", pwzTemp);
     }
 
     if (iAttributes & SCADB_CONFIRM_OVERWRITE)
     {
         // Check if the database already exists
         hr = SqlDatabaseExists(pwzServer, pwzInstance, pwzDatabase, fIntegratedAuth, pwzUser, pwzPassword, &bstrErrorDescription);
-        MessageExitOnFailure2(hr, msierrSQLFailedCreateDatabase, "failed to check if database exists: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
+        MessageExitOnFailure(hr, msierrSQLFailedCreateDatabase, "failed to check if database exists: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
 
         if (S_OK == hr) // found an existing database, confirm that they don't want to stop before it gets trampled, in no UI case just continue anyways
         {
@@ -1018,7 +1018,7 @@ extern "C" UINT __stdcall CreateDatabase(MSIHANDLE hInstall)
         WcaLog(LOGMSG_STANDARD, "Error 0x%x: failed to create SQL database but continuing, error: %ls, Database: %ls", hr, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription, pwzDatabase);
         hr = S_OK;
     }
-    MessageExitOnFailure2(hr, msierrSQLFailedCreateDatabase, "failed to create to database: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
+    MessageExitOnFailure(hr, msierrSQLFailedCreateDatabase, "failed to create to database: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
 
     hr = WcaProgressMessage(COST_SQL_CONNECTDB, FALSE);
 LExit:
@@ -1105,7 +1105,7 @@ extern "C" UINT __stdcall DropDatabase(MSIHANDLE hInstall)
         WcaLog(LOGMSG_STANDARD, "Error 0x%x: failed to drop SQL database but continuing, error: %ls, Database: %ls", hr, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription, pwzDatabase);
         hr = S_OK;
     }
-    MessageExitOnFailure2(hr, msierrSQLFailedDropDatabase, "failed to drop to database: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
+    MessageExitOnFailure(hr, msierrSQLFailedDropDatabase, "failed to drop to database: '%ls', error: %ls", pwzDatabase, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription);
 
     hr = WcaProgressMessage(COST_SQL_CONNECTDB, FALSE);
 
@@ -1206,10 +1206,10 @@ extern "C" UINT __stdcall ExecuteSqlStrings(MSIHANDLE hInstall)
     while (S_OK == hr && S_OK == (hr = WcaReadStringFromCaData(&pwz, &pwzSqlKey)))
     {
         hr = WcaReadIntegerFromCaData(&pwz, &iAttributesSQL);
-        ExitOnFailure1(hr, "failed to read attributes for SQL string: %ls", pwzSqlKey);
+        ExitOnFailure(hr, "failed to read attributes for SQL string: %ls", pwzSqlKey);
 
         hr = WcaReadStringFromCaData(&pwz, &pwzSql);
-        ExitOnFailure1(hr, "failed to read SQL string for key: %ls", pwzSqlKey);
+        ExitOnFailure(hr, "failed to read SQL string for key: %ls", pwzSqlKey);
 
         // If the SqlString row is set to continue on error and the DB connection failed, skip attempting to execute
         if ((iAttributesSQL & SCASQL_CONTINUE_ON_ERROR) && FAILED(hrDB))
@@ -1219,7 +1219,7 @@ extern "C" UINT __stdcall ExecuteSqlStrings(MSIHANDLE hInstall)
         }
 
         // Now check if the DB connection succeeded
-        MessageExitOnFailure1(hr = hrDB, msierrSQLFailedConnectDatabase, "failed to connect to database: '%ls'", pwzDatabase);
+        MessageExitOnFailure(hr = hrDB, msierrSQLFailedConnectDatabase, "failed to connect to database: '%ls'", pwzDatabase);
 
         WcaLog(LOGMSG_VERBOSE, "Executing SQL string: %ls", pwzSql);
         hr = SqlSessionExecuteQuery(pidbSession, pwzSql, NULL, NULL, &bstrErrorDescription);
@@ -1228,7 +1228,7 @@ extern "C" UINT __stdcall ExecuteSqlStrings(MSIHANDLE hInstall)
             WcaLog(LOGMSG_STANDARD, "Error 0x%x: failed to execute SQL string but continuing, error: %ls, SQL key: %ls SQL string: %ls", hr, NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription, pwzSqlKey, pwzSql);
             hr = S_OK;
         }
-        MessageExitOnFailure3(hr, msierrSQLFailedExecString, "failed to execute SQL string, error: %ls, SQL key: %ls SQL string: %ls", NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription, pwzSqlKey, pwzSql);
+        MessageExitOnFailure(hr, msierrSQLFailedExecString, "failed to execute SQL string, error: %ls, SQL key: %ls SQL string: %ls", NULL == bstrErrorDescription ? L"unknown error" : bstrErrorDescription, pwzSqlKey, pwzSql);
 
         WcaProgressMessage(COST_SQL_STRING, FALSE);
     }
@@ -1342,7 +1342,7 @@ extern "C" UINT __stdcall CreateSmb(MSIHANDLE hInstall)
     ssp.pUserPerms = pUserPermsList;
 
     hr = ScaEnsureSmbExists(&ssp);
-    MessageExitOnFailure1(hr, msierrSMBFailedCreate, "failed to create share: '%ls'", pwzFsKey);
+    MessageExitOnFailure(hr, msierrSMBFailedCreate, "failed to create share: '%ls'", pwzFsKey);
 
     hr = WcaProgressMessage(COST_SMB_CREATESMB, FALSE);
 
@@ -1398,7 +1398,7 @@ extern "C" UINT __stdcall DropSmb(MSIHANDLE hInstall)
     ssp.wzKey = pwzFsKey;
 
     hr = ScaDropSmb(&ssp);
-    MessageExitOnFailure1(hr, msierrSMBFailedDrop, "failed to delete share: '%ls'", pwzFsKey);
+    MessageExitOnFailure(hr, msierrSMBFailedDrop, "failed to delete share: '%ls'", pwzFsKey);
 
     hr = WcaProgressMessage(COST_SMB_DROPSMB, FALSE);
 
@@ -1462,19 +1462,19 @@ static HRESULT AddUserToGroup(
         WcaLog(LOGMSG_VERBOSE, "Failed to add user: %ls, domain %ls to group: %ls, domain: %ls with error 0x%x.  Attempting to use Active Directory", wzUser, wzUserDomain, wzGroup, wzGroupDomain, hr);
 
         hr = UserCreateADsPath(wzUserDomain, wzUser, &bstrUser);
-        ExitOnFailure2(hr, "failed to create user ADsPath for user: %ls domain: %ls", wzUser, wzUserDomain);
+        ExitOnFailure(hr, "failed to create user ADsPath for user: %ls domain: %ls", wzUser, wzUserDomain);
 
         hr = UserCreateADsPath(wzGroupDomain, wzGroup, &bstrGroup);
-        ExitOnFailure2(hr, "failed to create group ADsPath for group: %ls domain: %ls", wzGroup, wzGroupDomain);
+        ExitOnFailure(hr, "failed to create group ADsPath for group: %ls domain: %ls", wzGroup, wzGroupDomain);
 
         hr = ::ADsGetObject(bstrGroup,IID_IADsGroup, reinterpret_cast<void**>(&pGroup));
-        ExitOnFailure1(hr, "Failed to get group '%ls'.", reinterpret_cast<WCHAR*>(bstrGroup) );
+        ExitOnFailure(hr, "Failed to get group '%ls'.", reinterpret_cast<WCHAR*>(bstrGroup) );
 
         hr = pGroup->Add(bstrUser);
         if ((HRESULT_FROM_WIN32(ERROR_OBJECT_ALREADY_EXISTS) == hr) || (HRESULT_FROM_WIN32(ERROR_MEMBER_IN_ALIAS) == hr))
             hr = S_OK;
 
-        ExitOnFailure2(hr, "Failed to add user %ls to group '%ls'.", reinterpret_cast<WCHAR*>(bstrUser), reinterpret_cast<WCHAR*>(bstrGroup) );
+        ExitOnFailure(hr, "Failed to add user %ls to group '%ls'.", reinterpret_cast<WCHAR*>(bstrUser), reinterpret_cast<WCHAR*>(bstrGroup) );
     }
 
 LExit:
@@ -1531,16 +1531,16 @@ static HRESULT RemoveUserFromGroup(
         WcaLog(LOGMSG_VERBOSE, "Failed to remove user: %ls, domain %ls from group: %ls, domain: %ls with error 0x%x.  Attempting to use Active Directory", wzUser, wzUserDomain, wzGroup, wzGroupDomain, hr);
 
         hr = UserCreateADsPath(wzUserDomain, wzUser, &bstrUser);
-        ExitOnFailure2(hr, "failed to create user ADsPath in order to remove user: %ls domain: %ls from a group", wzUser, wzUserDomain);
+        ExitOnFailure(hr, "failed to create user ADsPath in order to remove user: %ls domain: %ls from a group", wzUser, wzUserDomain);
 
         hr = UserCreateADsPath(wzGroupDomain, wzGroup, &bstrGroup);
-        ExitOnFailure2(hr, "failed to create group ADsPath in order to remove user from group: %ls domain: %ls", wzGroup, wzGroupDomain);
+        ExitOnFailure(hr, "failed to create group ADsPath in order to remove user from group: %ls domain: %ls", wzGroup, wzGroupDomain);
 
         hr = ::ADsGetObject(bstrGroup,IID_IADsGroup, reinterpret_cast<void**>(&pGroup));
-        ExitOnFailure1(hr, "Failed to get group '%ls'.", reinterpret_cast<WCHAR*>(bstrGroup) );
+        ExitOnFailure(hr, "Failed to get group '%ls'.", reinterpret_cast<WCHAR*>(bstrGroup) );
 
         hr = pGroup->Remove(bstrUser);
-        ExitOnFailure2(hr, "Failed to remove user %ls from group '%ls'.", reinterpret_cast<WCHAR*>(bstrUser), reinterpret_cast<WCHAR*>(bstrGroup) );
+        ExitOnFailure(hr, "Failed to remove user %ls from group '%ls'.", reinterpret_cast<WCHAR*>(bstrUser), reinterpret_cast<WCHAR*>(bstrGroup) );
     }
 
 LExit:
@@ -1579,7 +1579,7 @@ static HRESULT ModifyUserLocalServiceRight(
     }
 
     hr = AclGetAccountSid(NULL, pwzUser, &psid);
-    ExitOnFailure1(hr, "Failed to get SID for user: %ls", pwzUser);
+    ExitOnFailure(hr, "Failed to get SID for user: %ls", pwzUser);
 
     nt = ::LsaOpenPolicy(NULL, &ObjectAttributes, POLICY_ALL_ACCESS, &hPolicy);
     hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
@@ -1593,13 +1593,13 @@ static HRESULT ModifyUserLocalServiceRight(
     {
         nt = ::LsaAddAccountRights(hPolicy, psid, &lucPrivilege, 1);
         hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
-        ExitOnFailure1(hr, "Failed to add 'logon as service' bit to user: %ls", pwzUser);
+        ExitOnFailure(hr, "Failed to add 'logon as service' bit to user: %ls", pwzUser);
     }
     else
     {
         nt = ::LsaRemoveAccountRights(hPolicy, psid, FALSE, &lucPrivilege, 1);
         hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
-        ExitOnFailure1(hr, "Failed to remove 'logon as service' bit from user: %ls", pwzUser);
+        ExitOnFailure(hr, "Failed to remove 'logon as service' bit from user: %ls", pwzUser);
     }
 
 LExit:
@@ -1641,7 +1641,7 @@ static HRESULT ModifyUserLocalBatchRight(
     }
 
     hr = AclGetAccountSid(NULL, pwzUser, &psid);
-    ExitOnFailure1(hr, "Failed to get SID for user: %ls", pwzUser);
+    ExitOnFailure(hr, "Failed to get SID for user: %ls", pwzUser);
 
     nt = ::LsaOpenPolicy(NULL, &ObjectAttributes, POLICY_ALL_ACCESS, &hPolicy);
     hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
@@ -1655,13 +1655,13 @@ static HRESULT ModifyUserLocalBatchRight(
     {
         nt = ::LsaAddAccountRights(hPolicy, psid, &lucPrivilege, 1);
         hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
-        ExitOnFailure1(hr, "Failed to add 'logon as batch job' bit to user: %ls", pwzUser);
+        ExitOnFailure(hr, "Failed to add 'logon as batch job' bit to user: %ls", pwzUser);
     }
     else
     {
         nt = ::LsaRemoveAccountRights(hPolicy, psid, FALSE, &lucPrivilege, 1);
         hr = HRESULT_FROM_WIN32(::LsaNtStatusToWinError(nt));
-        ExitOnFailure1(hr, "Failed to remove 'logon as batch job' bit from user: %ls", pwzUser);
+        ExitOnFailure(hr, "Failed to remove 'logon as batch job' bit from user: %ls", pwzUser);
     }
 
   LExit:
@@ -1838,21 +1838,21 @@ extern "C" UINT __stdcall CreateUser(
         }
         else if (NERR_PasswordTooShort == er || NERR_PasswordTooLong == er)
         {
-            MessageExitOnFailure1(hr = HRESULT_FROM_WIN32(er), msierrUSRFailedUserCreatePswd, "failed to create user: %ls due to invalid password.", pwzName);
+            MessageExitOnFailure(hr = HRESULT_FROM_WIN32(er), msierrUSRFailedUserCreatePswd, "failed to create user: %ls due to invalid password.", pwzName);
         }
-        MessageExitOnFailure1(hr = HRESULT_FROM_WIN32(er), msierrUSRFailedUserCreate, "failed to create user: %ls", pwzName);
+        MessageExitOnFailure(hr = HRESULT_FROM_WIN32(er), msierrUSRFailedUserCreate, "failed to create user: %ls", pwzName);
     }
 
     if (SCAU_ALLOW_LOGON_AS_SERVICE & iAttributes)
     {
         hr = ModifyUserLocalServiceRight(pwzDomain, pwzName, TRUE);
-        MessageExitOnFailure1(hr, msierrUSRFailedGrantLogonAsService, "Failed to grant logon as service rights to user: %ls", pwzName);
+        MessageExitOnFailure(hr, msierrUSRFailedGrantLogonAsService, "Failed to grant logon as service rights to user: %ls", pwzName);
     }
 
     if (SCAU_ALLOW_LOGON_AS_BATCH & iAttributes)
     {
         hr = ModifyUserLocalBatchRight(pwzDomain, pwzName, TRUE);
-        MessageExitOnFailure1(hr, msierrUSRFailedGrantLogonAsService, "Failed to grant logon as batch job rights to user: %ls", pwzName);
+        MessageExitOnFailure(hr, msierrUSRFailedGrantLogonAsService, "Failed to grant logon as batch job rights to user: %ls", pwzName);
     }
 
     //
@@ -1861,16 +1861,16 @@ extern "C" UINT __stdcall CreateUser(
     while (S_OK == (hr = WcaReadStringFromCaData(&pwz, &pwzGroup)))
     {
         hr = WcaReadStringFromCaData(&pwz, &pwzGroupDomain);
-        ExitOnFailure1(hr, "failed to get domain for group: %ls", pwzGroup);
+        ExitOnFailure(hr, "failed to get domain for group: %ls", pwzGroup);
 
         hr = AddUserToGroup(pwzName, pwzDomain, pwzGroup, pwzGroupDomain);
-        MessageExitOnFailure2(hr, msierrUSRFailedUserGroupAdd, "failed to add user: %ls to group %ls", pwzName, pwzGroup);
+        MessageExitOnFailure(hr, msierrUSRFailedUserGroupAdd, "failed to add user: %ls to group %ls", pwzName, pwzGroup);
     }
     if (E_NOMOREITEMS == hr) // if there are no more items, all is well
     {
         hr = S_OK;
     }
-    ExitOnFailure1(hr, "failed to get next group in which to include user:%ls", pwzName);
+    ExitOnFailure(hr, "failed to get next group in which to include user:%ls", pwzName);
 
 LExit:
     if (puserInfo)
@@ -2009,7 +2009,7 @@ extern "C" UINT __stdcall RemoveUser(
         {
             er = NERR_Success;
         }
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(er), "failed to delete user account: %ls", pwzName);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(er), "failed to delete user account: %ls", pwzName);
     }
     else
     {
@@ -2039,7 +2039,7 @@ extern "C" UINT __stdcall RemoveUser(
             hr = S_OK;
         }
 
-        ExitOnFailure1(hr, "failed to get next group from which to remove user:%ls", pwzName);
+        ExitOnFailure(hr, "failed to get next group from which to remove user:%ls", pwzName);
     }
 
 LExit:
@@ -2287,7 +2287,7 @@ extern "C" UINT __stdcall StartIIS7ConfigTransaction(MSIHANDLE hInstall)
         }
         else
         {
-            ExitOnFailure2(hr, "Failed to copy config backup %ls -> %ls", wzConfigSource, wzConfigCopy);
+            ExitOnFailure(hr, "Failed to copy config backup %ls -> %ls", wzConfigSource, wzConfigCopy);
         }
     }
 

--- a/src/ext/ca/serverca/scaexec/scaexecIIS7.cpp
+++ b/src/ext/ca/serverca/scaexec/scaexecIIS7.cpp
@@ -471,7 +471,7 @@ HRESULT IIS7ConfigChanges(MSIHANDLE /*hInstall*/, __inout LPWSTR pwzData)
                 break;
 
         default:
-            ExitOnFailure1(hr = E_UNEXPECTED, "IIS7ConfigChanges: Unexpected IIS Config action specified: %d", iAction);
+            ExitOnFailure(hr = E_UNEXPECTED, "IIS7ConfigChanges: Unexpected IIS Config action specified: %d", iAction);
             break;
         }
         if (S_OK == hr)
@@ -761,7 +761,7 @@ HRESULT IIS7WebDir(
             }
             // and delete location tag for this application
             hr = ClearLocationTag(pAdminMgr, pwzLocationPath);
-            ExitOnFailure1(hr, "failed to clear location tag for %ls", pwzLocationPath)
+            ExitOnFailure(hr, "failed to clear location tag for %ls", pwzLocationPath)
             break;
         }
         default:
@@ -1596,7 +1596,7 @@ static HRESULT DeleteGlobalFilter( __inout LPWSTR *ppwzCustomActionData, IAppHos
     ExitOnFailure(hr, "Failed to read filter site name");
 
     DeleteCollectionElement(pCollection, IIS_CONFIG_FILTER, IIS_CONFIG_NAME, pwzFilterName);
-    ExitOnFailure1(hr, "Failed to delete filter %ls", pwzFilterName);
+    ExitOnFailure(hr, "Failed to delete filter %ls", pwzFilterName);
 
 LExit:
     ReleaseStr(pwzFilterName);
@@ -1798,7 +1798,7 @@ static HRESULT DeleteSiteFilter(__inout LPWSTR *ppwzCustomActionData, IAppHostWr
     ExitOnFailure(hr, "Failed get filter collection");
 
     DeleteCollectionElement(pCollection, IIS_CONFIG_FILTER, IIS_CONFIG_NAME, pwzFilterName);
-    ExitOnFailure1(hr, "Failed to delete filter %ls", pwzFilterName);
+    ExitOnFailure(hr, "Failed to delete filter %ls", pwzFilterName);
 
 LExit:
     ReleaseStr(pwzFilterName);
@@ -2015,7 +2015,7 @@ HRESULT IIS7Application(
 
                     // and delete location tag for this application
                     hr = ClearLocationTag(pAdminMgr, pwzLocationPath);
-                    ExitOnFailure1(hr, "failed to clear location tag for %ls", pwzLocationPath);
+                    ExitOnFailure(hr, "failed to clear location tag for %ls", pwzLocationPath);
                 }
             }
             break;
@@ -3009,7 +3009,7 @@ static HRESULT GetSiteElement(
     ExitOnFailure(hr, "Failed get sites collection");
 
     hr = Iis7FindAppHostElementString(pCollection, IIS_CONFIG_SITE, IIS_CONFIG_NAME, swSiteName, ppSiteElement, NULL);
-    ExitOnFailure1(hr, "Failed to find site %ls", swSiteName);
+    ExitOnFailure(hr, "Failed to find site %ls", swSiteName);
 
     *fFound = ppSiteElement != NULL && *ppSiteElement != NULL;
 
@@ -3034,7 +3034,7 @@ static HRESULT GetApplicationElement( IAppHostElement *pSiteElement,
     ExitOnFailure(hr, "Failed get site app collection");
 
     hr = Iis7FindAppHostElementString(pCollection, IIS_CONFIG_APPLICATION, IIS_CONFIG_PATH, swAppPath, ppAppElement, NULL);
-    ExitOnFailure1(hr, "Failed to find app %ls", swAppPath);
+    ExitOnFailure(hr, "Failed to find app %ls", swAppPath);
 
     *fFound = ppAppElement != NULL && *ppAppElement != NULL;
 
@@ -3082,7 +3082,7 @@ static HRESULT GetApplicationElementForVDir( IAppHostElement *pSiteElement,
 
             // Try to find an app with the specified path
             hr = Iis7FindAppHostElementString(pCollection, IIS_CONFIG_APPLICATION, IIS_CONFIG_PATH, pwzAppSearchPath, ppAppElement, NULL);
-            ExitOnFailure1(hr, "Failed to search for app %ls", pwzAppSearchPath);
+            ExitOnFailure(hr, "Failed to search for app %ls", pwzAppSearchPath);
             *fFound = ppAppElement != NULL && *ppAppElement != NULL;
 
             if (*fFound)
@@ -3529,7 +3529,7 @@ static HRESULT DeleteAppPool( IAppHostWritableAdminManager *pAdminMgr,
     ExitOnFailure(hr, "Failed get AppPools collection");
 
     hr = DeleteCollectionElement(pCollection, IIS_CONFIG_ADD, IIS_CONFIG_NAME, swAppPoolName);
-    ExitOnFailure1(hr, "Failed to delete app pool %ls", swAppPoolName);
+    ExitOnFailure(hr, "Failed to delete app pool %ls", swAppPoolName);
 
 LExit:
     ReleaseObject(pAppPools);
@@ -4131,7 +4131,7 @@ static HRESULT ClearLocationTag(
         if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, swLocationPath, -1, bstrLocationPath, -1))
         {
             hr = pLocationCollection->DeleteLocation(vtIndex);
-            ExitOnFailure1(hr, "Failed to delete IIS location tag %ls",swLocationPath);
+            ExitOnFailure(hr, "Failed to delete IIS location tag %ls",swLocationPath);
             break;
         }
 
@@ -4164,14 +4164,14 @@ static HRESULT DeleteCollectionElement(
     VariantInit(&vtIndex);
 
     hr = Iis7FindAppHostElementString(pCollection, pwzElementName, pwzAttributeName, pwzAttributeValue, NULL, &dwIndex);
-    ExitOnFailure3(hr, "Failed while finding IAppHostElement %ls/@%ls=%ls", pwzElementName, pwzAttributeName, pwzAttributeValue);
+    ExitOnFailure(hr, "Failed while finding IAppHostElement %ls/@%ls=%ls", pwzElementName, pwzAttributeName, pwzAttributeValue);
 
     if (MAXDWORD != dwIndex)
     {
         vtIndex.vt = VT_UI4;
         vtIndex.ulVal = dwIndex;
         hr = pCollection->DeleteElement(vtIndex);
-        ExitOnFailure3(hr, "Failed to delete IAppHostElement %ls/@%ls=%ls", pwzElementName, pwzAttributeName, pwzAttributeValue);
+        ExitOnFailure(hr, "Failed to delete IAppHostElement %ls/@%ls=%ls", pwzElementName, pwzAttributeName, pwzAttributeValue);
     }
     // else : nothing to do, already deleted
 LExit:

--- a/src/ext/ca/serverca/scaexec/scaperfexec.cpp
+++ b/src/ext/ca/serverca/scaexec/scaperfexec.cpp
@@ -139,7 +139,7 @@ extern "C" UINT __stdcall RegisterPerfmon(
 
     if (0 == cchShortPathLength)
     {
-        ExitOnLastError1(hr, "failed to get short path format of path: %ls", pwzData);
+        ExitOnLastError(hr, "failed to get short path format of path: %ls", pwzData);
     }
 
     hr = StrAllocFormatted(&pwzCommand, L"lodctr \"%s\"", pwzShortPath);
@@ -150,7 +150,7 @@ extern "C" UINT __stdcall RegisterPerfmon(
     if (dwRet != ERROR_SUCCESS && dwRet != ERROR_ALREADY_EXISTS)
     {
         hr = HRESULT_FROM_WIN32(dwRet);
-        MessageExitOnFailure1(hr, msierrPERFMONFailedRegisterDLL, "failed to register with PerfMon, DLL: %ls", pwzData);
+        MessageExitOnFailure(hr, msierrPERFMONFailedRegisterDLL, "failed to register with PerfMon, DLL: %ls", pwzData);
     }
 
     hr = S_OK;
@@ -197,14 +197,14 @@ extern "C" UINT __stdcall UnregisterPerfmon(
     ExitOnNullWithLastError(pfnPerfCounterTextString, hr, "failed to get DLL function for PerfMon");
 
     hr = ::StringCchPrintfW(wz, countof(wz), L"unlodctr \"%s\"", pwzData);
-    ExitOnFailure1(hr, "Failed to format unlodctr string with: %ls", pwzData);
+    ExitOnFailure(hr, "Failed to format unlodctr string with: %ls", pwzData);
     WcaLog(LOGMSG_VERBOSE, "UnregisterPerfmon running command: '%ls'", wz);
     dwRet = (*pfnPerfCounterTextString)(wz, TRUE);
     // if the counters aren't registered, then OK to continue
     if (dwRet != ERROR_SUCCESS && dwRet != ERROR_FILE_NOT_FOUND && dwRet != ERROR_BADKEY)
     {
         hr = HRESULT_FROM_WIN32(dwRet);
-        MessageExitOnFailure1(hr, msierrPERFMONFailedUnregisterDLL, "failed to unregsister with PerfMon, DLL: %ls", pwzData);
+        MessageExitOnFailure(hr, msierrPERFMONFailedUnregisterDLL, "failed to unregsister with PerfMon, DLL: %ls", pwzData);
     }
 
     hr = S_OK;
@@ -282,10 +282,10 @@ static HRESULT ExecutePerfCounterData(
             ExitOnFailure(hr, "Failed to create temp directory.");
 
             hr = CreateDataFile(pwzTempFolder, pwzIniData, TRUE, &hIniData, &pwzIniFile);
-            ExitOnFailure1(hr, "Failed to create .ini file for performance counter category: %ls", pwzName);
+            ExitOnFailure(hr, "Failed to create .ini file for performance counter category: %ls", pwzName);
 
             hr = CreateDataFile(pwzTempFolder, pwzConstantData, FALSE, &hConstantData, NULL);
-            ExitOnFailure1(hr, "Failed to create .h file for performance counter category: %ls", pwzName);
+            ExitOnFailure(hr, "Failed to create .h file for performance counter category: %ls", pwzName);
 
             hr = StrAllocFormatted(&pwzExecute, L"%s \"%s\"", wzPrefix, pwzIniFile);
             ExitOnFailure(hr, "Failed to allocate string to execute.");
@@ -293,7 +293,7 @@ static HRESULT ExecutePerfCounterData(
             // Execute the install.
             er = (*pfnPerfCounterTextString)(pwzExecute, TRUE);
             hr = HRESULT_FROM_WIN32(er);
-            ExitOnFailure1(hr, "Failed to execute install of performance counter category: %ls", pwzName);
+            ExitOnFailure(hr, "Failed to execute install of performance counter category: %ls", pwzName);
 
             if (INVALID_HANDLE_VALUE != hIniData)
             {
@@ -322,7 +322,7 @@ static HRESULT ExecutePerfCounterData(
                 er = ERROR_SUCCESS;
             }
             hr = HRESULT_FROM_WIN32(er);
-            ExitOnFailure1(hr, "Failed to execute uninstall of performance counter category: %ls", pwzName);
+            ExitOnFailure(hr, "Failed to execute uninstall of performance counter category: %ls", pwzName);
         }
     }
 
@@ -398,12 +398,12 @@ static HRESULT CreateDataFile(
     hFile = ::CreateFileW(pwzFile, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to open new temp file: %ls", pwzFile);
+        ExitWithLastError(hr, "Failed to open new temp file: %ls", pwzFile);
     }
 
     if (!::WriteFile(hFile, pszData, cbData, &cbWritten, NULL))
     {
-        ExitWithLastError1(hr, "Failed to write data to new temp file: %ls", pwzFile);
+        ExitWithLastError(hr, "Failed to write data to new temp file: %ls", pwzFile);
     }
 
     if (INVALID_HANDLE_VALUE != hFile)

--- a/src/ext/ca/serverca/scaexec/scasmbexec.cpp
+++ b/src/ext/ca/serverca/scaexec/scasmbexec.cpp
@@ -35,7 +35,7 @@ HRESULT AllocateAcl(SCA_SMBP* pssp, PACL* ppACL)
     cEA = pssp->dwUserPermissionCount + 1;
     if (cEA >= MAXSIZE_T / sizeof(EXPLICIT_ACCESSW))
     {
-        ExitOnFailure1(hr = E_OUTOFMEMORY, "Too many user permissions to allocate: %u", cEA);
+        ExitOnFailure(hr = E_OUTOFMEMORY, "Too many user permissions to allocate: %u", cEA);
     }
 
     pEA = static_cast<EXPLICIT_ACCESSW*>(MemAlloc(cEA * sizeof(EXPLICIT_ACCESSW), TRUE));
@@ -88,7 +88,7 @@ HRESULT AllocateAcl(SCA_SMBP* pssp, PACL* ppACL)
         {
             hr = AclGetAccountSid(NULL, wzUser, &psid);
         }
-        ExitOnFailure1(hr, "failed to get sid for account: %ls", wzUser);
+        ExitOnFailure(hr, "failed to get sid for account: %ls", wzUser);
 
         // we now have a valid pSid, fill in the EXPLICIT_ACCESS
 
@@ -238,7 +238,7 @@ HRESULT CreateShare(SCA_SMBP* pssp)
 
     // Fail if the directory doesn't exist
     if (!DirExists(pssp->wzDirectory, NULL))
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND), "Can't create a file share on directory that doesn't exist: %ls.", pssp->wzDirectory);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND), "Can't create a file share on directory that doesn't exist: %ls.", pssp->wzDirectory);
 
     WcaLog(LOGMSG_VERBOSE, "Creating file share on directory \'%ls\' named \'%ls\'.", pssp->wzDirectory, pssp->wzKey);
 
@@ -261,7 +261,7 @@ HRESULT CreateShare(SCA_SMBP* pssp)
             WcaLog(LOGMSG_VERBOSE, "Duplicate error when existence check failed.");
 
         // error codes listed above.
-        ExitOnFailure1(hr, "Failed to create/modify file share: Err: %d", s);
+        ExitOnFailure(hr, "Failed to create/modify file share: Err: %d", s);
     }
 
 LExit:
@@ -313,13 +313,13 @@ HRESULT ScaDropSmb(SCA_SMBP* pssp)
 
     }
 
-    ExitOnFailure1(hr, "Unable to detect share. (%ls)", pssp->wzKey);
+    ExitOnFailure(hr, "Unable to detect share. (%ls)", pssp->wzKey);
 
     s = ::NetShareDel(NULL, pssp->wzKey, 0);
     if (NERR_Success != s)
     {
         hr = E_FAIL;
-        ExitOnFailure1(hr, "Failed to remove file share: Err: %d", s);
+        ExitOnFailure(hr, "Failed to remove file share: Err: %d", s);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scaapppool.cpp
+++ b/src/ext/ca/serverca/scasched/scaapppool.cpp
@@ -112,7 +112,7 @@ HRESULT ScaAppPoolRead(
             psap->fHasComponent = TRUE;
 
             hr = ::StringCchCopyW(psap->wzComponent, countof(psap->wzComponent), pwzData);
-            ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+            ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
             hr = WcaGetRecordInteger(hRec, apqInstalled, (int *)&psap->isInstalled);
             ExitOnFailure(hr, "Failed to get Component installed state for app pool");
@@ -122,7 +122,7 @@ HRESULT ScaAppPoolRead(
 
             WcaFetchWrappedReset(hComponentQuery);
             hr = WcaFetchWrappedRecordWhereString(hComponentQuery, caqComponent, psap->wzComponent, &hRecComp);
-            ExitOnFailure1(hr, "Failed to fetch Component.Attributes for Component '%ls'", psap->wzComponent);
+            ExitOnFailure(hr, "Failed to fetch Component.Attributes for Component '%ls'", psap->wzComponent);
 
             hr = WcaGetRecordInteger(hRecComp, caqAttributes, &psap->iCompAttributes);
             ExitOnFailure(hr, "failed to get Component.Attributes");
@@ -131,12 +131,12 @@ HRESULT ScaAppPoolRead(
         hr = WcaGetRecordString(hRec, apqAppPool, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.AppPool");
         hr = ::StringCchCopyW(psap->wzAppPool, countof(psap->wzAppPool), pwzData);
-        ExitOnFailure1(hr, "failed to copy AppPool name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy AppPool name: %ls", pwzData);
 
         hr = WcaGetRecordString(hRec, apqName, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.Name");
         hr = ::StringCchCopyW(psap->wzName, countof(psap->wzName), pwzData);
-        ExitOnFailure1(hr, "failed to copy app pool name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy app pool name: %ls", pwzData);
         hr = ::StringCchPrintfW(psap->wzKey, countof(psap->wzKey), L"/LM/W3SVC/AppPools/%s", pwzData);
         ExitOnFailure(hr, "failed to format app pool key name");
 
@@ -146,7 +146,7 @@ HRESULT ScaAppPoolRead(
         hr = WcaGetRecordString(hRec, apqUser, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.User");
         hr = ScaGetUserDeferred(pwzData, hUserQuery, &psap->suUser);
-        ExitOnFailure1(hr, "failed to get user: %ls", pwzData);
+        ExitOnFailure(hr, "failed to get user: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, apqRecycleRequests, &psap->iRecycleRequests);
         ExitOnFailure(hr, "failed to get AppPool.RecycleRequests");
@@ -157,7 +157,7 @@ HRESULT ScaAppPoolRead(
         hr = WcaGetRecordString(hRec, apqRecycleTimes, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.RecycleTimes");
         hr = ::StringCchCopyW(psap->wzRecycleTimes, countof(psap->wzRecycleTimes), pwzData);
-        ExitOnFailure1(hr, "failed to copy recycle value: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy recycle value: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, apqVirtualMemory, &psap->iVirtualMemory);
         ExitOnFailure(hr, "failed to get AppPool.VirtualMemory");
@@ -174,7 +174,7 @@ HRESULT ScaAppPoolRead(
         hr = WcaGetRecordString(hRec, apqCpuMon, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.CPUMon");
         hr = ::StringCchCopyW(psap->wzCpuMon, countof(psap->wzCpuMon), pwzData);
-        ExitOnFailure1(hr, "failed to copy cpu monitor value: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy cpu monitor value: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, apqMaxProc, &psap->iMaxProcesses);
         ExitOnFailure(hr, "failed to get AppPool.MaxProc");
@@ -182,12 +182,12 @@ HRESULT ScaAppPoolRead(
         hr = WcaGetRecordString(hRec, apqManagedRuntimeVersion, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.ManagedRuntimeVersion");
         hr = ::StringCchCopyW(psap->wzManagedRuntimeVersion, countof(psap->wzManagedRuntimeVersion), pwzData);
-        ExitOnFailure1(hr, "failed to copy ManagedRuntimeVersion value: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy ManagedRuntimeVersion value: %ls", pwzData);
 
         hr = WcaGetRecordString(hRec, apqManagedPipelineMode, &pwzData);
         ExitOnFailure(hr, "failed to get AppPool.ManagedPipelineMode");
         hr = ::StringCchCopyW(psap->wzManagedPipelineMode, countof(psap->wzManagedPipelineMode), pwzData);
-        ExitOnFailure1(hr, "failed to copy ManagedPipelineMode value: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy ManagedPipelineMode value: %ls", pwzData);
 
     }
 
@@ -227,17 +227,17 @@ HRESULT ScaFindAppPool(
             break;
         }
     }
-    ExitOnNull1(psap, hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Could not find the app pool: %ls", wzAppPool);
+    ExitOnNull(psap, hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Could not find the app pool: %ls", wzAppPool);
 
     // copy the web app pool name
     hr = ::StringCchCopyW(wzName, cchName, psap->wzName);
-    ExitOnFailure1(hr, "failed to copy app pool name while finding app pool: %ls", psap->wzName);
+    ExitOnFailure(hr, "failed to copy app pool name while finding app pool: %ls", psap->wzName);
 
     // if it's not being installed now, check if it exists already
     if (!psap->fHasComponent)
     {
         hr = AppPoolExists(piMetabase, psap->wzName);
-        ExitOnFailure1(hr, "failed to check for existence of app pool: %ls", psap->wzName);
+        ExitOnFailure(hr, "failed to check for existence of app pool: %ls", psap->wzName);
     }
 
 LExit:
@@ -289,7 +289,7 @@ HRESULT ScaAppPoolInstall(
         if (psap->fHasComponent && WcaIsInstalling(psap->isInstalled, psap->isAction))
         {
             hr = ScaWriteAppPool(piMetabase, psap);
-            ExitOnFailure1(hr, "failed to write AppPool '%ls' to metabase", psap->wzAppPool);
+            ExitOnFailure(hr, "failed to write AppPool '%ls' to metabase", psap->wzAppPool);
         }
     }
 
@@ -313,7 +313,7 @@ HRESULT ScaAppPoolUninstall(
         if (psap->fHasComponent && WcaIsUninstalling(psap->isInstalled, psap->isAction))
         {
             hr = ScaRemoveAppPool(piMetabase, psap);
-            ExitOnFailure1(hr, "Failed to remove AppPool '%ls' from metabase", psap->wzAppPool);
+            ExitOnFailure(hr, "Failed to remove AppPool '%ls' from metabase", psap->wzAppPool);
         }
     }
 
@@ -341,16 +341,16 @@ HRESULT ScaWriteAppPool(
     {
         // didn't find the AppPool key, so we need to create it
         hr = ScaCreateMetabaseKey(piMetabase, psap->wzKey, L"");
-        ExitOnFailure1(hr, "failed to create AppPool key: %ls", psap->wzKey);
+        ExitOnFailure(hr, "failed to create AppPool key: %ls", psap->wzKey);
 
         // mark it as an AppPool
         hr = ScaWriteMetabaseValue(piMetabase, psap->wzKey, NULL, MD_KEY_TYPE, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, STRING_METADATA, (LPVOID)L"IIsApplicationPool");
-        ExitOnFailure1(hr, "failed to mark key as AppPool key: %ls", psap->wzKey);
+        ExitOnFailure(hr, "failed to mark key as AppPool key: %ls", psap->wzKey);
 
         // TODO: Make this an Attribute?
         // set autostart value
         hr = ScaWriteMetabaseValue(piMetabase, psap->wzKey, NULL, MD_APPPOOL_AUTO_START, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, DWORD_METADATA, (LPVOID)1);
-        ExitOnFailure1(hr, "failed to mark key as AppPool key: %ls", psap->wzKey);
+        ExitOnFailure(hr, "failed to mark key as AppPool key: %ls", psap->wzKey);
     }
     else
     {
@@ -432,7 +432,7 @@ HRESULT ScaWriteAppPool(
         dwPercent = wcstoul(pwzValue, &wz, 10);
         if (100  < dwPercent)
         {
-            ExitOnFailure1(hr = E_INVALIDARG, "invalid maximum cpu percentage value: %d", dwPercent);
+            ExitOnFailure(hr = E_INVALIDARG, "invalid maximum cpu percentage value: %d", dwPercent);
         }
         if (wz && L',' == *wz)
         {
@@ -543,12 +543,12 @@ HRESULT ScaWriteAppPool(
             if (*psap->suUser.wzDomain)
             {
                 hr = StrAllocFormatted(&pwzValue, L"%s\\%s", psap->suUser.wzDomain, psap->suUser.wzName);
-                ExitOnFailure2(hr, "failed to format user name: %ls domain: %ls", psap->suUser.wzName, psap->suUser.wzDomain);
+                ExitOnFailure(hr, "failed to format user name: %ls domain: %ls", psap->suUser.wzName, psap->suUser.wzDomain);
             }
             else
             {
                 hr = StrAllocFormatted(&pwzValue, L"%s", psap->suUser.wzName);
-                ExitOnFailure1(hr, "failed to format user name: %ls", psap->suUser.wzName);
+                ExitOnFailure(hr, "failed to format user name: %ls", psap->suUser.wzName);
             }
 
             hr = ScaWriteMetabaseValue(piMetabase, psap->wzKey, NULL, MD_WAM_USER_NAME, METADATA_INHERIT , IIS_MD_UT_FILE, STRING_METADATA, (LPVOID)pwzValue);
@@ -579,7 +579,7 @@ HRESULT ScaRemoveAppPool(
     if (0 != lstrlenW(psap->wzKey))
     {
         hr = ScaDeleteMetabaseKey(piMetabase, psap->wzKey, L"");
-        ExitOnFailure1(hr, "failed to delete AppPool key: %ls", psap->wzKey);
+        ExitOnFailure(hr, "failed to delete AppPool key: %ls", psap->wzKey);
     }
 
     // TODO: Maybe check to make sure any web sites that are using this AppPool are put back in the 'DefaultAppPool'

--- a/src/ext/ca/serverca/scasched/scaapppool7.cpp
+++ b/src/ext/ca/serverca/scasched/scaapppool7.cpp
@@ -39,18 +39,18 @@ HRESULT ScaFindAppPool7(
             break;
         }
     }
-    ExitOnNull1(psap, hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Could not find the app pool: %ls", wzAppPool);
+    ExitOnNull(psap, hr, HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "Could not find the app pool: %ls", wzAppPool);
 
     // copy the web app pool name
 #pragma prefast(suppress:26037, "Source string is null terminated - it is populated as target of ::StringCchCopyW")
     hr = ::StringCchCopyW(wzName, cchName, psap->wzName);
-    ExitOnFailure1(hr, "failed to copy app pool name while finding app pool: %ls", psap->wzName);
+    ExitOnFailure(hr, "failed to copy app pool name while finding app pool: %ls", psap->wzName);
 
     // if it's not being installed now, check if it exists already
     if (!psap->fHasComponent)
     {
         hr = AppPoolExists(psap->wzName);
-        ExitOnFailure1(hr, "failed to check for existence of app pool: %ls", psap->wzName);
+        ExitOnFailure(hr, "failed to check for existence of app pool: %ls", psap->wzName);
     }
 
 LExit:
@@ -83,7 +83,7 @@ HRESULT ScaAppPoolInstall7(
         if (psap->fHasComponent && WcaIsInstalling(psap->isInstalled, psap->isAction))
         {
             hr = ScaWriteAppPool7(psap);
-            ExitOnFailure1(hr, "failed to write AppPool '%ls' to metabase", psap->wzAppPool);
+            ExitOnFailure(hr, "failed to write AppPool '%ls' to metabase", psap->wzAppPool);
         }
     }
 
@@ -105,7 +105,7 @@ HRESULT ScaAppPoolUninstall7(
         if (psap->fHasComponent && WcaIsUninstalling(psap->isInstalled, psap->isAction))
         {
             hr = ScaRemoveAppPool7(psap);
-            ExitOnFailure1(hr, "Failed to remove AppPool '%ls' from metabase", psap->wzAppPool);
+            ExitOnFailure(hr, "Failed to remove AppPool '%ls' from metabase", psap->wzAppPool);
         }
     }
 
@@ -133,7 +133,7 @@ HRESULT ScaWriteAppPool7(
     ExitOnFailure(hr, "failed to write AppPool create action.");
 
     hr = ScaWriteConfigString(psap->wzName);
-    ExitOnFailure1(hr, "failed to write AppPool name: %ls", psap->wzName);
+    ExitOnFailure(hr, "failed to write AppPool name: %ls", psap->wzName);
 
     // Now do all the optional stuff
 
@@ -207,7 +207,7 @@ HRESULT ScaWriteAppPool7(
         dwPercent = wcstoul(pwzValue, &wz, 10);
         if (100  < dwPercent)
         {
-            ExitOnFailure1(hr = E_INVALIDARG, "invalid maximum cpu percentage value: %d", dwPercent);
+            ExitOnFailure(hr = E_INVALIDARG, "invalid maximum cpu percentage value: %d", dwPercent);
         }
         if (wz && L',' == *wz)
         {
@@ -335,12 +335,12 @@ HRESULT ScaWriteAppPool7(
             if (*psap->suUser.wzDomain)
             {
                 hr = StrAllocFormatted(&pwzValue, L"%s\\%s", psap->suUser.wzDomain, psap->suUser.wzName);
-                ExitOnFailure2(hr, "failed to format user name: %ls domain: %ls", psap->suUser.wzName, psap->suUser.wzDomain);
+                ExitOnFailure(hr, "failed to format user name: %ls domain: %ls", psap->suUser.wzName, psap->suUser.wzDomain);
             }
             else
             {
                 hr = StrAllocFormatted(&pwzValue, L"%s", psap->suUser.wzName);
-                ExitOnFailure1(hr, "failed to format user name: %ls", psap->suUser.wzName);
+                ExitOnFailure(hr, "failed to format user name: %ls", psap->suUser.wzName);
             }
 
             hr = ScaWriteConfigID(IIS_APPPOOL_USER);
@@ -404,7 +404,7 @@ HRESULT ScaRemoveAppPool7(
         ExitOnFailure(hr, "failed to write AppPool delete action.");
 
         hr = ScaWriteConfigString(psap->wzName);
-        ExitOnFailure1(hr, "failed to delete AppPool: %ls", psap->wzName);
+        ExitOnFailure(hr, "failed to delete AppPool: %ls", psap->wzName);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scacert.cpp
+++ b/src/ext/ca/serverca/scasched/scacert.cpp
@@ -199,7 +199,7 @@ static HRESULT ConfigureCertificates(
 
         er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pwzComponent, &isInstalled, &isAction);
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnFailure1(hr, "failed to get state for component: %ls", pwzComponent);
+        ExitOnFailure(hr, "failed to get state for component: %ls", pwzComponent);
 
         if (!(WcaIsInstalling(isInstalled, isAction) && SCA_ACTION_INSTALL == saAction) &&
             !(WcaIsUninstalling(isInstalled, isAction) && SCA_ACTION_UNINSTALL == saAction) &&
@@ -226,7 +226,7 @@ static HRESULT ConfigureCertificates(
             break;
         default:
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Invalid store location value: %d", iData);
+            ExitOnFailure(hr, "Invalid store location value: %d", iData);
         }
 
         hr = WcaGetRecordString(hRecCertificate, cqStoreName, &pwzStoreName);
@@ -270,7 +270,7 @@ static HRESULT ConfigureCertificates(
         {
             // Find an existing certificate one (if there is one) to so we have it for rollback.
             hr = FindExistingCertificate(pwzName, dwStoreLocation, pwzStoreName, &pbCertificate, &cbCertificate);
-            ExitOnFailure1(hr, "Failed to search for existing certificate with friendly name: %ls", pwzName);
+            ExitOnFailure(hr, "Failed to search for existing certificate with friendly name: %ls", pwzName);
 
             if (pbCertificate)
             {
@@ -304,7 +304,7 @@ static HRESULT ConfigureCertificates(
         {
             // Actually get the certificate, resolve it to a blob, and get the blob's hash.
             hr = ResolveCertificate(pwzId, pwzName, dwStoreLocation, pwzStoreName, dwAttributes, pwzData, pwzPFXPassword, &pbCertificate, &cbCertificate);
-            ExitOnFailure1(hr, "Failed to resolve certificate: %ls", pwzId);
+            ExitOnFailure(hr, "Failed to resolve certificate: %ls", pwzId);
 
             hr = WcaWriteStreamToCaData(pbCertificate, cbCertificate, &pwzCaData);
             ExitOnFailure(hr, "Failed to pass Certificate.Data to deferred CustomAction.");
@@ -329,11 +329,11 @@ static HRESULT ConfigureCertificates(
         if (wzRollbackAction)
         {
             hr = WcaDoDeferredAction(wzRollbackAction, pwzRollbackCaData, dwCost);
-            ExitOnFailure2(hr, "Failed to schedule rollback certificate action '%ls' for: %ls", wzRollbackAction, pwzId);
+            ExitOnFailure(hr, "Failed to schedule rollback certificate action '%ls' for: %ls", wzRollbackAction, pwzId);
         }
 
         hr = WcaDoDeferredAction(wzAction, pwzCaData, dwCost);
-        ExitOnFailure2(hr, "Failed to schedule certificate action '%ls' for: %ls", wzAction, pwzId);
+        ExitOnFailure(hr, "Failed to schedule certificate action '%ls' for: %ls", wzAction, pwzId);
 
         // Clean up for the next certificate.
         ReleaseNullMem(pbCertificate);
@@ -502,7 +502,7 @@ static HRESULT ResolveCertificate(
 
         // Update the CertificateHash table.
         hr = WcaAddTempRecord(&hCertificateHashView, &hCertificateHashColumns, L"CertificateHash", NULL, 0, 2, wzId, wzEncodedCertificateHash);
-        ExitOnFailure1(hr, "Failed to add encoded has for certificate: %ls", wzId);
+        ExitOnFailure(hr, "Failed to add encoded has for certificate: %ls", wzId);
     }
 
     *ppbCertificate = pbData;
@@ -544,14 +544,14 @@ static HRESULT ReadCertificateFile(
 
     if (!::CryptQueryObject(CERT_QUERY_OBJECT_FILE, reinterpret_cast<LPCVOID>(wzPath), CERT_QUERY_CONTENT_FLAG_ALL, CERT_QUERY_FORMAT_FLAG_ALL, 0, NULL, &dwContentType, NULL, NULL, NULL, (LPCVOID*)&pCertContext))
     {
-        ExitOnFailure1(hr, "Failed to read certificate from file: %ls", wzPath);
+        ExitOnFailure(hr, "Failed to read certificate from file: %ls", wzPath);
     }
 
     if (pCertContext)
     {
         cbData = pCertContext->cbCertEncoded;
         pbData = static_cast<BYTE*>(MemAlloc(cbData, FALSE));
-        ExitOnNull1(pbData, hr, E_OUTOFMEMORY, "Failed to allocate memory to read certificate from file: %ls", wzPath);
+        ExitOnNull(pbData, hr, E_OUTOFMEMORY, "Failed to allocate memory to read certificate from file: %ls", wzPath);
 
         CopyMemory(pbData, pCertContext->pbCertEncoded, pCertContext->cbCertEncoded);
     }
@@ -561,7 +561,7 @@ static HRESULT ReadCertificateFile(
         if (dwContentType & CERT_QUERY_CONTENT_PFX)
         {
             hr = FileRead(&pbData, &cbData, wzPath);
-            ExitOnFailure1(hr, "Failed to read PFX file: %ls", wzPath);
+            ExitOnFailure(hr, "Failed to read PFX file: %ls", wzPath);
         }
         else
         {

--- a/src/ext/ca/serverca/scasched/scadb.cpp
+++ b/src/ext/ca/serverca/scasched/scadb.cpp
@@ -99,14 +99,14 @@ HRESULT ScaDbsRead(
         ExitOnFailure(hr, "Failed to get SqlDatabase.SqlDb");
 
         hr = WcaGetRecordString(hRec, sdqComponent, &pwzComponent);
-        ExitOnFailure1(hr, "Failed to get Component for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Component for database: '%ls'", psd->wzKey);
         if (pwzComponent && *pwzComponent)
         {
             fHasComponent = TRUE;
 
             er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pwzComponent, &isInstalled, &isAction);
             hr = HRESULT_FROM_WIN32(er);
-            ExitOnFailure1(hr, "Failed to get state for component: %ls", pwzComponent);
+            ExitOnFailure(hr, "Failed to get state for component: %ls", pwzComponent);
 
             // If we're doing install but the Component is not being installed or we're doing
             // uninstall but the Component is not being uninstalled, skip it.
@@ -118,45 +118,45 @@ HRESULT ScaDbsRead(
         }
 
         hr  = NewDb(&psd);
-        ExitOnFailure1(hr, "Failed to allocate memory for new database: %D", pwzId);
+        ExitOnFailure(hr, "Failed to allocate memory for new database: %D", pwzId);
 
         hr = ::StringCchCopyW(psd->wzKey, countof(psd->wzKey), pwzId);
-        ExitOnFailure1(hr, "Failed to copy SqlDatabase.SqlDbL: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to copy SqlDatabase.SqlDbL: %ls", pwzId);
 
         hr = ::StringCchCopyW(psd->wzComponent, countof(psd->wzComponent), pwzComponent);
-        ExitOnFailure1(hr, "Failed to copy SqlDatabase.Component_: %ls", pwzComponent);
+        ExitOnFailure(hr, "Failed to copy SqlDatabase.Component_: %ls", pwzComponent);
 
         psd->fHasComponent = fHasComponent;
         psd->isInstalled = isInstalled;
         psd->isAction = isAction;
 
         hr = WcaGetRecordFormattedString(hRec, sdqServer, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Server for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Server for database: '%ls'", psd->wzKey);
         hr = ::StringCchCopyW(psd->wzServer, countof(psd->wzServer), pwzData);
-        ExitOnFailure1(hr, "Failed to copy server string to database object:%ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy server string to database object:%ls", pwzData);
 
         hr = WcaGetRecordFormattedString(hRec, sdqInstance, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Instance for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Instance for database: '%ls'", psd->wzKey);
         hr = ::StringCchCopyW(psd->wzInstance, countof(psd->wzInstance), pwzData);
-        ExitOnFailure1(hr, "Failed to copy instance string to database object:%ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy instance string to database object:%ls", pwzData);
 
         hr = WcaGetRecordFormattedString(hRec, sdqDatabase, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Database for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Database for database: '%ls'", psd->wzKey);
         hr = ::StringCchCopyW(psd->wzDatabase, countof(psd->wzDatabase), pwzData);
-        ExitOnFailure1(hr, "Failed to copy database string to database object:%ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy database string to database object:%ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, sdqAttributes, &psd->iAttributes);
         ExitOnFailure(hr, "Failed to get SqlDatabase.Attributes");
 
         hr = WcaGetRecordFormattedString(hRec, sdqUser, &pwzData);
-        ExitOnFailure1(hr, "Failed to get User record for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get User record for database: '%ls'", psd->wzKey);
 
         // if a user was specified
         if (*pwzData)
         {
             psd->fUseIntegratedAuth = FALSE;
             hr = ScaGetUser(pwzData, &psd->scau);
-            ExitOnFailure1(hr, "Failed to get user information for database: '%ls'", psd->wzKey);
+            ExitOnFailure(hr, "Failed to get user information for database: '%ls'", psd->wzKey);
         }
         else
         {
@@ -165,13 +165,13 @@ HRESULT ScaDbsRead(
         }
 
         hr = WcaGetRecordString(hRec, sdqDbFileSpec, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Database FileSpec for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Database FileSpec for database: '%ls'", psd->wzKey);
 
         // if a database filespec was specified
         if (*pwzData)
         {
             hr = GetFileSpec(hViewFileSpec, pwzData, &psd->sfDb);
-            ExitOnFailure1(hr, "failed to get FileSpec for: %ls", pwzData);
+            ExitOnFailure(hr, "failed to get FileSpec for: %ls", pwzData);
             if (S_OK == hr)
             {
                 psd->fHasDbSpec = TRUE;
@@ -179,13 +179,13 @@ HRESULT ScaDbsRead(
         }
 
         hr = WcaGetRecordString(hRec, sdqLogFileSpec, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Log FileSpec for database: '%ls'", psd->wzKey);
+        ExitOnFailure(hr, "Failed to get Log FileSpec for database: '%ls'", psd->wzKey);
 
         // if a log filespec was specified
         if (*pwzData)
         {
             hr = GetFileSpec(hViewFileSpec, pwzData, &psd->sfLog);
-            ExitOnFailure1(hr, "failed to get FileSpec for: %ls", pwzData);
+            ExitOnFailure(hr, "failed to get FileSpec for: %ls", pwzData);
             if (S_OK == hr)
             {
                 psd->fHasLogSpec = TRUE;
@@ -250,7 +250,7 @@ HRESULT ScaDbsInstall(
                 ((psd->iAttributes & SCADB_DROP_ON_REINSTALL) && WcaIsReInstalling(psd->isInstalled, psd->isAction)))
             {
                 hr = SchedDropDatabase(psd->wzKey, psd->wzServer, psd->wzInstance, psd->wzDatabase, psd->iAttributes, psd->fUseIntegratedAuth, psd->scau.wzName, psd->scau.wzPassword);
-                ExitOnFailure1(hr, "Failed to drop database %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to drop database %ls", psd->wzKey);
             }
 
             // if installing this component
@@ -258,7 +258,7 @@ HRESULT ScaDbsInstall(
                 ((psd->iAttributes & SCADB_CREATE_ON_REINSTALL) && WcaIsReInstalling(psd->isInstalled, psd->isAction)))
             {
                 hr = SchedCreateDatabase(psd);
-                ExitOnFailure1(hr, "Failed to ensure database %ls exists", psd->wzKey);
+                ExitOnFailure(hr, "Failed to ensure database %ls exists", psd->wzKey);
             }
         }
     }
@@ -283,14 +283,14 @@ HRESULT ScaDbsUninstall(
             if ((psd->iAttributes & SCADB_DROP_ON_UNINSTALL) && WcaIsUninstalling(psd->isInstalled, psd->isAction))
             {
                 hr = SchedDropDatabase(psd->wzKey, psd->wzServer, psd->wzInstance, psd->wzDatabase, psd->iAttributes, psd->fUseIntegratedAuth, psd->scau.wzName, psd->scau.wzPassword);
-                ExitOnFailure1(hr, "Failed to drop database %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to drop database %ls", psd->wzKey);
             }
 
             // install the db
             if ((psd->iAttributes & SCADB_CREATE_ON_UNINSTALL) && WcaIsUninstalling(psd->isInstalled, psd->isAction))
             {
                 hr = SchedCreateDatabase(psd);
-                ExitOnFailure1(hr, "Failed to ensure database %ls exists", psd->wzKey);
+                ExitOnFailure(hr, "Failed to ensure database %ls exists", psd->wzKey);
             }
         }
     }
@@ -525,29 +525,29 @@ HRESULT GetFileSpec(
     hRecFileSpec = ::MsiCreateRecord(1);
     if (!hRecFileSpec)
     {
-        ExitOnFailure1(hr = E_UNEXPECTED, "failed to create record for filespec: %ls", wzKey);
+        ExitOnFailure(hr = E_UNEXPECTED, "failed to create record for filespec: %ls", wzKey);
     }
     hr = WcaSetRecordString(hRecFileSpec, 1, wzKey);
-    ExitOnFailure1(hr, "failed to set record string for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "failed to set record string for filespec: %ls", wzKey);
 
     // get the FileSpec record
     hr = WcaExecuteView(hViewFileSpec, hRecFileSpec);
-    ExitOnFailure1(hr, "failed to execute view on SqlFileSpec table for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "failed to execute view on SqlFileSpec table for filespec: %ls", wzKey);
     hr = WcaFetchSingleRecord(hViewFileSpec, &hRec);
-    ExitOnFailure1(hr, "failed to get record for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "failed to get record for filespec: %ls", wzKey);
 
     // read the data out of the filespec record
     hr = WcaGetRecordFormattedString(hRec, sfsqName, &pwzData);
-    ExitOnFailure1(hr, "Failed to get SqlFileSpec.Name for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to get SqlFileSpec.Name for filespec: %ls", wzKey);
     hr = ::StringCchCopyW(psf->wzName, countof(psf->wzName), pwzData);
-    ExitOnFailure1(hr, "Failed to copy SqlFileSpec.Name string: %ls", pwzData);
+    ExitOnFailure(hr, "Failed to copy SqlFileSpec.Name string: %ls", pwzData);
 
     hr = WcaGetRecordFormattedString(hRec, sfsqFilename, &pwzData);
-    ExitOnFailure1(hr, "Failed to get SqlFileSpec.Filename for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to get SqlFileSpec.Filename for filespec: %ls", wzKey);
     if (*pwzData)
     {
         hr = ::StringCchCopyW(psf->wzFilename, countof(psf->wzFilename), pwzData);
-        ExitOnFailure1(hr, "Failed to copy filename to filespec object: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy filename to filespec object: %ls", pwzData);
     }
     else   // if there is no file, skip this FILESPEC
     {
@@ -556,11 +556,11 @@ HRESULT GetFileSpec(
     }
 
     hr = WcaGetRecordFormattedString(hRec, sfsqSize, &pwzData);
-    ExitOnFailure1(hr, "Failed to get SqlFileSpec.Size for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to get SqlFileSpec.Size for filespec: %ls", wzKey);
     if (*pwzData)
     {
         hr = ::StringCchCopyW(psf->wzSize, countof(psf->wzSize), pwzData);
-        ExitOnFailure1(hr, "Failed to copy size to filespec object: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy size to filespec object: %ls", pwzData);
     }
     else
     {
@@ -568,11 +568,11 @@ HRESULT GetFileSpec(
     }
 
     hr = WcaGetRecordFormattedString(hRec, sfsqMaxSize, &pwzData);
-    ExitOnFailure1(hr, "Failed to get SqlFileSpec.MaxSize for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to get SqlFileSpec.MaxSize for filespec: %ls", wzKey);
     if (*pwzData)
     {
         hr = ::StringCchCopyW(psf->wzMaxSize, countof(psf->wzMaxSize), pwzData);
-        ExitOnFailure1(hr, "Failed to copy max size to filespec object: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy max size to filespec object: %ls", pwzData);
     }
     else
     {
@@ -580,11 +580,11 @@ HRESULT GetFileSpec(
     }
 
     hr = WcaGetRecordFormattedString(hRec, sfsqGrowth, &pwzData);
-    ExitOnFailure1(hr, "Failed to get SqlFileSpec.GrowthSize for filespec: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to get SqlFileSpec.GrowthSize for filespec: %ls", wzKey);
     if (*pwzData)
     {
         hr = ::StringCchCopyW(psf->wzGrow, countof(psf->wzGrow), pwzData);
-        ExitOnFailure1(hr, "Failed to copy growth size to filespec object: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy growth size to filespec object: %ls", pwzData);
     }
     else
     {

--- a/src/ext/ca/serverca/scasched/scafilter.cpp
+++ b/src/ext/ca/serverca/scasched/scafilter.cpp
@@ -84,7 +84,7 @@ UINT __stdcall ScaFiltersRead(
         psf = *ppsfList;
 
         hr = ::StringCchCopyW(psf->wzComponent, countof(psf->wzComponent), pwzData);
-        ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
         psf->isInstalled = isInstalled;
         psf->isAction = isAction;
@@ -186,31 +186,31 @@ HRESULT ScaFiltersInstall(
             }
 
             hr = ScaCreateMetabaseKey(piMetabase, psf->wzFilterRoot, psf->wzKey);
-            ExitOnFailure1(hr, "Failed to create key for filter '%ls'", psf->wzKey);
+            ExitOnFailure(hr, "Failed to create key for filter '%ls'", psf->wzKey);
 
             hr = ScaWriteMetabaseValue(piMetabase, psf->wzFilterRoot, psf->wzKey, MD_KEY_TYPE, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, STRING_METADATA, (LPVOID)L"IIsFilter");
-            ExitOnFailure1(hr, "Failed to write key type for filter '%ls'", psf->wzKey);
+            ExitOnFailure(hr, "Failed to write key type for filter '%ls'", psf->wzKey);
 
             // filter path
             hr = ScaWriteMetabaseValue(piMetabase, psf->wzFilterRoot, psf->wzKey, MD_FILTER_IMAGE_PATH, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, STRING_METADATA, (LPVOID)psf->wzPath);
-            ExitOnFailure1(hr, "Failed to write Path for filter '%ls'", psf->wzKey);
+            ExitOnFailure(hr, "Failed to write Path for filter '%ls'", psf->wzKey);
 
             // filter description
             hr = ScaWriteMetabaseValue(piMetabase, psf->wzFilterRoot, psf->wzKey, MD_FILTER_DESCRIPTION, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, STRING_METADATA, (LPVOID)psf->wzDescription);
-            ExitOnFailure1(hr, "Failed to write Description for filter '%ls'", psf->wzKey);
+            ExitOnFailure(hr, "Failed to write Description for filter '%ls'", psf->wzKey);
 
             // filter flags
             if (MSI_NULL_INTEGER != psf->iFlags)
             {
                 hr = ScaWriteMetabaseValue(piMetabase, psf->wzFilterRoot, psf->wzKey, MD_FILTER_FLAGS, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, DWORD_METADATA, (LPVOID)((DWORD_PTR)psf->iFlags));
-                ExitOnFailure1(hr, "Failed to write Flags for filter '%ls'", psf->wzKey);
+                ExitOnFailure(hr, "Failed to write Flags for filter '%ls'", psf->wzKey);
             }
 
             // filter load order
             if (MSI_NULL_INTEGER != psf->iLoadOrder)
             {
                 hr = AddFilterToLoadOrder(psf->wzKey, psf->iLoadOrder, &pwzLoadOrder);
-                ExitOnFailure1(hr, "Failed to add filter '%ls' to load order.", psf->wzKey);
+                ExitOnFailure(hr, "Failed to add filter '%ls' to load order.", psf->wzKey);
             }
         }
 
@@ -262,13 +262,13 @@ HRESULT ScaFiltersUninstall(
             }
 
             hr = RemoveFilterFromLoadOrder(psf->wzKey, &pwzLoadOrder);
-            ExitOnFailure1(hr, "Failed to remove filter '%ls' from load order", psf->wzKey);
+            ExitOnFailure(hr, "Failed to remove filter '%ls' from load order", psf->wzKey);
 
             // remove the filter from the load order and remove the filter's key
             if (0 != lstrlenW(psf->wzFilterRoot))
             {
                 hr = ScaDeleteMetabaseKey(piMetabase, psf->wzFilterRoot, psf->wzKey);
-                ExitOnFailure1(hr, "Failed to remove web '%ls' from metabase", psf->wzKey);
+                ExitOnFailure(hr, "Failed to remove web '%ls' from metabase", psf->wzKey);
             }
         }
 

--- a/src/ext/ca/serverca/scasched/scafilter7.cpp
+++ b/src/ext/ca/serverca/scasched/scafilter7.cpp
@@ -67,7 +67,7 @@ UINT __stdcall ScaFiltersRead7(
         psf = *ppsfList;
 
         hr = ::StringCchCopyW(psf->wzComponent, countof(psf->wzComponent), pwzData);
-        ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
         psf->isInstalled = isInstalled;
         psf->isAction = isAction;
@@ -196,7 +196,7 @@ static HRESULT WriteFilter(const SCA_FILTER* psf)
 
     //filter Name key
     hr = ScaWriteConfigString(psf->wzKey);
-    ExitOnFailure1(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
+    ExitOnFailure(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
 
     //web site name
     hr = ScaWriteConfigString(psf->wzFilterRoot);
@@ -204,11 +204,11 @@ static HRESULT WriteFilter(const SCA_FILTER* psf)
 
     // filter path
     hr = ScaWriteConfigString(psf->wzPath);
-    ExitOnFailure1(hr, "Failed to write Path for filter '%ls'", psf->wzKey);
+    ExitOnFailure(hr, "Failed to write Path for filter '%ls'", psf->wzKey);
 
     //filter load order
     hr = ScaWriteConfigInteger(psf->iLoadOrder);
-    ExitOnFailure1(hr, "Failed to write load order for filter '%ls'", psf->wzKey);
+    ExitOnFailure(hr, "Failed to write load order for filter '%ls'", psf->wzKey);
 
 LExit:
     return hr;
@@ -245,7 +245,7 @@ HRESULT ScaFiltersUninstall7(
 
                 //filter Name key
                 hr = ScaWriteConfigString(psf->wzKey);
-                ExitOnFailure1(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
+                ExitOnFailure(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
 
                 //web site name
                 hr = ScaWriteConfigString(psf->wzFilterRoot);
@@ -278,7 +278,7 @@ HRESULT ScaFiltersUninstall7(
 
                 //filter Name key
                 hr = ScaWriteConfigString(psf->wzKey);
-                ExitOnFailure1(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
+                ExitOnFailure(hr, "Failed to write key name for filter '%ls'", psf->wzKey);
 
                 //web site name
                 hr = ScaWriteConfigString(psf->wzFilterRoot);

--- a/src/ext/ca/serverca/scasched/scahttpheader.cpp
+++ b/src/ext/ca/serverca/scasched/scahttpheader.cpp
@@ -194,7 +194,7 @@ HRESULT ScaWriteHttpHeader(
         // TODO: Make it configurable to not inherit HTTP Headers
         //
         hr = StrAllocConcat(&pwzSearchKey, wzRoot, 0);
-        ExitOnFailure1(hr, "Failed to copy root string: %ls", wzRoot);
+        ExitOnFailure(hr, "Failed to copy root string: %ls", wzRoot);
 
         pwz = pwzSearchKey + lstrlenW(pwzSearchKey);
         while (NULL == pwzHeaders)
@@ -218,7 +218,7 @@ HRESULT ScaWriteHttpHeader(
             {
                 hr = S_FALSE;
             }
-            ExitOnFailure1(hr, "Failed to find search for HTTP headers for web root: %ls while walking up the tree", wzRoot);
+            ExitOnFailure(hr, "Failed to find search for HTTP headers for web root: %ls while walking up the tree", wzRoot);
 
             if (S_OK == hr)
             {
@@ -233,7 +233,7 @@ HRESULT ScaWriteHttpHeader(
         hr = StrAllocString(&pwzHeaders, reinterpret_cast<LPWSTR>(mr.pbMDData), 0);
         ExitOnFailure(hr, "Failed to allocate HTTP header string");
     }
-    ExitOnFailure1(hr, "Failed while searching for default HTTP headers to start with for web root: %ls", wzRoot);
+    ExitOnFailure(hr, "Failed while searching for default HTTP headers to start with for web root: %ls", wzRoot);
 
     // Loop through the HTTP headers
     for (SCA_HTTP_HEADER* pshh = pshhList; pshh; pshh = pshh->pshhNext)

--- a/src/ext/ca/serverca/scasched/scaiis.cpp
+++ b/src/ext/ca/serverca/scasched/scaiis.cpp
@@ -93,7 +93,7 @@ HRESULT ScaDeleteApp(IMSAdminBase* piMetabase, LPCWSTR wzWebRoot)
     ExitOnFailure(hr, "Failed to add metabase key to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_DELETEAPP);
-    ExitOnFailure2(hr, "Failed to add ScaDeleteApp action data: %ls cost: %d", pwzCustomActionData, COST_IIS_DELETEAPP);
+    ExitOnFailure(hr, "Failed to add ScaDeleteApp action data: %ls cost: %d", pwzCustomActionData, COST_IIS_DELETEAPP);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -131,7 +131,7 @@ HRESULT ScaCreateApp(IMSAdminBase* piMetabase, LPCWSTR wzWebRoot,
     ExitOnFailure(hr, "Failed to add isolation value to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_CREATEAPP);
-    ExitOnFailure2(hr, "Failed to add ScaCreateApp action data: %ls cost: %d", pwzCustomActionData, COST_IIS_CREATEAPP);
+    ExitOnFailure(hr, "Failed to add ScaCreateApp action data: %ls cost: %d", pwzCustomActionData, COST_IIS_CREATEAPP);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -178,7 +178,7 @@ HRESULT ScaCreateMetabaseKey(IMSAdminBase* piMetabase, LPCWSTR wzRootKey,
     ExitOnFailure(hr, "Failed to add metabase key to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_CREATEKEY);
-    ExitOnFailure2(hr, "Failed to add ScaCreateMetabaseKey action data: %ls cost: %d", pwzCustomActionData, COST_IIS_CREATEKEY);
+    ExitOnFailure(hr, "Failed to add ScaCreateMetabaseKey action data: %ls cost: %d", pwzCustomActionData, COST_IIS_CREATEKEY);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -225,7 +225,7 @@ HRESULT ScaDeleteMetabaseKey(IMSAdminBase* piMetabase, LPCWSTR wzRootKey,
     ExitOnFailure(hr, "Failed to add metabase key to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_DELETEKEY);
-    ExitOnFailure2(hr, "Failed to add ScaDeleteMetabaseKey action data: %ls cost: %d", pwzCustomActionData, COST_IIS_DELETEKEY);
+    ExitOnFailure(hr, "Failed to add ScaDeleteMetabaseKey action data: %ls cost: %d", pwzCustomActionData, COST_IIS_DELETEKEY);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -280,7 +280,7 @@ HRESULT ScaDeleteMetabaseValue(IMSAdminBase* piMetabase, LPCWSTR wzRootKey,
     ExitOnFailure(hr, "Failed to add metabase data type to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_DELETEVALUE);
-    ExitOnFailure2(hr, "Failed to add ScaDeleteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_DELETEVALUE);
+    ExitOnFailure(hr, "Failed to add ScaDeleteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_DELETEVALUE);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -387,7 +387,7 @@ HRESULT ScaWriteMetabaseValue(IMSAdminBase* piMetabase, LPCWSTR wzRootKey,
     // TODO: maybe look the key up and make sure we're not just writing the same value that already there
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_WRITEVALUE);
-    ExitOnFailure2(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEVALUE);
+    ExitOnFailure(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEVALUE);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -401,7 +401,7 @@ HRESULT ScaAddToIisConfiguration(LPCWSTR pwzData, DWORD dwCost)
     HRESULT hr = S_OK;
 
     hr = WcaWriteStringToCaData(pwzData, &vpwzCustomActionData);
-    ExitOnFailure1(hr, "failed to add to metabase configuration data string: %ls", pwzData);
+    ExitOnFailure(hr, "failed to add to metabase configuration data string: %ls", pwzData);
 
     vdwCustomActionCost += dwCost;
 

--- a/src/ext/ca/serverca/scasched/scaiis7.cpp
+++ b/src/ext/ca/serverca/scasched/scaiis7.cpp
@@ -41,7 +41,7 @@ HRESULT ScaWriteConfigString(const LPCWSTR wzValue)
     ExitOnFailure(hr, "Failed to add metabase delete key directive to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_WRITEKEY);
-    ExitOnFailure2(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
+    ExitOnFailure(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -58,7 +58,7 @@ HRESULT ScaWriteConfigInteger(DWORD dwValue)
     ExitOnFailure(hr, "Failed to add metabase delete key directive to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_WRITEKEY);
-    ExitOnFailure2(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
+    ExitOnFailure(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
 
 LExit:
     ReleaseStr(pwzCustomActionData);
@@ -75,7 +75,7 @@ HRESULT ScaWriteConfigID(IIS_CONFIG_ACTION emID)
     ExitOnFailure(hr, "Failed to add metabase delete key directive to CustomActionData");
 
     hr = ScaAddToIisConfiguration(pwzCustomActionData, COST_IIS_WRITEKEY);
-    ExitOnFailure2(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
+    ExitOnFailure(hr, "Failed to add ScaWriteMetabaseValue action data: %ls, cost: %d", pwzCustomActionData, COST_IIS_WRITEKEY);
 
 LExit:
     ReleaseStr(pwzCustomActionData);

--- a/src/ext/ca/serverca/scasched/scaperf.cpp
+++ b/src/ext/ca/serverca/scasched/scaperf.cpp
@@ -255,11 +255,11 @@ static HRESULT ProcessPerformanceCategory(
         // Check to see if the Component is being installed or uninstalled
         // when we are processing the same.
         hr = WcaGetRecordString(hRec, pcdqComponent, &pwzComponent);
-        ExitOnFailure1(hr, "Failed to get Component for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to get Component for PerformanceCategory: %ls", pwzId);
 
         er = ::MsiGetComponentStateW(hInstall, pwzComponent, &isInstalled, &isAction);
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnFailure1(hr, "Failed to get Component state for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to get Component state for PerformanceCategory: %ls", pwzId);
 
         if ((fInstall && !WcaIsInstalling(isInstalled, isAction)) ||
             (!fInstall && !WcaIsUninstalling(isInstalled, isAction)))
@@ -268,19 +268,19 @@ static HRESULT ProcessPerformanceCategory(
         }
 
         hr = WcaGetRecordString(hRec, pcdqName, &pwzName);
-        ExitOnFailure1(hr, "Failed to get Name for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to get Name for PerformanceCategory: %ls", pwzId);
         hr = WcaWriteStringToCaData(pwzName, &pwzCustomActionData);
-        ExitOnFailure1(hr, "Failed to add Name to CustomActionData for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to add Name to CustomActionData for PerformanceCategory: %ls", pwzId);
 
         hr = WcaGetRecordString(hRec, pcdqIniData, &pwzData);
-        ExitOnFailure1(hr, "Failed to get IniData for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to get IniData for PerformanceCategory: %ls", pwzId);
         hr = WcaWriteStringToCaData(pwzData, &pwzCustomActionData);
-        ExitOnFailure1(hr, "Failed to add IniData to CustomActionData for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to add IniData to CustomActionData for PerformanceCategory: %ls", pwzId);
 
         hr = WcaGetRecordString(hRec, pcdqConstantData, &pwzData);
-        ExitOnFailure1(hr, "Failed to get ConstantData for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to get ConstantData for PerformanceCategory: %ls", pwzId);
         hr = WcaWriteStringToCaData(pwzData, &pwzCustomActionData);
-        ExitOnFailure1(hr, "Failed to add ConstantData to CustomActionData for PerformanceCategory: %ls", pwzId);
+        ExitOnFailure(hr, "Failed to add ConstantData to CustomActionData for PerformanceCategory: %ls", pwzId);
     }
 
     if (hr == E_NOMOREITEMS)
@@ -295,18 +295,18 @@ static HRESULT ProcessPerformanceCategory(
         if (fInstall)
         {
             hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"RollbackRegisterPerfCounterData"), pwzCustomActionData, COST_PERFMON_UNREGISTER);
-            ExitOnFailure1(hr, "Failed to schedule RollbackRegisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
+            ExitOnFailure(hr, "Failed to schedule RollbackRegisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
 
             hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"RegisterPerfCounterData"), pwzCustomActionData, COST_PERFMON_REGISTER);
-            ExitOnFailure1(hr, "Failed to schedule RegisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
+            ExitOnFailure(hr, "Failed to schedule RegisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
         }
         else
         {
             hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"RollbackUnregisterPerfCounterData"), pwzCustomActionData, COST_PERFMON_REGISTER);
-            ExitOnFailure1(hr, "Failed to schedule RollbackUnregisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
+            ExitOnFailure(hr, "Failed to schedule RollbackUnregisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
 
             hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"UnregisterPerfCounterData"), pwzCustomActionData, COST_PERFMON_UNREGISTER);
-            ExitOnFailure1(hr, "Failed to schedule UnregisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
+            ExitOnFailure(hr, "Failed to schedule UnregisterPerfCounterData action for PerformanceCategory: %ls", pwzId);
         }
     }
 

--- a/src/ext/ca/serverca/scasched/scaproperty.cpp
+++ b/src/ext/ca/serverca/scasched/scaproperty.cpp
@@ -81,12 +81,12 @@ HRESULT ScaPropertyRead(
         hr = WcaGetRecordString(hRec, pqProperty, &pwzData);
         ExitOnFailure(hr, "failed to get IIsProperty.Property");
         hr = ::StringCchCopyW(pss->wzProperty, countof(pss->wzProperty), pwzData);
-        ExitOnFailure1(hr, "failed to copy Property name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy Property name: %ls", pwzData);
 
         hr = WcaGetRecordString(hRec, pqValue, &pwzData);
         ExitOnFailure(hr, "failed to get IIsProperty.Value");
         hr = ::StringCchCopyW(pss->wzValue, countof(pss->wzValue), pwzData);
-        ExitOnFailure1(hr, "failed to copy Property value: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy Property value: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, pqAttributes, &pss->iAttributes);
         ExitOnFailure(hr, "failed to get IIsProperty.Attributes");
@@ -94,7 +94,7 @@ HRESULT ScaPropertyRead(
         hr = WcaGetRecordString(hRec, pqComponent, &pwzData);
         ExitOnFailure(hr, "failed to get IIsProperty.Component");
         hr = ::StringCchCopyW(pss->wzComponent, countof(pss->wzComponent), pwzData);
-        ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, pqInstalled, (int *)&pss->isInstalled);
         ExitOnFailure(hr, "Failed to get Component installed state for filter");
@@ -133,7 +133,7 @@ HRESULT ScaPropertyInstall(
         if (WcaIsInstalling(psp->isInstalled, psp->isAction))
         {
             hr = ScaWriteProperty(piMetabase, psp);
-            ExitOnFailure1(hr, "failed to write Property '%ls' to metabase", psp->wzProperty);
+            ExitOnFailure(hr, "failed to write Property '%ls' to metabase", psp->wzProperty);
         }
     }
 
@@ -157,7 +157,7 @@ HRESULT ScaPropertyUninstall(
         if (WcaIsUninstalling(psp->isInstalled, psp->isAction))
         {
             hr = ScaRemoveProperty(piMetabase, psp);
-            ExitOnFailure1(hr, "Failed to remove Property '%ls' from metabase", psp->wzProperty);
+            ExitOnFailure(hr, "Failed to remove Property '%ls' from metabase", psp->wzProperty);
         }
     }
 

--- a/src/ext/ca/serverca/scasched/scaproperty7.cpp
+++ b/src/ext/ca/serverca/scasched/scaproperty7.cpp
@@ -25,7 +25,7 @@ HRESULT ScaPropertyInstall7(
         if (WcaIsInstalling(psp->isInstalled, psp->isAction))
         {
             hr = ScaWriteProperty7(psp);
-            ExitOnFailure1(hr, "failed to write Property '%ls' ", psp->wzProperty);
+            ExitOnFailure(hr, "failed to write Property '%ls' ", psp->wzProperty);
         }
     }
 
@@ -46,7 +46,7 @@ HRESULT ScaPropertyUninstall7(
         if (WcaIsUninstalling(psp->isInstalled, psp->isAction))
         {
             hr = ScaRemoveProperty7(psp);
-            ExitOnFailure1(hr, "Failed to remove Property '%ls'", psp->wzProperty);
+            ExitOnFailure(hr, "Failed to remove Property '%ls'", psp->wzProperty);
         }
     }
 

--- a/src/ext/ca/serverca/scasched/scasmbsched.cpp
+++ b/src/ext/ca/serverca/scasched/scasmbsched.cpp
@@ -175,18 +175,18 @@ HRESULT ScaSmbRead(SCA_SMB** ppssList)
         ExitOnFailure(hr, "Failed to copy share name string to smb object");
 
         hr = WcaGetRecordString(hRec, ssqComponent, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Component for FileShare: '%ls'", pss->wzShareName);
+        ExitOnFailure(hr, "Failed to get Component for FileShare: '%ls'", pss->wzShareName);
         hr = ::StringCchCopyW(pss->wzComponent, countof(pss->wzComponent), pwzData);
         ExitOnFailure(hr, "Failed to copy component string to smb object");
 
         hr = WcaGetRecordFormattedString(hRec, ssqDescription, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Share Description for FileShare: '%ls'", pss->wzShareName);
+        ExitOnFailure(hr, "Failed to get Share Description for FileShare: '%ls'", pss->wzShareName);
         hr = ::StringCchCopyW(pss->wzDescription, countof(pss->wzDescription), pwzData);
         ExitOnFailure(hr, "Failed to copy description string to smb object");
 
         // get user info from the user table
         hr = WcaGetRecordFormattedString(hRec, ssqUser, &pwzData);
-        ExitOnFailure1(hr, "Failed to get User record for FileShare: '%ls'", pss->wzShareName);
+        ExitOnFailure(hr, "Failed to get User record for FileShare: '%ls'", pss->wzShareName);
 
         // get component install state
         er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pss->wzComponent, &pss->isInstalled, &pss->isAction);
@@ -199,7 +199,7 @@ HRESULT ScaSmbRead(SCA_SMB** ppssList)
             pss->fUseIntegratedAuth = FALSE;
             pss->fLegacyUserProvided = TRUE;
             hr = ScaGetUser(pwzData, &pss->scau);
-            ExitOnFailure1(hr, "Failed to get user information for fileshare: '%ls'", pss->wzShareName);
+            ExitOnFailure(hr, "Failed to get user information for fileshare: '%ls'", pss->wzShareName);
         }
         else
         {
@@ -211,7 +211,7 @@ HRESULT ScaSmbRead(SCA_SMB** ppssList)
 
         // get the share's directory
         hr = WcaGetRecordString(hRec, ssqDirectory, &pwzData);
-        ExitOnFailure1(hr, "Failed to get directory for FileShare: '%ls'", pss->wzShareName);
+        ExitOnFailure(hr, "Failed to get directory for FileShare: '%ls'", pss->wzShareName);
 
         WCHAR wzPath[MAX_PATH];
         DWORD dwLen;
@@ -301,7 +301,7 @@ HRESULT RetrieveFileShareUserPerm(SCA_SMB* pss, SCA_SMB_EX_USER_PERMS** ppExUser
     else if (NERR_Success != s || psi == NULL)
     {
         hr = E_FAIL;
-        ExitOnFailure1(hr, "Failed to get share information with return code: %d", s);
+        ExitOnFailure(hr, "Failed to get share information with return code: %d", s);
     }
     if (!::GetSecurityDescriptorDacl(psi->shi502_security_descriptor, &bValid, &acl, &bDaclDefaulted) || !bValid)
     {
@@ -310,7 +310,7 @@ HRESULT RetrieveFileShareUserPerm(SCA_SMB* pss, SCA_SMB_EX_USER_PERMS** ppExUser
 
     er = ::GetExplicitEntriesFromAclW(acl, &nCount, &pEA);
     hr = HRESULT_FROM_WIN32(er);
-    ExitOnFailure1(hr, "Failed to get  access entries from acl for file share %ls", pss->wzShareName);
+    ExitOnFailure(hr, "Failed to get  access entries from acl for file share %ls", pss->wzShareName);
     for (dwCounter = 0; dwCounter < nCount; ++dwCounter)
     {
         if (TRUSTEE_IS_SID == pEA[dwCounter].Trustee.TrusteeForm)
@@ -454,7 +454,7 @@ HRESULT ScaSmbInstall(SCA_SMB* pssList)
         if (WcaIsInstalling(pss->isInstalled, pss->isAction) )
         {
             hr = SchedCreateSmb(pss);
-            ExitOnFailure1(hr, "Failed to schedule the creation of the fileshare: %ls", pss->wzShareName);
+            ExitOnFailure(hr, "Failed to schedule the creation of the fileshare: %ls", pss->wzShareName);
         }
     }
 
@@ -549,7 +549,7 @@ HRESULT ScaSmbUninstall(SCA_SMB* pssList)
         if (WcaIsUninstalling(pss->isInstalled, pss->isAction) )
         {
             hr = SchedDropSmb(pss);
-            ExitOnFailure1(hr, "Failed to remove file share %ls", pss->wzShareName);
+            ExitOnFailure(hr, "Failed to remove file share %ls", pss->wzShareName);
         }
     }
 
@@ -607,7 +607,7 @@ HRESULT ScaSmbExPermsRead(SCA_SMB* pss)
         hr = WcaGetRecordString(hRec, ssupqUser, &pwzData);
         ExitOnFailure(hr, "Failed to get FileSharePermissions.User");
         hr = ScaGetUser(pwzData, &pExUserPerms->scau);
-        ExitOnFailure1(hr, "Failed to get user information for fileshare: '%ls'", pss->wzShareName);
+        ExitOnFailure(hr, "Failed to get user information for fileshare: '%ls'", pss->wzShareName);
 
         hr = WcaGetRecordInteger(hRec, ssupqPermissions, &pExUserPerms->nPermissions);
         ExitOnFailure(hr, "Failed to get FileSharePermissions.Permissions");

--- a/src/ext/ca/serverca/scasched/scasqlstr.cpp
+++ b/src/ext/ca/serverca/scasched/scasqlstr.cpp
@@ -74,7 +74,7 @@ HRESULT ScaSqlStrsRead(
 
         er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pwzComponent, &isInstalled, &isAction);
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnFailure1(hr, "Failed to get state for component: %ls", pwzComponent);
+        ExitOnFailure(hr, "Failed to get state for component: %ls", pwzComponent);
 
         // If we're doing install but the Component is not being installed or we're doing
         // uninstall but the Component is not being uninstalled, skip it.
@@ -93,28 +93,28 @@ HRESULT ScaSqlStrsRead(
         hr = WcaGetRecordString(hRec, ssqSqlString, &pwzData);
         ExitOnFailure(hr, "Failed to get SqlString.String");
         hr = ::StringCchCopyW(psss->wzKey, countof(psss->wzKey), pwzData);
-        ExitOnFailure1(hr, "Failed to copy SqlString.String: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy SqlString.String: %ls", pwzData);
 
         // find the database information for this string
         hr = WcaGetRecordString(hRec, ssqSqlDb, &pwzData);
-        ExitOnFailure1(hr, "Failed to get SqlString.SqlDb_ for SqlString '%ls'", psss->wzKey);
+        ExitOnFailure(hr, "Failed to get SqlString.SqlDb_ for SqlString '%ls'", psss->wzKey);
         hr = ::StringCchCopyW(psss->wzSqlDb, countof(psss->wzSqlDb), pwzData);
-        ExitOnFailure1(hr, "Failed to copy SqlString.SqlDb_: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy SqlString.SqlDb_: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, ssqAttributes, &psss->iAttributes);
-        ExitOnFailure1(hr, "Failed to get SqlString.Attributes for SqlString '%ls'", psss->wzKey);
+        ExitOnFailure(hr, "Failed to get SqlString.Attributes for SqlString '%ls'", psss->wzKey);
 
         //get the sequence number for the string (note that this will be sequenced with scripts too)
         hr = WcaGetRecordInteger(hRec, ssqSequence, &psss->iSequence);
-        ExitOnFailure1(hr, "Failed to get SqlString.Sequence for SqlString '%ls'", psss->wzKey);
+        ExitOnFailure(hr, "Failed to get SqlString.Sequence for SqlString '%ls'", psss->wzKey);
 
         // execute SQL
         hr = WcaGetRecordFormattedString(hRec, ssqSQL, &pwzData);
-        ExitOnFailure1(hr, "Failed to get SqlString.SQL for SqlString '%ls'", psss->wzKey);
+        ExitOnFailure(hr, "Failed to get SqlString.SQL for SqlString '%ls'", psss->wzKey);
 
         Assert(!psss->pwzSql);
         hr = StrAllocString(&psss->pwzSql, pwzData, 0);
-        ExitOnFailure1(hr, "Failed to alloc string for SqlString '%ls'", psss->wzKey);
+        ExitOnFailure(hr, "Failed to alloc string for SqlString '%ls'", psss->wzKey);
 
         *ppsssList = AddSqlStrToList(*ppsssList, psss);
         psss = NULL; // set the sss to NULL so it doesn't get freed below
@@ -191,7 +191,7 @@ HRESULT ScaSqlStrsReadScripts(
 
         er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pwzComponent, &isInstalled, &isAction);
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnFailure1(hr, "Failed to get state for component: %ls", pwzComponent);
+        ExitOnFailure(hr, "Failed to get state for component: %ls", pwzComponent);
 
         // If we're doing install but the Component is not being installed or we're doing
         // uninstall but the Component is not being uninstalled, skip it.
@@ -209,31 +209,31 @@ HRESULT ScaSqlStrsReadScripts(
         hr = WcaGetRecordString(hRec, sscrqSqlScript, &pwzData);
         ExitOnFailure(hr, "Failed to get SqlScript.Script");
         hr = ::StringCchCopyW(sss.wzKey, countof(sss.wzKey), pwzData);
-        ExitOnFailure1(hr, "Failed to copy SqlScript.Script: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy SqlScript.Script: %ls", pwzData);
 
         // find the database information for this string
         hr = WcaGetRecordString(hRec, sscrqSqlDb, &pwzData);
-        ExitOnFailure1(hr, "Failed to get SqlScript.SqlDb_ for SqlScript '%ls'", sss.wzKey);
+        ExitOnFailure(hr, "Failed to get SqlScript.SqlDb_ for SqlScript '%ls'", sss.wzKey);
         hr = ::StringCchCopyW(sss.wzSqlDb, countof(sss.wzSqlDb), pwzData);
-        ExitOnFailure1(hr, "Failed to copy SqlScritp.SqlDbb: %ls", pwzData);
+        ExitOnFailure(hr, "Failed to copy SqlScritp.SqlDbb: %ls", pwzData);
 
         hr = WcaGetRecordInteger(hRec, sscrqAttributes, &sss.iAttributes);
-        ExitOnFailure1(hr, "Failed to get SqlScript.Attributes for SqlScript '%ls'", sss.wzKey);
+        ExitOnFailure(hr, "Failed to get SqlScript.Attributes for SqlScript '%ls'", sss.wzKey);
 
         hr = WcaGetRecordInteger(hRec, sscrqSequence, &sss.iSequence);
-        ExitOnFailure1(hr, "Failed to get SqlScript.Sequence for SqlScript '%ls'", sss.wzKey);
+        ExitOnFailure(hr, "Failed to get SqlScript.Sequence for SqlScript '%ls'", sss.wzKey);
 
         // get the sql script out of the binary stream
         hr = WcaExecuteView(hViewBinary, hRec);
-        ExitOnFailure1(hr, "Failed to open SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
+        ExitOnFailure(hr, "Failed to open SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
         hr = WcaFetchSingleRecord(hViewBinary, &hRecBinary);
-        ExitOnFailure1(hr, "Failed to fetch SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
+        ExitOnFailure(hr, "Failed to fetch SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
 
         // Note: We need to allocate an extra character on the stream to NULL terminate the SQL script.
         //       The WcaGetRecordStream() function won't let us add extra space on the end of the stream
         //       so we'll read the stream "the old fashioned way".
         //hr = WcaGetRecordStream(hRecBinary, ssbsqData, (BYTE**)&pbScript, &cbScript);
-        //ExitOnFailure1(hr, "Failed to read SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
+        //ExitOnFailure(hr, "Failed to read SqlScript.BinaryScript_ for SqlScript '%ls'", sss.wzKey);
         er = ::MsiRecordReadStream(hRecBinary, ssbsqData, NULL, &cbRead);
         hr = HRESULT_FROM_WIN32(er);
         ExitOnFailure(hr, "failed to get size of stream");
@@ -255,7 +255,7 @@ HRESULT ScaSqlStrsReadScripts(
             cchScript = (cbScript / sizeof(WCHAR)) - 1;
 
             hr = StrAllocString(&pwzScriptBuffer, reinterpret_cast<LPWSTR>(pbScript) + 1, 0);
-            ExitOnFailure1(hr, "Failed to allocate WCHAR string of size '%d'", cchScript);
+            ExitOnFailure(hr, "Failed to allocate WCHAR string of size '%d'", cchScript);
         }
         else
         {
@@ -263,7 +263,7 @@ HRESULT ScaSqlStrsReadScripts(
             cchScript = cbScript;
 
             hr = StrAllocStringAnsi(&pwzScriptBuffer, reinterpret_cast<LPCSTR>(pbScript), 0, CP_ACP);
-            ExitOnFailure1(hr, "Failed to allocate WCHAR string of size '%d'", cchScript);
+            ExitOnFailure(hr, "Failed to allocate WCHAR string of size '%d'", cchScript);
         }
 
         // Free the byte buffer since it has been converted to a new UNICODE string, one way or another.
@@ -469,7 +469,7 @@ HRESULT ScaSqlStrsReadScripts(
 
                 // cchRequired includes the NULL terminating char
                 hr = StrAllocString(&psss->pwzSql, pwzScript, 0);
-                ExitOnFailure1(hr, "Failed to allocate string for SQL script: '%ls'", psss->wzKey);
+                ExitOnFailure(hr, "Failed to allocate string for SQL script: '%ls'", psss->wzKey);
 
                 *ppsssList = AddSqlStrToList(*ppsssList, psss);
                 psss = NULL; // set the db NULL so it doesn't accidentally get freed below
@@ -651,7 +651,7 @@ static HRESULT ExecuteStrings(
                 const SCA_DB* psd = ScaDbsFindDatabase(psss->wzSqlDb, psdList);
                 if (!psd)
                 {
-                    ExitOnFailure1(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "failed to find data for Database: %ls", psss->wzSqlDb);
+                    ExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_NOT_FOUND), "failed to find data for Database: %ls", psss->wzSqlDb);
                 }
 
                 if (-1 == iOldRollback)
@@ -666,7 +666,7 @@ static HRESULT ExecuteStrings(
                     Assert(pwzCustomActionData && *pwzCustomActionData && uiCost);
 
                     hr = WcaDoDeferredAction(1 == iOldRollback ? L"RollbackExecuteSqlStrings" : L"ExecuteSqlStrings", pwzCustomActionData, uiCost);
-                    ExitOnFailure1(hr, "failed to schedule ExecuteSqlStrings action, rollback: %d", iOldRollback);
+                    ExitOnFailure(hr, "failed to schedule ExecuteSqlStrings action, rollback: %d", iOldRollback);
                     iOldRollback = iRollback;
 
                     *pwzCustomActionData = L'\0';
@@ -676,32 +676,32 @@ static HRESULT ExecuteStrings(
                 Assert(!pwzCustomActionData  || (pwzCustomActionData && 0 == *pwzCustomActionData) && 0 == uiCost);
 
                 hr = WcaWriteStringToCaData(psd->wzKey, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Server Database String to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Server Database String to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = WcaWriteStringToCaData(psd->wzServer, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Server to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Server to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = WcaWriteStringToCaData(psd->wzInstance, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Instance to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Instance to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = WcaWriteStringToCaData(psd->wzDatabase, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Database to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Database to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = ::StringCchPrintfW(wzNumber, countof(wzNumber), L"%d", psd->iAttributes);
                 ExitOnFailure(hr, "Failed to format attributes integer value to string");
                 hr = WcaWriteStringToCaData(wzNumber, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Attributes to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Attributes to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = ::StringCchPrintfW(wzNumber, countof(wzNumber), L"%d", psd->fUseIntegratedAuth);
                 ExitOnFailure(hr, "Failed to format UseIntegratedAuth integer value to string");
                 hr = WcaWriteStringToCaData(wzNumber, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL IntegratedAuth flag to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL IntegratedAuth flag to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = WcaWriteStringToCaData(psd->scau.wzName, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL UserName to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL UserName to CustomActionData for Database String: %ls", psd->wzKey);
 
                 hr = WcaWriteStringToCaData(psd->scau.wzPassword, &pwzCustomActionData);
-                ExitOnFailure1(hr, "Failed to add SQL Password to CustomActionData for Database String: %ls", psd->wzKey);
+                ExitOnFailure(hr, "Failed to add SQL Password to CustomActionData for Database String: %ls", psd->wzKey);
 
                 uiCost += COST_SQL_CONNECTDB;
 
@@ -711,13 +711,13 @@ static HRESULT ExecuteStrings(
             WcaLog(LOGMSG_VERBOSE, "Scheduling SQL string: %ls", psss->pwzSql);
 
             hr = WcaWriteStringToCaData(psss->wzKey, &pwzCustomActionData);
-            ExitOnFailure1(hr, "Failed to add SQL Key to CustomActionData for SQL string: %ls", psss->wzKey);
+            ExitOnFailure(hr, "Failed to add SQL Key to CustomActionData for SQL string: %ls", psss->wzKey);
 
             hr = WcaWriteIntegerToCaData(psss->iAttributes, &pwzCustomActionData);
-            ExitOnFailure1(hr, "failed to add attributes to CustomActionData for SQL string: %ls", psss->wzKey);
+            ExitOnFailure(hr, "failed to add attributes to CustomActionData for SQL string: %ls", psss->wzKey);
 
             hr = WcaWriteStringToCaData(psss->pwzSql, &pwzCustomActionData);
-            ExitOnFailure1(hr, "Failed to to add SQL Query to CustomActionData for SQL string: %ls", psss->wzKey);
+            ExitOnFailure(hr, "Failed to to add SQL Query to CustomActionData for SQL string: %ls", psss->wzKey);
             uiCost += COST_SQL_STRING;
         }
     }

--- a/src/ext/ca/serverca/scasched/scassl.cpp
+++ b/src/ext/ca/serverca/scasched/scassl.cpp
@@ -52,7 +52,7 @@ HRESULT ScaSslCertificateRead(
         ExitOnFailure(hr, "Failed to get hash for web ssl certificate.");
 
         hr = StrHexDecode(pwzData, pswsc->rgbSHA1Hash, countof(pswsc->rgbSHA1Hash));
-        ExitOnFailure2(hr, "Failed to decode certificate hash for web: %ls, data: %ls", wzWebId, pwzData);
+        ExitOnFailure(hr, "Failed to decode certificate hash for web: %ls, data: %ls", wzWebId, pwzData);
     }
 
     if (E_NOMOREITEMS == hr)

--- a/src/ext/ca/serverca/scasched/scauser.cpp
+++ b/src/ext/ca/serverca/scasched/scauser.cpp
@@ -340,22 +340,22 @@ HRESULT ScaUserRead(
             psu->isInstalled = isInstalled;
             psu->isAction = isAction;
             hr = ::StringCchCopyW(psu->wzComponent, countof(psu->wzComponent), pwzData);
-            ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+            ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
             hr = WcaGetRecordString(hRec, vaqUser, &pwzData);
             ExitOnFailure(hr, "failed to get User.User");
             hr = ::StringCchCopyW(psu->wzKey, countof(psu->wzKey), pwzData);
-            ExitOnFailure1(hr, "failed to copy user key: %ls", pwzData);
+            ExitOnFailure(hr, "failed to copy user key: %ls", pwzData);
 
             hr = WcaGetRecordFormattedString(hRec, vaqName, &pwzData);
             ExitOnFailure(hr, "failed to get User.Name");
             hr = ::StringCchCopyW(psu->wzName, countof(psu->wzName), pwzData);
-            ExitOnFailure1(hr, "failed to copy user name: %ls", pwzData);
+            ExitOnFailure(hr, "failed to copy user name: %ls", pwzData);
 
             hr = WcaGetRecordFormattedString(hRec, vaqDomain, &pwzData);
             ExitOnFailure(hr, "failed to get User.Domain");
             hr = ::StringCchCopyW(psu->wzDomain, countof(psu->wzDomain), pwzData);
-            ExitOnFailure1(hr, "failed to copy user domain: %ls", pwzData);
+            ExitOnFailure(hr, "failed to copy user domain: %ls", pwzData);
 
             hr = WcaGetRecordFormattedString(hRec, vaqPassword, &pwzData);
             ExitOnFailure(hr, "failed to get User.Password");
@@ -373,9 +373,9 @@ HRESULT ScaUserRead(
                 ExitOnFailure(hr, "Failed to create user record for querying UserGroup table");
 
                 hr = WcaOpenView(vcsUserGroupQuery, &hUserGroupView);
-                ExitOnFailure1(hr, "Failed to open view on UserGroup table for user %ls", psu->wzKey);
+                ExitOnFailure(hr, "Failed to open view on UserGroup table for user %ls", psu->wzKey);
                 hr = WcaExecuteView(hUserGroupView, hUserRec);
-                ExitOnFailure1(hr, "Failed to execute view on UserGroup table for user: %ls", psu->wzKey);
+                ExitOnFailure(hr, "Failed to execute view on UserGroup table for user: %ls", psu->wzKey);
 
                 while (S_OK == (hr = WcaFetchRecord(hUserGroupView, &hRec)))
                 {
@@ -386,7 +386,7 @@ HRESULT ScaUserRead(
                     ExitOnFailure(hr, "failed to add group to list");
 
                     hr = ScaGetGroup(pwzData, psu->psgGroups);
-                    ExitOnFailure1(hr, "failed to get information for group: %ls", pwzData);
+                    ExitOnFailure(hr, "failed to get information for group: %ls", pwzData);
                 }
 
                 if (E_NOMOREITEMS == hr)
@@ -421,10 +421,10 @@ static HRESULT WriteGroupInfo(
     for (SCA_GROUP* psg = psgList; psg; psg = psg->psgNext)
     {
         hr = WcaWriteStringToCaData(psg->wzName, ppwzActionData);
-        ExitOnFailure1(hr, "failed to add group name to custom action data: %ls", psg->wzName);
+        ExitOnFailure(hr, "failed to add group name to custom action data: %ls", psg->wzName);
 
         hr = WcaWriteStringToCaData(psg->wzDomain, ppwzActionData);
-        ExitOnFailure1(hr, "failed to add group domain to custom action data: %ls", psg->wzDomain);
+        ExitOnFailure(hr, "failed to add group domain to custom action data: %ls", psg->wzDomain);
     }
 
 LExit:
@@ -462,10 +462,10 @@ static HRESULT WriteGroupRollbackInfo(
         }
 
         hr = WcaWriteStringToCaData(psg->wzName, ppwzActionData);
-        ExitOnFailure1(hr, "failed to add group name to custom action data: %ls", psg->wzName);
+        ExitOnFailure(hr, "failed to add group name to custom action data: %ls", psg->wzName);
 
         hr = WcaWriteStringToCaData(psg->wzDomain, ppwzActionData);
-        ExitOnFailure1(hr, "failed to add group domain to custom action data: %ls", psg->wzDomain);
+        ExitOnFailure(hr, "failed to add group domain to custom action data: %ls", psg->wzDomain);
     }
 
 LExit:
@@ -498,18 +498,18 @@ HRESULT ScaUserExecute(
         // data.  Sometimes we'll add more data.
         Assert(psu->wzName);
         hr = WcaWriteStringToCaData(psu->wzName, &pwzActionData);
-        ExitOnFailure1(hr, "Failed to add user name to custom action data: %ls", psu->wzName);
+        ExitOnFailure(hr, "Failed to add user name to custom action data: %ls", psu->wzName);
         hr = WcaWriteStringToCaData(psu->wzDomain, &pwzActionData);
-        ExitOnFailure1(hr, "Failed to add user domain to custom action data: %ls", psu->wzDomain);
+        ExitOnFailure(hr, "Failed to add user domain to custom action data: %ls", psu->wzDomain);
         hr = WcaWriteIntegerToCaData(psu->iAttributes, &pwzActionData);
-        ExitOnFailure1(hr, "failed to add user attributes to custom action data for user: %ls", psu->wzKey);
+        ExitOnFailure(hr, "failed to add user attributes to custom action data for user: %ls", psu->wzKey);
 
         // Check to see if the user already exists since we have to be very careful when adding
         // and removing users.  Note: MSDN says that it is safe to call these APIs from any
         // user, so we should be safe calling it during immediate mode.
         er = ::NetApiBufferAllocate(sizeof(USER_INFO_0), reinterpret_cast<LPVOID*>(&pUserInfo));
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnFailure1(hr, "Failed to allocate memory to check existence of user: %ls", psu->wzName);
+        ExitOnFailure(hr, "Failed to allocate memory to check existence of user: %ls", psu->wzName);
 
         LPCWSTR wzDomain = psu->wzDomain;
         if (wzDomain && *wzDomain)
@@ -557,7 +557,7 @@ HRESULT ScaUserExecute(
                 if ((SCAU_FAIL_IF_EXISTS & (psu->iAttributes)) && !(SCAU_UPDATE_IF_EXISTS & (psu->iAttributes)))
                 {
                     hr = HRESULT_FROM_WIN32(NERR_UserExists);
-                    MessageExitOnFailure1(hr, msierrUSRFailedUserCreateExists, "Failed to create user: %ls because user already exists.", psu->wzName);
+                    MessageExitOnFailure(hr, msierrUSRFailedUserCreateExists, "Failed to create user: %ls because user already exists.", psu->wzName);
                 }
             }
 
@@ -577,11 +577,11 @@ HRESULT ScaUserExecute(
                 }
 
                 hr = WcaWriteStringToCaData(psu->wzName, &pwzRollbackData);
-                ExitOnFailure1(hr, "Failed to add user name to rollback custom action data: %ls", psu->wzName);
+                ExitOnFailure(hr, "Failed to add user name to rollback custom action data: %ls", psu->wzName);
                 hr = WcaWriteStringToCaData(psu->wzDomain, &pwzRollbackData);
-                ExitOnFailure1(hr, "Failed to add user domain to rollback custom action data: %ls", psu->wzDomain);
+                ExitOnFailure(hr, "Failed to add user domain to rollback custom action data: %ls", psu->wzDomain);
                 hr = WcaWriteIntegerToCaData(iRollbackUserAttributes, &pwzRollbackData);
-                ExitOnFailure1(hr, "failed to add user attributes to rollback custom action data for user: %ls", psu->wzKey);
+                ExitOnFailure(hr, "failed to add user attributes to rollback custom action data for user: %ls", psu->wzKey);
 
                 // If the user already exists, add relevant group information to rollback data
                 if (USER_EXISTS_YES == ueUserExists || USER_EXISTS_INDETERMINATE == ueUserExists)
@@ -598,7 +598,7 @@ HRESULT ScaUserExecute(
             // Schedule the creation now.
             //
             hr = WcaWriteStringToCaData(psu->wzPassword, &pwzActionData);
-            ExitOnFailure1(hr, "failed to add user password to custom action data for user: %ls", psu->wzKey);
+            ExitOnFailure(hr, "failed to add user password to custom action data for user: %ls", psu->wzKey);
 
             // Add user's group information to custom action data
             hr = WriteGroupInfo(psu->psgGroups, &pwzActionData);

--- a/src/ext/ca/serverca/scasched/scavdir.cpp
+++ b/src/ext/ca/serverca/scasched/scavdir.cpp
@@ -82,7 +82,7 @@ HRESULT __stdcall ScaVirtualDirsRead(
         pvdir = *ppsvdList;
 
         hr = ::StringCchCopyW(pvdir->wzComponent, countof(pvdir->wzComponent), pwzData);
-        ExitOnFailure1(hr, "failed to copy component name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy component name: %ls", pwzData);
 
         pvdir->isInstalled = isInstalled;
         pvdir->isAction = isAction;
@@ -97,7 +97,7 @@ HRESULT __stdcall ScaVirtualDirsRead(
             // If we're uninstalling, ignore any failure to find the existing web
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to get base of web: %ls for VirtualDir", pwzData);
+        ExitOnFailure(hr, "Failed to get base of web: %ls for VirtualDir", pwzData);
 
         hr = WcaGetRecordString(hRec, vdqAlias, &pwzData);
         ExitOnFailure(hr, "Failed to get Alias for VirtualDir");
@@ -165,13 +165,13 @@ HRESULT __stdcall ScaVirtualDirsRead(
         if (*pwzData && *ppshhList)
         {
             hr = ScaGetHttpHeader(hhptVDir, pwzData, ppshhList, &pvdir->pshh);
-            ExitOnFailure1(hr, "Failed to get custom HTTP headers for VirtualDir: %ls", pwzData);
+            ExitOnFailure(hr, "Failed to get custom HTTP headers for VirtualDir: %ls", pwzData);
         }
 
         if (*pwzData && *ppsweList)
         {
             hr = ScaGetWebError(weptVDir, pwzData, ppsweList, &pvdir->pswe);
-            ExitOnFailure1(hr, "Failed to get custom web errors for VirtualDir: %ls", pwzData);
+            ExitOnFailure(hr, "Failed to get custom web errors for VirtualDir: %ls", pwzData);
         }
     }
 
@@ -289,7 +289,7 @@ HRESULT ScaVirtualDirsUninstall(
             if (0 != lstrlenW(psvd->wzVDirRoot))
             {
                 hr = ScaDeleteMetabaseKey(piMetabase, psvd->wzVDirRoot, L"");
-                ExitOnFailure1(hr, "Failed to remove VirtualDir '%ls' from metabase", psvd->wzKey);
+                ExitOnFailure(hr, "Failed to remove VirtualDir '%ls' from metabase", psvd->wzKey);
             }
         }
 

--- a/src/ext/ca/serverca/scasched/scavdir7.cpp
+++ b/src/ext/ca/serverca/scasched/scavdir7.cpp
@@ -72,7 +72,7 @@ HRESULT __stdcall ScaVirtualDirsRead7(
 
         // get vdir properties
         hr = ::StringCchCopyW(pvdir->wzComponent, countof(pvdir->wzComponent), pwzData);
-        ExitOnFailure1(hr, "failed to copy vdir component name: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy vdir component name: %ls", pwzData);
 
         hr = WcaGetRecordString(hRec, vdqWeb, &pwzData);
         ExitOnFailure(hr, "Failed to get Web for VirtualDir");
@@ -152,13 +152,13 @@ HRESULT __stdcall ScaVirtualDirsRead7(
         if (*pwzData && *ppshhList)
         {
             hr = ScaGetHttpHeader(hhptVDir, pwzData, ppshhList, &pvdir->pshh);
-            ExitOnFailure1(hr, "Failed to get custom HTTP headers for VirtualDir: %ls", pwzData);
+            ExitOnFailure(hr, "Failed to get custom HTTP headers for VirtualDir: %ls", pwzData);
         }
 
         if (*pwzData && *ppsweList)
         {
             hr = ScaGetWebError(weptVDir, pwzData, ppsweList, &pvdir->pswe);
-            ExitOnFailure1(hr, "Failed to get custom web errors for VirtualDir: %ls", pwzData);
+            ExitOnFailure(hr, "Failed to get custom web errors for VirtualDir: %ls", pwzData);
         }
     }
 
@@ -337,7 +337,7 @@ HRESULT ScaVirtualDirsUninstall7(
                 ExitOnFailure(hr, "Failed to write vdir path");
             }
 
-            ExitOnFailure1(hr, "Failed to remove VirtualDir '%ls' from config", psvd->wzKey);
+            ExitOnFailure(hr, "Failed to remove VirtualDir '%ls' from config", psvd->wzKey);
         }
 
         psvd = psvd->psvdNext;

--- a/src/ext/ca/serverca/scasched/scaweb.cpp
+++ b/src/ext/ca/serverca/scasched/scaweb.cpp
@@ -469,7 +469,7 @@ HRESULT ScaWebsInstall(
         if (psw->fHasComponent && WcaIsInstalling(psw->isInstalled, psw->isAction))
         {
             hr = ScaWebWrite(piMetabase, psw, psapList);
-            ExitOnFailure1(hr, "failed to write web '%ls' to metabase", psw->wzKey);
+            ExitOnFailure(hr, "failed to write web '%ls' to metabase", psw->wzKey);
         }
 
         psw = psw->pswNext;
@@ -494,7 +494,7 @@ HRESULT ScaWebsUninstall(
         if (psw->fHasComponent && WcaIsUninstalling(psw->isInstalled, psw->isAction))
         {
             hr = ScaWebRemove(piMetabase, psw);
-            ExitOnFailure1(hr, "Failed to remove web '%ls' from metabase", psw->wzKey);
+            ExitOnFailure(hr, "Failed to remove web '%ls' from metabase", psw->wzKey);
         }
 
         psw = psw->pswNext;
@@ -870,7 +870,7 @@ static HRESULT ScaWebFindFreeBase(
                 }
             }
             // In case we don't find a slash, error out
-            ExitOnNull1(pcchSlash, hr, E_INVALIDARG, "Failed to find a slash in the web root: %ls", psw->wzWebBase);
+            ExitOnNull(pcchSlash, hr, E_INVALIDARG, "Failed to find a slash in the web root: %ls", psw->wzWebBase);
 
             prgdwSubKeys[cSubKeysFilled] = wcstol(pcchSlash + 1, NULL, 10);
             ++cSubKeysFilled;
@@ -904,7 +904,7 @@ static HRESULT ScaWebFindFreeBase(
     }
 
     hr = ::StringCchPrintfW(wzWebBase, cchWebBase, L"/LM/W3SVC/%u", dwKey);
-    ExitOnFailure1(hr, "failed to format web base with key: %u", dwKey);
+    ExitOnFailure(hr, "failed to format web base with key: %u", dwKey);
 
 LExit:
     MetaFreeValue(&mr);
@@ -1101,7 +1101,7 @@ static HRESULT ScaWebWrite(
     if (psw->pswscList)
     {
         hr = ScaSslCertificateWriteMetabase(piMetabase, psw->wzWebBase, psw->pswscList);
-        ExitOnFailure1(hr, "Failed to write SSL certificates for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write SSL certificates for Web site: %ls", psw->wzKey);
     }
 
     hr = ScaWriteMetabaseValue(piMetabase, psw->wzWebBase, L"", MD_SECURE_BINDINGS, METADATA_NO_ATTRIBUTES, IIS_MD_UT_SERVER, MULTISZ_METADATA, wzSecureBindings);
@@ -1111,21 +1111,21 @@ static HRESULT ScaWebWrite(
     if (psw->pshhList)
     {
         hr = ScaWriteHttpHeader(piMetabase, wzRootOfWeb, psw->pshhList);
-        ExitOnFailure1(hr, "Failed to write custom HTTP headers for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write custom HTTP headers for Web site: %ls", psw->wzKey);
     }
 
     // write the errors
     if (psw->psweList)
     {
         hr = ScaWriteWebError(piMetabase, weptWeb, psw->wzWebBase, psw->psweList);
-        ExitOnFailure1(hr, "Failed to write custom web errors for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write custom web errors for Web site: %ls", psw->wzKey);
     }
 
     // write the mimetypes
     if (psw->psmm)
     {
         hr = ScaWriteMimeMap(piMetabase, wzRootOfWeb, psw->psmm);
-        ExitOnFailure1(hr, "Failed to write mimemap for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write mimemap for Web site: %ls", psw->wzKey);
     }
 
     // write the log information to the metabase
@@ -1149,7 +1149,7 @@ static HRESULT ScaWebRemove(
 
     // simply remove the root key and everything else is pulled at the same time
     hr = ScaDeleteMetabaseKey(piMetabase, psw->wzWebBase, L"");
-    ExitOnFailure1(hr, "Failed to remove web '%ls' from metabase", psw->wzKey);
+    ExitOnFailure(hr, "Failed to remove web '%ls' from metabase", psw->wzKey);
 
 LExit:
     return hr;

--- a/src/ext/ca/serverca/scasched/scaweb7.cpp
+++ b/src/ext/ca/serverca/scasched/scaweb7.cpp
@@ -258,7 +258,7 @@ HRESULT ScaWebsRead7(
                 pwzData[dwLen-1] = 0;
             }
             hr = ::StringCchCopyW(psw->wzDirectory, countof(psw->wzDirectory), pwzData);
-            ExitOnFailure1(hr, "Failed to copy web dir: '%ls'", pwzData);
+            ExitOnFailure(hr, "Failed to copy web dir: '%ls'", pwzData);
 
         }
 
@@ -617,7 +617,7 @@ HRESULT ScaWebsInstall7(
         if (psw->fHasComponent && WcaIsInstalling(psw->isInstalled, psw->isAction))
         {
             hr = ScaWebWrite7(psw, psapList);
-            ExitOnFailure1(hr, "failed to write web '%ls' to metabase", psw->wzKey);
+            ExitOnFailure(hr, "failed to write web '%ls' to metabase", psw->wzKey);
         }
 
         psw = psw->pswNext;
@@ -641,7 +641,7 @@ HRESULT ScaWebsUninstall7(
         {
             // If someone
             hr = ScaWebRemove7(psw);
-            ExitOnFailure1(hr, "Failed to remove web '%ls' ", psw->wzKey);
+            ExitOnFailure(hr, "Failed to remove web '%ls' ", psw->wzKey);
         }
 
         psw = psw->pswNext;
@@ -751,7 +751,7 @@ static HRESULT ScaWebWrite7(
     {
         // Check if site already exists.
         hr = ScaWebSearch7(psw, NULL, &fExists);
-        ExitOnFailure1(hr, "Failed to search for web: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to search for web: %ls", psw->wzKey);
 
         if (fExists)
         {
@@ -916,21 +916,21 @@ static HRESULT ScaWebWrite7(
     if (psw->pswscList)
     {
         hr = ScaSslCertificateWrite7(psw->wzDescription, psw->pswscList);
-        ExitOnFailure1(hr, "Failed to write SSL certificates for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write SSL certificates for Web site: %ls", psw->wzKey);
     }
 
     // write the headers
     if (psw->pshhList)
     {
         hr = ScaWriteHttpHeader7(psw->wzDescription, L"/", psw->pshhList);
-        ExitOnFailure1(hr, "Failed to write custom HTTP headers for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write custom HTTP headers for Web site: %ls", psw->wzKey);
     }
 
     // write the errors
     if (psw->psweList)
     {
         hr = ScaWriteWebError7(psw->wzDescription, L"/", psw->psweList);
-        ExitOnFailure1(hr, "Failed to write custom web errors for Web site: %ls", psw->wzKey);
+        ExitOnFailure(hr, "Failed to write custom web errors for Web site: %ls", psw->wzKey);
     }
 
     // write the log information to the metabase

--- a/src/ext/ca/serverca/scasched/scawebapp.cpp
+++ b/src/ext/ca/serverca/scasched/scawebapp.cpp
@@ -51,7 +51,7 @@ HRESULT ScaGetWebApplication(MSIHANDLE /*hViewApplications*/,
         ExitOnFailure(hr, "Failed to copy name string to webapp object");
 
         hr = WcaGetRecordInteger(hRec, wappqIsolation, &pswapp->iIsolation);
-        ExitOnFailure1(hr, "Failed to get App isolation: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to get App isolation: '%ls'", pswapp->wzName);
 
         hr = WcaGetRecordInteger(hRec, wappqAllowSession, &pswapp->fAllowSessionState);
 
@@ -62,13 +62,13 @@ HRESULT ScaGetWebApplication(MSIHANDLE /*hViewApplications*/,
         hr = WcaGetRecordInteger(hRec, wappqParentPaths, &pswapp->fParentPaths);
 
         hr = WcaGetRecordString(hRec, wappqDefaultScript, &pwzData);
-        ExitOnFailure1(hr, "Failed to get default scripting language for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to get default scripting language for App: '%ls'", pswapp->wzName);
         hr = ::StringCchCopyW(pswapp->wzDefaultScript, countof(pswapp->wzDefaultScript), pwzData);
         ExitOnFailure(hr, "Failed to copy default script string to webapp object");
 
         // asp script timeout
         hr = WcaGetRecordInteger(hRec, wappqScriptTimeout, &pswapp->iScriptTimeout);
-        ExitOnFailure1(hr, "Failed to get scripting timeout for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to get scripting timeout for App: '%ls'", pswapp->wzName);
 
         // asp server-side script debugging
         hr = WcaGetRecordInteger(hRec, wappqServerDebugging, &pswapp->fServerDebugging);
@@ -77,13 +77,13 @@ HRESULT ScaGetWebApplication(MSIHANDLE /*hViewApplications*/,
         hr = WcaGetRecordInteger(hRec, wappqClientDebugging, &pswapp->fClientDebugging);
 
         hr = WcaGetRecordString(hRec, wappqAppPool, &pwzData);
-        ExitOnFailure1(hr, "Failed to get AppPool for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to get AppPool for App: '%ls'", pswapp->wzName);
         hr = ::StringCchCopyW(pswapp->wzAppPool, countof(pswapp->wzAppPool), pwzData);
-        ExitOnFailure2(hr, "failed to copy AppPool: '%ls' for App: '%ls'", pwzData, pswapp->wzName);
+        ExitOnFailure(hr, "failed to copy AppPool: '%ls' for App: '%ls'", pwzData, pswapp->wzName);
 
         // app extensions
          hr = ScaWebAppExtensionsRead(pwzApplication, hWebAppExtQuery, &pswapp->pswappextList);
-        ExitOnFailure1(hr, "Failed to read AppExtensions for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to read AppExtensions for App: '%ls'", pswapp->wzName);
 
         hr = S_OK;
     }
@@ -122,82 +122,82 @@ HRESULT ScaWriteWebApplication(IMSAdminBase* piMetabase, LPCWSTR wzRootOfWeb,
     if (2 == pswapp->iIsolation)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_APP_ISOLATED, METADATA_INHERIT, IIS_MD_UT_WAM, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->iIsolation));
-        ExitOnFailure1(hr, "Failed to write isolation value for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write isolation value for App: '%ls'", pswapp->wzName);
     }
 
     // application name
     hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_APP_FRIENDLY_NAME, METADATA_INHERIT, IIS_MD_UT_WAM, STRING_METADATA, pswapp->wzName);
-    ExitOnFailure1(hr, "Failed to write Name of App: '%ls'", pswapp->wzName);
+    ExitOnFailure(hr, "Failed to write Name of App: '%ls'", pswapp->wzName);
 
     // allow session state
     if (MSI_NULL_INTEGER != pswapp->fAllowSessionState)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_ALLOWSESSIONSTATE, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->fAllowSessionState));
-        ExitOnFailure1(hr, "Failed to write allow session information for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write allow session information for App: '%ls'", pswapp->wzName);
     }
 
     // session timeout
     if (MSI_NULL_INTEGER != pswapp->iSessionTimeout)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_SESSIONTIMEOUT, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->iSessionTimeout));
-        ExitOnFailure1(hr, "Failed to write session timeout for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write session timeout for App: '%ls'", pswapp->wzName);
     }
 
     // asp buffering
     if (MSI_NULL_INTEGER != pswapp->fBuffer)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_BUFFERINGON, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->fBuffer));
-        ExitOnFailure1(hr, "Failed to write buffering flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write buffering flag for App: '%ls'", pswapp->wzName);
     }
 
     // asp parent paths
     if (MSI_NULL_INTEGER != pswapp->fParentPaths)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_ENABLEPARENTPATHS, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->fParentPaths));
-        ExitOnFailure1(hr, "Failed to write parent paths flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write parent paths flag for App: '%ls'", pswapp->wzName);
     }
 
     // default scripting language
     if (*pswapp->wzDefaultScript)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_SCRIPTLANGUAGE, METADATA_INHERIT, ASP_MD_UT_APP, STRING_METADATA, pswapp->wzDefaultScript);
-        ExitOnFailure1(hr, "Failed to write default scripting language for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write default scripting language for App: '%ls'", pswapp->wzName);
     }
 
     // asp script timeout
     if (MSI_NULL_INTEGER != pswapp->iScriptTimeout)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_SCRIPTTIMEOUT, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->iScriptTimeout));
-        ExitOnFailure1(hr, "Failed to write script timeout for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write script timeout for App: '%ls'", pswapp->wzName);
     }
 
     // asp server-side script debugging
     if (MSI_NULL_INTEGER != pswapp->fServerDebugging)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_ENABLESERVERDEBUG, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->fServerDebugging));
-        ExitOnFailure1(hr, "Failed to write ASP server-side script debugging flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write ASP server-side script debugging flag for App: '%ls'", pswapp->wzName);
     }
 
     // asp server-side script debugging
     if (MSI_NULL_INTEGER != pswapp->fClientDebugging)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_ASP_ENABLECLIENTDEBUG, METADATA_INHERIT, ASP_MD_UT_APP, DWORD_METADATA, (LPVOID)((DWORD_PTR)pswapp->fClientDebugging));
-        ExitOnFailure1(hr, "Failed to write ASP client-side script debugging flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write ASP client-side script debugging flag for App: '%ls'", pswapp->wzName);
     }
 
     // AppPool
     if (*pswapp->wzAppPool && NULL != psapList)
     {
         hr = ScaFindAppPool(piMetabase, pswapp->wzAppPool, wzAppPoolName, countof(wzAppPoolName), psapList);
-        ExitOnFailure1(hr, "failed to find app pool: %ls", pswapp->wzAppPool);
+        ExitOnFailure(hr, "failed to find app pool: %ls", pswapp->wzAppPool);
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_APP_APPPOOL_ID, METADATA_INHERIT, IIS_MD_UT_SERVER, STRING_METADATA, wzAppPoolName);
-        ExitOnFailure1(hr, "Failed to write default AppPool for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write default AppPool for App: '%ls'", pswapp->wzName);
     }
 
     if (pswapp->pswappextList)
     {
         hr = ScaWebAppExtensionsWrite(piMetabase, wzRootOfWeb, pswapp->pswappextList);
-        ExitOnFailure1(hr, "Failed to write AppExtensions for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write AppExtensions for App: '%ls'", pswapp->wzName);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scawebapp7.cpp
+++ b/src/ext/ca/serverca/scasched/scawebapp7.cpp
@@ -42,7 +42,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SESSIONSTATE);
         ExitOnFailure(hr, "Failed to write WebApp ASP sessionstate id");
         hr = ScaWriteConfigInteger(pswapp->fAllowSessionState);
-        ExitOnFailure1(hr, "Failed to write allow session information for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write allow session information for App: '%ls'", pswapp->wzName);
     }
 
     // session timeout
@@ -52,7 +52,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SESSIONTIMEOUT);
         ExitOnFailure(hr, "Failed to write WebApp ASP sessiontimepot id");
         hr = ScaWriteConfigInteger(pswapp->iSessionTimeout);
-        ExitOnFailure1(hr, "Failed to write session timeout for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write session timeout for App: '%ls'", pswapp->wzName);
     }
 
     // asp buffering
@@ -62,7 +62,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_BUFFER);
         ExitOnFailure(hr, "Failed to write WebApp ASP buffer id");
         hr = ScaWriteConfigInteger(pswapp->fBuffer);
-        ExitOnFailure1(hr, "Failed to write buffering flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write buffering flag for App: '%ls'", pswapp->wzName);
     }
 
     // asp parent paths
@@ -72,7 +72,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_PARENTPATHS);
         ExitOnFailure(hr, "Failed to write WebApp ASP parentpaths id");
         hr = ScaWriteConfigInteger(pswapp->fParentPaths);
-        ExitOnFailure1(hr, "Failed to write parent paths flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write parent paths flag for App: '%ls'", pswapp->wzName);
     }
 
     // default scripting language
@@ -82,7 +82,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SCRIPTLANG);
         ExitOnFailure(hr, "Failed to write WebApp ASP script lang id");
         hr = ScaWriteConfigString(pswapp->wzDefaultScript);
-        ExitOnFailure1(hr, "Failed to write default scripting language for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write default scripting language for App: '%ls'", pswapp->wzName);
     }
 
     // asp script timeout
@@ -92,7 +92,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SCRIPTTIMEOUT);
         ExitOnFailure(hr, "Failed to write WebApp ASP script timeout id");
         hr = ScaWriteConfigInteger(pswapp->iScriptTimeout);
-        ExitOnFailure1(hr, "Failed to write script timeout for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write script timeout for App: '%ls'", pswapp->wzName);
     }
 
     // asp server-side script debugging
@@ -102,7 +102,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SCRIPTSERVERDEBUG);
         ExitOnFailure(hr, "Failed to write WebApp ASP script debug id");
         hr = ScaWriteConfigInteger(pswapp->fServerDebugging);
-        ExitOnFailure1(hr, "Failed to write ASP server-side script debugging flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write ASP server-side script debugging flag for App: '%ls'", pswapp->wzName);
     }
 
     // asp client-side script debugging
@@ -112,7 +112,7 @@ HRESULT ScaWriteWebApplication7(
         hr = ScaWriteConfigID(IIS_ASP_SCRIPTCLIENTDEBUG);
         ExitOnFailure(hr, "Failed to write WebApp ASP script debug id");
         hr = ScaWriteConfigInteger(pswapp->fClientDebugging);
-        ExitOnFailure1(hr, "Failed to write ASP client-side script debugging flag for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write ASP client-side script debugging flag for App: '%ls'", pswapp->wzName);
     }
 
     //done with ASP application properties
@@ -123,7 +123,7 @@ HRESULT ScaWriteWebApplication7(
     if (pswapp->pswappextList)
     {
         hr = ScaWebAppExtensionsWrite7(wzWebName, wzRootOfWeb, pswapp->pswappextList);
-        ExitOnFailure1(hr, "Failed to write AppExtensions for App: '%ls'", pswapp->wzName);
+        ExitOnFailure(hr, "Failed to write AppExtensions for App: '%ls'", pswapp->wzName);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scawebappext.cpp
+++ b/src/ext/ca/serverca/scasched/scawebappext.cpp
@@ -55,13 +55,13 @@ HRESULT ScaWebAppExtensionsRead(
 
         // application extension verbs
         hr = WcaGetRecordString(hRec, wappextqVerbs, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Verbs for Application: '%ls'", wzApplication);
+        ExitOnFailure(hr, "Failed to get Verbs for Application: '%ls'", wzApplication);
         hr = ::StringCchCopyW(pswappext->wzVerbs, countof(pswappext->wzVerbs), pwzData);
         ExitOnFailure(hr, "Failed to copy verbs string to webappext object");
 
         // extension executeable
         hr = WcaGetRecordString(hRec, wappextqExecutable, &pwzData);
-        ExitOnFailure1(hr, "Failed to get Executable for Application: '%ls'", wzApplication);
+        ExitOnFailure(hr, "Failed to get Executable for Application: '%ls'", wzApplication);
         hr = ::StringCchCopyW(pswappext->wzExecutable, countof(pswappext->wzExecutable), pwzData);
         ExitOnFailure(hr, "Failed to copy executable string to webappext object");
 
@@ -153,7 +153,7 @@ HRESULT ScaWebAppExtensionsWrite(
     if (*wzAppExtensions)
     {
         hr = ScaWriteMetabaseValue(piMetabase, wzRootOfWeb, NULL, MD_SCRIPT_MAPS, METADATA_INHERIT, IIS_MD_UT_FILE, MULTISZ_METADATA, wzAppExtensions);
-        ExitOnFailure1(hr, "Failed to write AppExtension: '%ls'", wzAppExtension);
+        ExitOnFailure(hr, "Failed to write AppExtension: '%ls'", wzAppExtension);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scawebdir.cpp
+++ b/src/ext/ca/serverca/scasched/scawebdir.cpp
@@ -209,7 +209,7 @@ HRESULT ScaWebDirsUninstall(IMSAdminBase* piMetabase, SCA_WEBDIR* pswdList)
             }
 
             hr = ScaDeleteMetabaseKey(piMetabase, pswd->wzWebDirRoot, L"");
-            ExitOnFailure1(hr, "Failed to remove WebDir '%ls' from metabase", pswd->wzKey);
+            ExitOnFailure(hr, "Failed to remove WebDir '%ls' from metabase", pswd->wzKey);
         }
 
         pswd = pswd->pswdNext;

--- a/src/ext/ca/serverca/scasched/scaweberr.cpp
+++ b/src/ext/ca/serverca/scasched/scaweberr.cpp
@@ -86,7 +86,7 @@ HRESULT ScaWebErrorRead(
 
         // If they've specified both a file and a URL, that's invalid
         if (*(pswe->wzFile) && *(pswe->wzURL))
-            ExitOnFailure2(hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA), "Both File and URL specified for web error.  File: %ls, URL: %ls", pswe->wzFile, pswe->wzURL);
+            ExitOnFailure(hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA), "Both File and URL specified for web error.  File: %ls, URL: %ls", pswe->wzFile, pswe->wzURL);
     }
 
     if (E_NOMOREITEMS == hr)
@@ -206,7 +206,7 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
         // we can walk up key by key and look for custom errors to inherit
 
         hr = StrAllocConcat(&pwzSearchKey, wzRoot, 0);
-        ExitOnFailure1(hr, "Failed to copy root string: %ls", wzRoot);
+        ExitOnFailure(hr, "Failed to copy root string: %ls", wzRoot);
 
         pwz = pwzSearchKey + lstrlenW(pwzSearchKey);
 
@@ -225,7 +225,7 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
             hr = MetaGetValue(piMetabase, METADATA_MASTER_ROOT_HANDLE, pwzSearchKey, &mr);
             if (HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND) == hr || MD_ERROR_DATA_NOT_FOUND == hr)
                 hr = S_FALSE;
-            ExitOnFailure1(hr, "failed to discover default error values to start with for web root: %ls while walking up the tree", wzRoot);
+            ExitOnFailure(hr, "failed to discover default error values to start with for web root: %ls while walking up the tree", wzRoot);
 
             if (S_OK == hr)
             {
@@ -242,12 +242,12 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
     {
         pwzErrors = reinterpret_cast<LPWSTR>(mr.pbMDData);
     }
-    ExitOnFailure1(hr, "failed to discover default error values to start with for web root: %ls", wzRoot);
+    ExitOnFailure(hr, "failed to discover default error values to start with for web root: %ls", wzRoot);
 
     // The above code should have come up with some value to start pwzErrors off with.  Make sure it did.
     if (NULL == pwzErrors)
     {
-        ExitOnFailure1(hr = E_UNEXPECTED, "failed to discover default error values to start with for web root: %ls", wzRoot);
+        ExitOnFailure(hr = E_UNEXPECTED, "failed to discover default error values to start with for web root: %ls", wzRoot);
     }
 
     // Loop through the web errors
@@ -269,7 +269,7 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
         }
 
         hr = MultiSzFindSubstring(pwzErrors, pwzCodeSubCode, &dwFoundCodeSubCodeIndex, &wzFoundCodeSubCode);
-        ExitOnFailure1(hr, "failed to find existing error code,subcode: %ls", pwzCodeSubCode);
+        ExitOnFailure(hr, "failed to find existing error code,subcode: %ls", pwzCodeSubCode);
 
         // If we didn't find this error code/sub code pair in the list already, make sure it's acceptable to add
         if (S_FALSE == hr)
@@ -284,7 +284,7 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
 
             // We don't care where it is, just whether it's there or not
             hr = MultiSzFindSubstring(pwzAcceptableErrors, pwzAcceptableCodeSubCode, NULL, NULL);
-            ExitOnFailure1(hr, "failed to find whether or not error code, subcode: %ls is supported", pwzCodeSubCode);
+            ExitOnFailure(hr, "failed to find whether or not error code, subcode: %ls is supported", pwzCodeSubCode);
 
             if (S_FALSE == hr)
             {
@@ -300,18 +300,18 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
         if (*(pswe->wzFile))
         {
             hr = StrAllocFormatted(&pwzNewError, L"%s,FILE,%s", pwzCodeSubCode, pswe->wzFile);
-            ExitOnFailure2(hr, "failed to create new error code string with code,subcode: %ls, file: %ls", pwzCodeSubCode, pswe->wzFile);
+            ExitOnFailure(hr, "failed to create new error code string with code,subcode: %ls, file: %ls", pwzCodeSubCode, pswe->wzFile);
         }
         else if (*(pswe->wzURL))
         {
             hr = StrAllocFormatted(&pwzNewError, L"%s,URL,%s", pwzCodeSubCode, pswe->wzURL);
-            ExitOnFailure2(hr, "failed to create new error code string with code,subcode: %ls, file: %ls", pwzCodeSubCode, pswe->wzFile);
+            ExitOnFailure(hr, "failed to create new error code string with code,subcode: %ls, file: %ls", pwzCodeSubCode, pswe->wzFile);
         }
         else if (fOldValueFound)
         {
             // If no File or URL was specified, they want a default error so remove the old value from the MULTISZ and move on
             hr = MultiSzRemoveString(&pwzErrors, dwFoundCodeSubCodeIndex);
-            ExitOnFailure1(hr, "failed to remove string for error code sub code: %ls in order to make it 'default'", pwzCodeSubCode);
+            ExitOnFailure(hr, "failed to remove string for error code sub code: %ls in order to make it 'default'", pwzCodeSubCode);
             continue;
         }
 
@@ -319,12 +319,12 @@ HRESULT ScaWriteWebError(IMSAdminBase* piMetabase, int iParentType, LPCWSTR wzRo
         if (fOldValueFound)
         {
             hr = MultiSzReplaceString(&pwzErrors, dwFoundCodeSubCodeIndex, pwzNewError);
-            ExitOnFailure1(hr, "failed to replace old error string with new error string for error code,subcode: %ls", pwzCodeSubCode);
+            ExitOnFailure(hr, "failed to replace old error string with new error string for error code,subcode: %ls", pwzCodeSubCode);
         }
         else
         {
             hr = MultiSzPrepend(&pwzErrors, NULL, pwzNewError);
-            ExitOnFailure1(hr, "failed to prepend new error string for error code,subcode: %ls", pwzCodeSubCode);
+            ExitOnFailure(hr, "failed to prepend new error string for error code,subcode: %ls", pwzCodeSubCode);
         }
     }
 

--- a/src/ext/ca/serverca/scasched/scaweblog.cpp
+++ b/src/ext/ca/serverca/scasched/scaweblog.cpp
@@ -54,21 +54,21 @@ static HRESULT LookupLogFormatGUID(
 
     // verify that we have this log format available in IIS
     hr = MetaGetValue(piMetabase, METADATA_MASTER_ROOT_HANDLE, wzKey, &mrKeyType);
-    ExitOnFailure1(hr, "Failed to find specified Log format key in IIS for log format: %ls", wzLogFormat);
+    ExitOnFailure(hr, "Failed to find specified Log format key in IIS for log format: %ls", wzLogFormat);
     ExitOnNull(mrKeyType.pbMDData, hr, E_POINTER, "Request for Log format key in IIS for log format returned success, but value was NULL");
 
     if (0 != lstrcmpW(L"IIsLogModule", (LPCWSTR)mrKeyType.pbMDData))
     {
-        ExitOnFailure1(hr = E_UNEXPECTED, "Found invalid log format in IIS: %ls", (LPCWSTR)mrKeyType.pbMDData);
+        ExitOnFailure(hr = E_UNEXPECTED, "Found invalid log format in IIS: %ls", (LPCWSTR)mrKeyType.pbMDData);
     }
 
     // find the GUID for that log format
     hr = MetaGetValue(piMetabase, METADATA_MASTER_ROOT_HANDLE, wzKey, &mrPluginId);
-    ExitOnFailure1(hr, "Failed to retrieve IISLog format GUID. Key: %ls", wzKey);
+    ExitOnFailure(hr, "Failed to retrieve IISLog format GUID. Key: %ls", wzKey);
     ExitOnNull(mrPluginId.pbMDData, hr, E_POINTER, "Retrieval of IISLog format GUID returned success, but value was NULL");
 
     hr = ::StringCchCopyW(wzGUID, cchGUID, (LPCWSTR)mrPluginId.pbMDData);
-    ExitOnFailure1(hr, "failed to copy metabase value: %ls", (LPCWSTR)mrPluginId.pbMDData);
+    ExitOnFailure(hr, "failed to copy metabase value: %ls", (LPCWSTR)mrPluginId.pbMDData);
 
 LExit:
 
@@ -112,7 +112,7 @@ HRESULT ScaGetWebLog(
     hr = WcaFetchWrappedRecordWhereString(hWebLogQuery, wlqLog, wzLog, &hRec);
     if (E_NOMOREITEMS == hr)
     {
-        ExitOnFailure1(hr, "cannot locate IIsWebLog.Log='%ls'", wzLog);
+        ExitOnFailure(hr, "cannot locate IIsWebLog.Log='%ls'", wzLog);
     }
     HRESULT hrTemp = WcaFetchWrappedRecordWhereString(hWebLogQuery, wlqLog, wzLog, &hRec);
 
@@ -125,20 +125,20 @@ HRESULT ScaGetWebLog(
 
     // check that log key matches
     hr = WcaGetRecordString(hRec, wlqLog, &pwzData);
-    ExitOnFailure1(hr, "failed to get IIsWebLog.Log for Log: %ls", wzLog);
+    ExitOnFailure(hr, "failed to get IIsWebLog.Log for Log: %ls", wzLog);
     hr = ::StringCchCopyW(pswl->wzLog, countof(pswl->wzLog), pwzData);
-    ExitOnFailure1(hr, "failed to copy log name: %ls", pwzData);
+    ExitOnFailure(hr, "failed to copy log name: %ls", pwzData);
 
     hr = WcaGetRecordString(hRec, wlqFormat, &pwzData);
-    ExitOnFailure1(hr, "failed to get IIsWebLog.Format for Log:", wzLog);
+    ExitOnFailure(hr, "failed to get IIsWebLog.Format for Log:", wzLog);
     hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), pwzData);
-    ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+    ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
 
     // if they specified a log format, look up its GUID in the metabase
     if (*pswl->wzFormat && 0 != lstrcmpW(pswl->wzFormat, L"none"))
     {
         hr = LookupLogFormatGUID(piMetabase, pswl->wzFormat, pswl->wzFormatGUID, countof(pswl->wzFormatGUID));
-        ExitOnFailure1(hr, "Failed to get Log Format GUID for Log: %ls", wzLog);
+        ExitOnFailure(hr, "Failed to get Log Format GUID for Log: %ls", wzLog);
     }
 
 LExit:
@@ -166,7 +166,7 @@ HRESULT ScaWriteWebLog(
         {
             // user wishes for Logging to be turned 'off'
             hr = ScaWriteMetabaseValue(piMetabase, wzWebBase, L"", MD_LOG_TYPE, METADATA_INHERIT, IIS_MD_UT_SERVER, DWORD_METADATA, (LPVOID)((DWORD_PTR)0));
-            ExitOnFailure1(hr, "Failed to write Log Type for Web: %ls", wzWebBase);
+            ExitOnFailure(hr, "Failed to write Log Type for Web: %ls", wzWebBase);
         }
         else
         {
@@ -174,10 +174,10 @@ HRESULT ScaWriteWebLog(
             
             // write the GUID for the log format for the web to the metabase
             hr = ScaWriteMetabaseValue(piMetabase, wzWebBase, L"", MD_LOG_PLUGIN_ORDER, METADATA_INHERIT, IIS_MD_UT_SERVER, STRING_METADATA, pswl->wzFormatGUID);
-            ExitOnFailure1(hr, "Failed to write Log GUID for Web: %ls", wzWebBase);
+            ExitOnFailure(hr, "Failed to write Log GUID for Web: %ls", wzWebBase);
 
             hr = ScaWriteMetabaseValue(piMetabase, wzWebBase, L"", MD_LOG_TYPE, METADATA_INHERIT, IIS_MD_UT_SERVER, DWORD_METADATA, (LPVOID)((DWORD_PTR)1));
-            ExitOnFailure1(hr, "Failed to write Log Type for Web: %ls", wzWebBase);
+            ExitOnFailure(hr, "Failed to write Log Type for Web: %ls", wzWebBase);
         }
     }
 

--- a/src/ext/ca/serverca/scasched/scaweblog7.cpp
+++ b/src/ext/ca/serverca/scasched/scaweblog7.cpp
@@ -43,7 +43,7 @@ HRESULT ScaGetWebLog7(
     hr = WcaFetchWrappedRecordWhereString(hWebLogQuery, wlqLog, wzLog, &hRec);
     if (E_NOMOREITEMS == hr)
     {
-        ExitOnFailure1(hr, "cannot locate IIsWebLog.Log='%ls'", wzLog);
+        ExitOnFailure(hr, "cannot locate IIsWebLog.Log='%ls'", wzLog);
     }
     HRESULT hrTemp = WcaFetchWrappedRecordWhereString(hWebLogQuery, wlqLog, wzLog, &hRec);
 
@@ -56,43 +56,43 @@ HRESULT ScaGetWebLog7(
 
     // check that log key matches
     hr = WcaGetRecordString(hRec, wlqLog, &pwzData);
-    ExitOnFailure1(hr, "failed to get IIsWebLog.Log for Log: %ls", wzLog);
+    ExitOnFailure(hr, "failed to get IIsWebLog.Log for Log: %ls", wzLog);
     hr = ::StringCchCopyW(pswl->wzLog, countof(pswl->wzLog), pwzData);
-    ExitOnFailure1(hr, "failed to copy log name: %ls", pwzData);
+    ExitOnFailure(hr, "failed to copy log name: %ls", pwzData);
 
     hr = WcaGetRecordString(hRec, wlqFormat, &pwzData);
-    ExitOnFailure1(hr, "failed to get IIsWebLog.Format for Log:", wzLog);
+    ExitOnFailure(hr, "failed to get IIsWebLog.Format for Log:", wzLog);
 
     //translate WIX log format name strings to IIS7
     if (0 == lstrcmpW(pwzData, L"Microsoft IIS Log File Format"))
     {
         hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), L"IIS");
-        ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
     }
     else if (0 == lstrcmpW(pwzData, L"NCSA Common Log File Format"))
     {
         hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), L"NCSA");
-        ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
     }
     else if (0 == lstrcmpW(pwzData, L"none"))
     {
         hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), L"none");
-        ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
     }
     else if (0 == lstrcmpW(pwzData, L"ODBC Logging"))
     {
         hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), L"W3C");
-        ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
     }
     else if (0 == lstrcmpW(pwzData, L"W3C Extended Log File Format"))
     {
         hr = ::StringCchCopyW(pswl->wzFormat, countof(pswl->wzFormat), L"W3C");
-        ExitOnFailure1(hr, "failed to copy log format: %ls", pwzData);
+        ExitOnFailure(hr, "failed to copy log format: %ls", pwzData);
     }
     else
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_INDEX);
-        ExitOnFailure1(hr, "Invalid log file format: %ls", pwzData);
+        ExitOnFailure(hr, "Invalid log file format: %ls", pwzData);
     }
 
 LExit:

--- a/src/ext/ca/serverca/scasched/scawebsvcext.cpp
+++ b/src/ext/ca/serverca/scasched/scawebsvcext.cpp
@@ -202,7 +202,7 @@ HRESULT __stdcall ScaWebSvcExtCommit(
 
     // Write Metabase
     hr = ScaWriteMetabaseValue(piMetabase, vcsWebSvcExtRoot, NULL, MD_WEB_SVC_EXT_RESTRICTION_LIST, METADATA_INHERIT, IIS_MD_UT_FILE, MULTISZ_METADATA, wzWebSvcExtList);
-    ExitOnFailure1(hr, "Failed to write WebServiceExtensions: '%ls'", wzWebSvcExtList);
+    ExitOnFailure(hr, "Failed to write WebServiceExtensions: '%ls'", wzWebSvcExtList);
 
 LExit:
     ReleaseStr(wzWebSvcExtList);
@@ -232,7 +232,7 @@ static HRESULT ScaWebSvcExtInstall(
 
     // Check if it's already in there
     hr = MultiSzFindSubstring(*ppwzWebSvcExtList, psWseList->wzFile, &dwIndex, &wzFoundString);
-    ExitOnFailure1(hr, "failed to search for string:%ls in web service extension MULTISZ", psWseList->wzFile);
+    ExitOnFailure(hr, "failed to search for string:%ls in web service extension MULTISZ", psWseList->wzFile);
 
     if (S_FALSE != hr && NULL != wcsstr(wzFoundString, psWseList->wzGroup) && NULL != wcsstr(wzFoundString, psWseList->wzDescription))
     {
@@ -248,12 +248,12 @@ static HRESULT ScaWebSvcExtInstall(
     if (fAlreadyExists)
     {
         hr = MultiSzReplaceString(ppwzWebSvcExtList, dwIndex, pwzWebSvcExt);
-        ExitOnFailure1(hr, "failed to update web service extension string: %ls", pwzWebSvcExt);
+        ExitOnFailure(hr, "failed to update web service extension string: %ls", pwzWebSvcExt);
     }
     else
     {
         hr = MultiSzPrepend(ppwzWebSvcExtList, pcchWebSvcExtList, pwzWebSvcExt);
-        ExitOnFailure1(hr, "failed to prepend web service extension string: %ls", pwzWebSvcExt);
+        ExitOnFailure(hr, "failed to prepend web service extension string: %ls", pwzWebSvcExt);
     }
 
 LExit:
@@ -278,13 +278,13 @@ static HRESULT ScaWebSvcExtUninstall(
 
     // Find the string to remove
     hr = MultiSzFindSubstring(*ppwzWebSvcExtList, psWseList->wzFile, &dwIndex, &wzFoundString);
-    ExitOnFailure1(hr, "failed to search for string:%ls in web service extension MULTISZ", psWseList->wzFile);
+    ExitOnFailure(hr, "failed to search for string:%ls in web service extension MULTISZ", psWseList->wzFile);
 
     // If we found a match (ignoring the Allow and Deletable flags)
     if (S_FALSE != hr && NULL != wcsstr(wzFoundString, psWseList->wzGroup) && NULL != wcsstr(wzFoundString, psWseList->wzDescription))
     {
         hr = MultiSzRemoveString(ppwzWebSvcExtList, dwIndex);
-        ExitOnFailure1(hr, "failed to remove string: %d from web service extension MULTISZ", dwIndex);
+        ExitOnFailure(hr, "failed to remove string: %d from web service extension MULTISZ", dwIndex);
     }
 
 LExit:

--- a/src/ext/ca/wixca/dll/CloseApps.cpp
+++ b/src/ext/ca/wixca/dll/CloseApps.cpp
@@ -320,7 +320,7 @@ extern "C" UINT __stdcall WixCloseApplications(
             if (MSICONDITION_ERROR == condition)
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "failed to process condition for WixCloseApplication '%ls'", pwzId);
+                ExitOnFailure(hr, "failed to process condition for WixCloseApplication '%ls'", pwzId);
             }
             else if (MSICONDITION_FALSE == condition)
             {

--- a/src/ext/ca/wixca/dll/OsInfo.cpp
+++ b/src/ext/ca/wixca/dll/OsInfo.cpp
@@ -313,11 +313,11 @@ static HRESULT SetPropertyWellKnownSID(
     DWORD size = MAX_PATH;
 
     hr = AclGetWellKnownSid(sidType, &psid);
-    ExitOnFailure1(hr, "Failed to get SID; skipping account %ls", wzPropertyName);
+    ExitOnFailure(hr, "Failed to get SID; skipping account %ls", wzPropertyName);
 
     if (!::LookupAccountSidW(NULL, psid, wzName, &size, wzRefDomain, &refSize, &nameUse))
     {
-        ExitWithLastError1(hr, "Failed to look up account for SID; skipping account %ls.", wzPropertyName);
+        ExitWithLastError(hr, "Failed to look up account for SID; skipping account %ls.", wzPropertyName);
     }
 
     hr = StrAllocFormatted(&pwzPropertyValue, L"%s\\%s", wzRefDomain, wzName);

--- a/src/ext/ca/wixca/dll/TouchFile.cpp
+++ b/src/ext/ca/wixca/dll/TouchFile.cpp
@@ -38,7 +38,7 @@ static BOOL SetExistingFileModifiedTime(
     if (f64Bit)
     {
         hr = WcaDisableWow64FSRedirection();
-        ExitOnFailure2(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
+        ExitOnFailure(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
 
         fReenableFileSystemRedirection = TRUE;
     }
@@ -98,7 +98,7 @@ static BOOL TryGetExistingFileModifiedTime(
     if (f64Bit)
     {
         hr = WcaDisableWow64FSRedirection();
-        ExitOnFailure2(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
+        ExitOnFailure(hr, "Failed to disable 64-bit file system redirection to path: '%ls' for: %ls", wzPath, wzId);
 
         fReenableFileSystemRedirection = TRUE;
     }
@@ -160,10 +160,10 @@ static HRESULT ProcessTouchFileTable(
         ExitOnFailure(hr, "Failed to get touch file identity.");
 
         hr = WcaGetRecordString(hRec, tfqComponent, &sczComponent);
-        ExitOnFailure1(hr, "Failed to get touch file component for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file component for: %ls", sczId);
 
         hr = WcaGetRecordInteger(hRec, tfqTouchFileAttributes, &iTouchFileAttributes);
-        ExitOnFailure1(hr, "Failed to get touch file attributes for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file attributes for: %ls", sczId);
 
         WCA_TODO todo = WcaGetComponentToDo(sczComponent);
 
@@ -174,16 +174,16 @@ static HRESULT ProcessTouchFileTable(
         if (fOnInstall || fOnReinstall || fOnUninstall)
         {
             hr = WcaGetRecordFormattedString(hRec, tfqPath, &sczPath);
-            ExitOnFailure1(hr, "Failed to get touch file path for: %ls", sczId);
+            ExitOnFailure(hr, "Failed to get touch file path for: %ls", sczId);
 
             if (TryGetExistingFileModifiedTime(sczId, sczPath, (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_64BIT), &ftRollbackModified))
             {
                 hr = AddDataToCustomActionData(&sczRollbackData, sczId, sczPath, iTouchFileAttributes, ftRollbackModified);
-                ExitOnFailure1(hr, "Failed to add to rollback custom action data for: %ls", sczId);
+                ExitOnFailure(hr, "Failed to add to rollback custom action data for: %ls", sczId);
             }
 
             hr = AddDataToCustomActionData(&sczExecuteData, sczId, sczPath, iTouchFileAttributes, ftModified);
-            ExitOnFailure1(hr, "Failed to add to execute custom action data for: %ls", sczId);
+            ExitOnFailure(hr, "Failed to add to execute custom action data for: %ls", sczId);
         }
     }
 
@@ -282,23 +282,23 @@ extern "C" UINT WINAPI WixExecuteTouchFile(
         ExitOnFailure(hr, "Failed to get touch file identity from custom action data.");
 
         hr = WcaReadStringFromCaData(&pwz, &sczPath);
-        ExitOnFailure1(hr, "Failed to get touch file path from custom action data for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file path from custom action data for: %ls", sczId);
 
         hr = WcaReadIntegerFromCaData(&pwz, &iTouchFileAttributes);
-        ExitOnFailure1(hr, "Failed to get touch file attributes from custom action data for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file attributes from custom action data for: %ls", sczId);
 
         hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int*>(&ftModified.dwHighDateTime));
-        ExitOnFailure1(hr, "Failed to get touch file high date/time from custom action data for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file high date/time from custom action data for: %ls", sczId);
 
         hr = WcaReadIntegerFromCaData(&pwz, reinterpret_cast<int*>(&ftModified.dwLowDateTime));
-        ExitOnFailure1(hr, "Failed to get touch file low date/time from custom action data for: %ls", sczId);
+        ExitOnFailure(hr, "Failed to get touch file low date/time from custom action data for: %ls", sczId);
 
         hr = SetExistingFileModifiedTime(sczId, sczPath, (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_64BIT), &ftModified);
         if (FAILED(hr))
         {
             if (iTouchFileAttributes & TOUCH_FILE_ATTRIBUTE_VITAL)
             {
-                ExitOnFailure2(hr, "Failed to touch file: '%ls' for: %ls", &sczPath, sczId);
+                ExitOnFailure(hr, "Failed to touch file: '%ls' for: %ls", &sczPath, sczId);
             }
             else
             {

--- a/src/ext/ca/wixca/dll/XmlConfig.cpp
+++ b/src/ext/ca/wixca/dll/XmlConfig.cpp
@@ -172,7 +172,7 @@ static HRESULT ReadXmlConfigTable(
 
         // Get component name
         hr = WcaGetRecordString(hRec, xfqComponent, &pwzData);
-        ExitOnFailure1(hr, "failed to get component name for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get component name for XmlConfig: %ls", (*ppxfcTail)->wzId);
 
         // Get the component's state
         if (0 < lstrlenW(pwzData))
@@ -186,13 +186,13 @@ static HRESULT ReadXmlConfigTable(
 
         // Get the xml file
         hr = WcaGetRecordFormattedString(hRec, xfqFile, &pwzData);
-        ExitOnFailure1(hr, "failed to get xml file for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get xml file for XmlConfig: %ls", (*ppxfcTail)->wzId);
         hr = StringCchCopyW((*ppxfcTail)->wzFile, countof((*ppxfcTail)->wzFile), pwzData);
         ExitOnFailure(hr, "failed to copy xml file path");
 
         // Figure out if the file is already on the machine or if it's being installed
         hr = WcaGetRecordString(hRec, xfqFile, &pwzData);
-        ExitOnFailure1(hr, "failed to get xml file for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get xml file for XmlConfig: %ls", (*ppxfcTail)->wzId);
         if (NULL != wcsstr(pwzData, L"[!") || NULL != wcsstr(pwzData, L"[#"))
         {
             (*ppxfcTail)->fInstalledFile = TRUE;
@@ -200,31 +200,31 @@ static HRESULT ReadXmlConfigTable(
 
         // Get the XmlConfig table flags
         hr = WcaGetRecordInteger(hRec, xfqXmlFlags, &(*ppxfcTail)->iXmlFlags);
-        ExitOnFailure1(hr, "failed to get XmlConfig flags for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get XmlConfig flags for XmlConfig: %ls", (*ppxfcTail)->wzId);
 
         // Get the Element Path
         hr = WcaGetRecordFormattedString(hRec, xfqElementPath, &(*ppxfcTail)->pwzElementPath);
-        ExitOnFailure1(hr, "failed to get Element Path for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Element Path for XmlConfig: %ls", (*ppxfcTail)->wzId);
 
         // Get the Verify Path
         hr = WcaGetRecordFormattedString(hRec, xfqVerifyPath, &(*ppxfcTail)->pwzVerifyPath);
-        ExitOnFailure1(hr, "failed to get Verify Path for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Verify Path for XmlConfig: %ls", (*ppxfcTail)->wzId);
 
         // Get the name
         hr = WcaGetRecordFormattedString(hRec, xfqName, &pwzData);
-        ExitOnFailure1(hr, "failed to get Name for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Name for XmlConfig: %ls", (*ppxfcTail)->wzId);
         hr = StringCchCopyW((*ppxfcTail)->wzName, countof((*ppxfcTail)->wzName), pwzData);
         ExitOnFailure(hr, "failed to copy name of element");
 
         // Get the value
         hr = WcaGetRecordFormattedString(hRec, xfqValue, &pwzData);
-        ExitOnFailure1(hr, "failed to get Value for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Value for XmlConfig: %ls", (*ppxfcTail)->wzId);
         hr = StrAllocString(&(*ppxfcTail)->pwzValue, pwzData, 0);
         ExitOnFailure(hr, "failed to allocate buffer for value");
 
         // Get the component attributes
         hr = WcaGetRecordInteger(hRec, xfqCompAttributes, &(*ppxfcTail)->iCompAttributes);
-        ExitOnFailure1(hr, "failed to get component attributes for XmlConfig: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get component attributes for XmlConfig: %ls", (*ppxfcTail)->wzId);
     }
 
     // if we looped through all records all is well
@@ -352,26 +352,26 @@ static HRESULT BeginChangeFile(
     }
 
     hr = WcaWriteStringToCaData(pwzFile, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write file to custom action data: %ls", pwzFile);
+    ExitOnFailure(hr, "failed to write file to custom action data: %ls", pwzFile);
 
     // If the file already exits, then we have to put it back the way it was on failure
     if (FileExistsEx(pwzFile, NULL))
     {
         hr = FileRead(&pbData, &cbData, pwzFile);
-        ExitOnFailure1(hr, "failed to read file: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to read file: %ls", pwzFile);
 
         // Set up the rollback for this file
         hr = WcaWriteIntegerToCaData((int)fIs64Bit, &pwzRollbackCustomActionData);
         ExitOnFailure(hr, "failed to write component bitness to rollback custom action data");
 
         hr = WcaWriteStringToCaData(pwzFile, &pwzRollbackCustomActionData);
-        ExitOnFailure1(hr, "failed to write file name to rollback custom action data: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to write file name to rollback custom action data: %ls", pwzFile);
 
         hr = WcaWriteStreamToCaData(pbData, cbData, &pwzRollbackCustomActionData);
         ExitOnFailure(hr, "failed to write file contents to rollback custom action data.");
 
         hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"ExecXmlConfigRollback"), pwzRollbackCustomActionData, COST_XMLFILE);
-        ExitOnFailure1(hr, "failed to schedule ExecXmlConfigRollback for file: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to schedule ExecXmlConfigRollback for file: %ls", pwzFile);
 
         ReleaseStr(pwzRollbackCustomActionData);
     }
@@ -394,16 +394,16 @@ static HRESULT WriteChangeData(
     XML_CONFIG_CHANGE* pxfcAdditionalChanges = NULL;
 
     hr = WcaWriteStringToCaData(pxfc->pwzElementPath, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write ElementPath to custom action data: %ls", pxfc->pwzElementPath);
+    ExitOnFailure(hr, "failed to write ElementPath to custom action data: %ls", pxfc->pwzElementPath);
 
     hr = WcaWriteStringToCaData(pxfc->pwzVerifyPath, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write VerifyPath to custom action data: %ls", pxfc->pwzVerifyPath);
+    ExitOnFailure(hr, "failed to write VerifyPath to custom action data: %ls", pxfc->pwzVerifyPath);
 
     hr = WcaWriteStringToCaData(pxfc->wzName, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
+    ExitOnFailure(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
 
     hr = WcaWriteStringToCaData(pxfc->pwzValue, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
+    ExitOnFailure(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
 
     if (pxfc->iXmlFlags & XMLCONFIG_CREATE && pxfc->iXmlFlags & XMLCONFIG_ELEMENT && xaCreateElement == action && pxfc->pxfcAdditionalChanges)
     {
@@ -416,10 +416,10 @@ static HRESULT WriteChangeData(
             Assert((0 == lstrcmpW(pxfcAdditionalChanges->wzComponent, pxfc->wzComponent)) && 0 == pxfcAdditionalChanges->iXmlFlags && (0 == lstrcmpW(pxfcAdditionalChanges->wzFile, pxfc->wzFile)));
 
             hr = WcaWriteStringToCaData(pxfcAdditionalChanges->wzName, ppwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
+            ExitOnFailure(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
 
             hr = WcaWriteStringToCaData(pxfcAdditionalChanges->pwzValue, ppwzCustomActionData);
-            ExitOnFailure1(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
+            ExitOnFailure(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
 
             pxfcAdditionalChanges = pxfcAdditionalChanges->pxfcNext;
         }
@@ -539,7 +539,7 @@ extern "C" UINT __stdcall SchedXmlConfig(
             if (fCurrentFileChanged)
             {
                 hr = BeginChangeFile(pwzCurrentFile, pxfc->iCompAttributes, &pwzCustomActionData);
-                ExitOnFailure1(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
+                ExitOnFailure(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
 
                 fCurrentFileChanged = FALSE;
                 ++cFiles;
@@ -748,7 +748,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
             {
                 if (xaCreateElement == xa || xaWriteValue == xa || xaWriteDocument == xa)
                 {
-                    MessageExitOnFailure1(hr = hrOpenFailure, msierrXmlConfigFailedOpen, "failed to load XML file: %ls", pwzFile);
+                    MessageExitOnFailure(hr = hrOpenFailure, msierrXmlConfigFailedOpen, "failed to load XML file: %ls", pwzFile);
                 }
                 else
                 {
@@ -775,7 +775,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
                 }
             }
 
-            MessageExitOnFailure2(hr, msierrXmlConfigFailedSelect, "failed to find node: %ls in XML file: %ls", pwzElementPath, pwzFile);
+            MessageExitOnFailure(hr, msierrXmlConfigFailedSelect, "failed to find node: %ls in XML file: %ls", pwzElementPath, pwzFile);
 
             // Make the modification
             switch (xa)
@@ -785,13 +785,13 @@ extern "C" UINT __stdcall ExecXmlConfig(
                 {
                     // We're setting an attribute
                     hr = XmlSetAttribute(pixn, pwzName, pwzValue);
-                    ExitOnFailure2(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
+                    ExitOnFailure(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
                 }
                 else
                 {
                     // We're setting the text of the node
                     hr = XmlSetText(pixn, pwzValue);
-                    ExitOnFailure2(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzElementPath);
+                    ExitOnFailure(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzElementPath);
                 }
                 break;
             case xaWriteDocument:
@@ -803,7 +803,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
                         // We found the verify path which means we have no further work to do
                         continue;
                     }
-                    ExitOnFailure1(hr, "failed to query verify path: %ls", pwzVerifyPath);
+                    ExitOnFailure(hr, "failed to query verify path: %ls", pwzVerifyPath);
                 }
 
                 hr = XmlLoadDocumentEx(pwzValue, XML_LOAD_PRESERVE_WHITESPACE, &pixdNew);
@@ -828,16 +828,16 @@ extern "C" UINT __stdcall ExecXmlConfig(
                         // We found the verify path which means we have no further work to do
                         continue;
                     }
-                    ExitOnFailure1(hr, "failed to query verify path: %ls", pwzVerifyPath);
+                    ExitOnFailure(hr, "failed to query verify path: %ls", pwzVerifyPath);
                 }
 
                 hr = XmlCreateChild(pixn, pwzName, &pixnNewNode);
-                ExitOnFailure1(hr, "failed to create child element: %ls", pwzName);
+                ExitOnFailure(hr, "failed to create child element: %ls", pwzName);
 
                 if (pwzValue && *pwzValue)
                 {
                     hr = XmlSetText(pixnNewNode, pwzValue);
-                    ExitOnFailure2(hr, "failed to set text to: %ls for node: %ls", pwzValue, pwzName);
+                    ExitOnFailure(hr, "failed to set text to: %ls for node: %ls", pwzValue, pwzName);
                 }
 
                 while (cAdditionalChanges > 0)
@@ -849,7 +849,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
 
                     // Set the additional attribute
                     hr = XmlSetAttribute(pixnNewNode, pwzName, pwzValue);
-                    ExitOnFailure2(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
+                    ExitOnFailure(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
 
                     cAdditionalChanges--;
                 }
@@ -861,7 +861,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
                 {
                     // Delete the attribute
                     hr = XmlRemoveAttribute(pixn, pwzName);
-                    ExitOnFailure1(hr, "failed to remove attribute: %ls", pwzName);
+                    ExitOnFailure(hr, "failed to remove attribute: %ls", pwzName);
                 }
                 else
                 {
@@ -906,7 +906,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
             if (fPreserveDate)
             {
                 hr = FileGetTime(pwzFile, NULL, NULL, &ft);
-                ExitOnFailure1(hr, "failed to get modified time of file : %ls", pwzFile);
+                ExitOnFailure(hr, "failed to get modified time of file : %ls", pwzFile);
             }
 
             int iSaveAttempt = 0;
@@ -920,7 +920,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
                     switch (id)
                     {
                     case IDABORT:
-                        ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                        ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                     case IDRETRY:
                         hr = S_FALSE;   // hit me, baby, one more time
                         break;
@@ -940,12 +940,12 @@ extern "C" UINT __stdcall ExecXmlConfig(
                             }
                             else
                             {
-                                ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                                ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                             }
                         }
                         break;
                     default: // Unknown error
-                        ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                        ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                     }
                 }
             } while (S_FALSE == hr);
@@ -953,7 +953,7 @@ extern "C" UINT __stdcall ExecXmlConfig(
             if (fPreserveDate)
             {
                 hr = FileSetTime(pwzFile, NULL, NULL, &ft);
-                ExitOnFailure1(hr, "failed to set modified time of file : %ls", pwzFile);
+                ExitOnFailure(hr, "failed to set modified time of file : %ls", pwzFile);
             }
 
             if (fIsFSRedirectDisabled)
@@ -1068,16 +1068,16 @@ extern "C" UINT __stdcall ExecXmlConfigRollback(
     }
 
     hr = FileGetTime(pwzFileName, NULL, NULL, &ft);
-    ExitOnFailure1(hr, "Failed to get modified date of file %ls.", pwzFileName);
+    ExitOnFailure(hr, "Failed to get modified date of file %ls.", pwzFileName);
 
     // Open the file
     hFile = ::CreateFileW(pwzFileName, GENERIC_WRITE, NULL, NULL, TRUNCATE_EXISTING, NULL, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "failed to open file: %ls", pwzFileName);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "failed to open file: %ls", pwzFileName);
 
     // Write out the old data
     if (!::WriteFile(hFile, pbData, (DWORD)cbData, &cbDataWritten, NULL))
     {
-        ExitOnLastError1(hr, "failed to write to file: %ls", pwzFileName);
+        ExitOnLastError(hr, "failed to write to file: %ls", pwzFileName);
     }
 
     Assert(cbData == cbDataWritten);
@@ -1085,7 +1085,7 @@ extern "C" UINT __stdcall ExecXmlConfigRollback(
     ReleaseFile(hFile);
 
     hr = FileSetTime(pwzFileName, NULL, NULL, &ft);
-    ExitOnFailure1(hr, "Failed to set modified date of file %ls.", pwzFileName);
+    ExitOnFailure(hr, "Failed to set modified date of file %ls.", pwzFileName);
 
 LExit:
     ReleaseStr(pwzCustomActionData);

--- a/src/ext/ca/wixca/dll/XmlFile.cpp
+++ b/src/ext/ca/wixca/dll/XmlFile.cpp
@@ -161,41 +161,41 @@ static HRESULT ReadXmlFileTable(
 
         // Get component name
         hr = WcaGetRecordString(hRec, xfqComponent, &pwzData);
-        ExitOnFailure1(hr, "failed to get component name for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get component name for XmlFile: %ls", (*ppxfcTail)->wzId);
 
         // Get the component's state
         er = ::MsiGetComponentStateW(WcaGetInstallHandle(), pwzData, &(*ppxfcTail)->isInstalled, &(*ppxfcTail)->isAction);
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(er), "failed to get install state for Component: %ls", pwzData);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(er), "failed to get install state for Component: %ls", pwzData);
 
         // Get the xml file
         hr = WcaGetRecordFormattedString(hRec, xfqFile, &pwzData);
-        ExitOnFailure1(hr, "failed to get xml file for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get xml file for XmlFile: %ls", (*ppxfcTail)->wzId);
         hr = StringCchCopyW((*ppxfcTail)->wzFile, countof((*ppxfcTail)->wzFile), pwzData);
         ExitOnFailure(hr, "failed to copy xml file path");
 
         // Get the XmlFile table flags
         hr = WcaGetRecordInteger(hRec, xfqXmlFlags, &(*ppxfcTail)->iXmlFlags);
-        ExitOnFailure1(hr, "failed to get XmlFile flags for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get XmlFile flags for XmlFile: %ls", (*ppxfcTail)->wzId);
 
         // Get the XPath
         hr = WcaGetRecordFormattedString(hRec, xfqXPath, &(*ppxfcTail)->pwzElementPath);
-        ExitOnFailure1(hr, "failed to get XPath for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get XPath for XmlFile: %ls", (*ppxfcTail)->wzId);
 
         // Get the name
         hr = WcaGetRecordFormattedString(hRec, xfqName, &pwzData);
-        ExitOnFailure1(hr, "failed to get Name for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Name for XmlFile: %ls", (*ppxfcTail)->wzId);
         hr = StringCchCopyW((*ppxfcTail)->wzName, countof((*ppxfcTail)->wzName), pwzData);
         ExitOnFailure(hr, "failed to copy name of element");
 
         // Get the value
         hr = WcaGetRecordFormattedString(hRec, xfqValue, &pwzData);
-        ExitOnFailure1(hr, "failed to get Value for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get Value for XmlFile: %ls", (*ppxfcTail)->wzId);
         hr = StrAllocString(&(*ppxfcTail)->pwzValue, pwzData, 0);
         ExitOnFailure(hr, "failed to allocate buffer for value");
 
         // Get the component attributes
         hr = WcaGetRecordInteger(hRec, xfqCompAttributes, &(*ppxfcTail)->iCompAttributes);
-        ExitOnFailure1(hr, "failed to get component attributes for XmlFile: %ls", (*ppxfcTail)->wzId);
+        ExitOnFailure(hr, "failed to get component attributes for XmlFile: %ls", (*ppxfcTail)->wzId);
     }
 
     // if we looped through all records all is well
@@ -247,26 +247,26 @@ static HRESULT BeginChangeFile(
         ExitOnFailure(hr, "failed to write XSLPattern selectionlanguage indicator to custom action data");
     }
     hr = WcaWriteStringToCaData(pwzFile, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write file to custom action data: %ls", pwzFile);
+    ExitOnFailure(hr, "failed to write file to custom action data: %ls", pwzFile);
 
     // If the file already exits, then we have to put it back the way it was on failure
     if (FileExistsEx(pwzFile, NULL))
     {
         hr = FileRead(&pbData, &cbData, pwzFile);
-        ExitOnFailure1(hr, "failed to read file: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to read file: %ls", pwzFile);
 
         // Set up the rollback for this file
         hr = WcaWriteIntegerToCaData((int)fIs64Bit, &pwzRollbackCustomActionData);
         ExitOnFailure(hr, "failed to write component bitness to rollback custom action data");
 
         hr = WcaWriteStringToCaData(pwzFile, &pwzRollbackCustomActionData);
-        ExitOnFailure1(hr, "failed to write file name to rollback custom action data: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to write file name to rollback custom action data: %ls", pwzFile);
 
         hr = WcaWriteStreamToCaData(pbData, cbData, &pwzRollbackCustomActionData);
         ExitOnFailure(hr, "failed to write file contents to rollback custom action data.");
 
         hr = WcaDoDeferredAction(PLATFORM_DECORATION(L"ExecXmlFileRollback"), pwzRollbackCustomActionData, COST_XMLFILE);
-        ExitOnFailure1(hr, "failed to schedule ExecXmlFileRollback for file: %ls", pwzFile);
+        ExitOnFailure(hr, "failed to schedule ExecXmlFileRollback for file: %ls", pwzFile);
 
         ReleaseStr(pwzRollbackCustomActionData);
     }
@@ -287,13 +287,13 @@ static HRESULT WriteChangeData(
     HRESULT hr = S_OK;
 
     hr = WcaWriteStringToCaData(pxfc->pwzElementPath, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write ElementPath to custom action data: %ls", pxfc->pwzElementPath);
+    ExitOnFailure(hr, "failed to write ElementPath to custom action data: %ls", pxfc->pwzElementPath);
 
     hr = WcaWriteStringToCaData(pxfc->wzName, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
+    ExitOnFailure(hr, "failed to write Name to custom action data: %ls", pxfc->wzName);
 
     hr = WcaWriteStringToCaData(pxfc->pwzValue, ppwzCustomActionData);
-    ExitOnFailure1(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
+    ExitOnFailure(hr, "failed to write Value to custom action data: %ls", pxfc->pwzValue);
 
 LExit:
     return hr;
@@ -363,7 +363,7 @@ extern "C" UINT __stdcall SchedXmlFile(
                             if (!fCurrentFileChanged)
                             {
                                 hr = BeginChangeFile(pwzCurrentFile, pxfcUninstall, &pwzCustomActionData);
-                                ExitOnFailure1(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
+                                ExitOnFailure(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
 
                                 fCurrentFileChanged = TRUE;
                                 ++cFiles;
@@ -412,7 +412,7 @@ extern "C" UINT __stdcall SchedXmlFile(
             if (!fCurrentFileChanged)
             {
                 hr = BeginChangeFile(pwzCurrentFile, pxfc, &pwzCustomActionData);
-                ExitOnFailure1(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
+                ExitOnFailure(hr, "failed to begin file change for file: %ls", pwzCurrentFile);
                 fCurrentFileChanged = TRUE;
                 ++cFiles;
             }
@@ -643,7 +643,7 @@ extern "C" UINT __stdcall ExecXmlFile(
             {
                 if (xaCreateElement == xa || xaWriteValue == xa || xaBulkWriteValue == xa)
                 {
-                    MessageExitOnFailure1(hr = hrOpenFailure, msierrXmlFileFailedOpen, "failed to load XML file: %ls", pwzFile);
+                    MessageExitOnFailure(hr = hrOpenFailure, msierrXmlFileFailedOpen, "failed to load XML file: %ls", pwzFile);
                 }
                 else
                 {
@@ -662,7 +662,7 @@ extern "C" UINT __stdcall ExecXmlFile(
                     hr = HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND);
                 }
 
-                MessageExitOnFailure2(hr, msierrXmlFileFailedSelect, "failed to find any nodes: %ls in XML file: %ls", pwzXPath, pwzFile);
+                MessageExitOnFailure(hr, msierrXmlFileFailedSelect, "failed to find any nodes: %ls in XML file: %ls", pwzXPath, pwzFile);
                 for (;;)
                 {
                     pixNodes->nextNode(&pixn);
@@ -673,13 +673,13 @@ extern "C" UINT __stdcall ExecXmlFile(
                     {
                         // We're setting an attribute
                         hr = XmlSetAttribute(pixn, pwzName, pwzValue);
-                        ExitOnFailure2(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
+                        ExitOnFailure(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
                     }
                     else
                     {
                         // We're setting the text of the node
                         hr = XmlSetText(pixn, pwzValue);
-                        ExitOnFailure2(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzXPath);
+                        ExitOnFailure(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzXPath);
                     }
                     ReleaseNullObject(pixn);
                 }
@@ -689,7 +689,7 @@ extern "C" UINT __stdcall ExecXmlFile(
                 hr = XmlSelectSingleNode(pixd, pwzXPath, &pixn);
                 if (S_FALSE == hr)
                     hr = HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND);
-                MessageExitOnFailure2(hr, msierrXmlFileFailedSelect, "failed to find node: %ls in XML file: %ls", pwzXPath, pwzFile);
+                MessageExitOnFailure(hr, msierrXmlFileFailedSelect, "failed to find node: %ls in XML file: %ls", pwzXPath, pwzFile);
 
                 // Make the modification
                 if (xaWriteValue == xa)
@@ -698,24 +698,24 @@ extern "C" UINT __stdcall ExecXmlFile(
                     {
                         // We're setting an attribute
                         hr = XmlSetAttribute(pixn, pwzName, pwzValue);
-                        ExitOnFailure2(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
+                        ExitOnFailure(hr, "failed to set attribute: %ls to value %ls", pwzName, pwzValue);
                     }
                     else
                     {
                         // We're setting the text of the node
                         hr = XmlSetText(pixn, pwzValue);
-                        ExitOnFailure2(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzXPath);
+                        ExitOnFailure(hr, "failed to set text to: %ls for element %ls.  Make sure that XPath points to an element.", pwzValue, pwzXPath);
                     }
                 }
                 else if (xaCreateElement == xa)
                 {
                     hr = XmlCreateChild(pixn, pwzName, &pixnNewNode);
-                    ExitOnFailure1(hr, "failed to create child element: %ls", pwzName);
+                    ExitOnFailure(hr, "failed to create child element: %ls", pwzName);
 
                     if (pwzValue && *pwzValue)
                     {
                         hr = XmlSetText(pixnNewNode, pwzValue);
-                        ExitOnFailure2(hr, "failed to set text to: %ls for node: %ls", pwzValue, pwzName);
+                        ExitOnFailure(hr, "failed to set text to: %ls for node: %ls", pwzValue, pwzName);
                     }
 
                     ReleaseNullObject(pixnNewNode);
@@ -726,7 +726,7 @@ extern "C" UINT __stdcall ExecXmlFile(
                     {
                         // Delete the attribute
                         hr = XmlRemoveAttribute(pixn, pwzName);
-                        ExitOnFailure1(hr, "failed to remove attribute: %ls", pwzName);
+                        ExitOnFailure(hr, "failed to remove attribute: %ls", pwzName);
                     }
                     else
                     {
@@ -739,7 +739,7 @@ extern "C" UINT __stdcall ExecXmlFile(
                 {
                     // TODO: This may be a little heavy handed
                     hr = XmlRemoveChildren(pixn, pwzName);
-                    ExitOnFailure1(hr, "failed to delete child node: %ls", pwzName);
+                    ExitOnFailure(hr, "failed to delete child node: %ls", pwzName);
                 }
                 else
                 {
@@ -754,7 +754,7 @@ extern "C" UINT __stdcall ExecXmlFile(
             if (fPreserveDate)
             {
                 hr = FileGetTime(pwzFile, NULL, NULL, &ft);
-                ExitOnFailure1(hr, "failed to get modified time of file : %ls", pwzFile);
+                ExitOnFailure(hr, "failed to get modified time of file : %ls", pwzFile);
             }
 
             int iSaveAttempt = 0;
@@ -768,7 +768,7 @@ extern "C" UINT __stdcall ExecXmlFile(
                     switch (id)
                     {
                     case IDABORT:
-                        ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                        ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                     case IDRETRY:
                         hr = S_FALSE;   // hit me, baby, one more time
                         break;
@@ -788,12 +788,12 @@ extern "C" UINT __stdcall ExecXmlFile(
                             }
                             else
                             {
-                                ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                                ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                             }
                         }
                         break;
                     default: // Unknown error
-                        ExitOnFailure1(hr, "Failed to save changes to XML file: %ls", pwzFile);
+                        ExitOnFailure(hr, "Failed to save changes to XML file: %ls", pwzFile);
                     }
                 }
             } while (S_FALSE == hr);
@@ -801,7 +801,7 @@ extern "C" UINT __stdcall ExecXmlFile(
             if (fPreserveDate)
             {
                 hr = FileSetTime(pwzFile, NULL, NULL, &ft);
-                ExitOnFailure1(hr, "failed to set modified time of file : %ls", pwzFile);
+                ExitOnFailure(hr, "failed to set modified time of file : %ls", pwzFile);
             }
 
             if (fIsFSRedirectDisabled)
@@ -914,15 +914,15 @@ extern "C" UINT __stdcall ExecXmlFileRollback(
 
     // Always preserve the modified date on rollback
     hr = FileGetTime(pwzFileName, NULL, NULL, &ft);
-    ExitOnFailure1(hr, "Failed to get modified date of file %ls.", pwzFileName);
+    ExitOnFailure(hr, "Failed to get modified date of file %ls.", pwzFileName);
 
     // Open the file
     hFile = ::CreateFileW(pwzFileName, GENERIC_WRITE, NULL, NULL, TRUNCATE_EXISTING, NULL, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "failed to open file: %ls", pwzFileName);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "failed to open file: %ls", pwzFileName);
 
     // Write out the old data
     if (!::WriteFile(hFile, pbData, (DWORD)cbData, &cbDataWritten, NULL))
-        ExitOnLastError1(hr, "failed to write to file: %ls", pwzFileName);
+        ExitOnLastError(hr, "failed to write to file: %ls", pwzFileName);
 
     Assert(cbData == cbDataWritten);
 
@@ -930,7 +930,7 @@ extern "C" UINT __stdcall ExecXmlFileRollback(
 
     // Always preserve the modified date on rollback
     hr = FileSetTime(pwzFileName, NULL, NULL, &ft);
-    ExitOnFailure1(hr, "Failed to set modified date of file %ls.", pwzFileName);
+    ExitOnFailure(hr, "Failed to set modified date of file %ls.", pwzFileName);
 
 LExit:
     ReleaseStr(pwzCustomActionData);

--- a/src/ext/ca/wixca/dll/netshortcuts.cpp
+++ b/src/ext/ca/wixca/dll/netshortcuts.cpp
@@ -212,14 +212,14 @@ static HRESULT CreateUrl(
 
     // set shortcut target
     hr = piURL->SetURL(wzTarget, 0);
-    ExitOnFailure2(hr, "failed to set shortcut '%ls' target '%ls'", wzShortcutPath, wzTarget);
+    ExitOnFailure(hr, "failed to set shortcut '%ls' target '%ls'", wzShortcutPath, wzTarget);
 
     // get an IPersistFile and save the shortcut
     hr = piURL->QueryInterface(IID_IPersistFile, (void**)&piPersistFile);
-    ExitOnFailure1(hr, "failed to get IPersistFile for shortcut '%ls'", wzShortcutPath);
+    ExitOnFailure(hr, "failed to get IPersistFile for shortcut '%ls'", wzShortcutPath);
 
     hr = piPersistFile->Save(wzShortcutPath, TRUE);
-    ExitOnFailure1(hr, "failed to save shortcut '%ls'", wzShortcutPath);
+    ExitOnFailure(hr, "failed to save shortcut '%ls'", wzShortcutPath);
 
 LExit:
     ReleaseObject(piPersistFile);
@@ -249,14 +249,14 @@ static HRESULT CreateLink(
 
     // set shortcut target
     hr = piShellLink->SetPath(wzTarget);
-    ExitOnFailure2(hr, "failed to set shortcut '%ls' target '%ls'", wzShortcutPath, wzTarget);
+    ExitOnFailure(hr, "failed to set shortcut '%ls' target '%ls'", wzShortcutPath, wzTarget);
 
     // get an IPersistFile and save the shortcut
     hr = piShellLink->QueryInterface(IID_IPersistFile, (void**)&piPersistFile);
-    ExitOnFailure1(hr, "failed to get IPersistFile for shortcut '%ls'", wzShortcutPath);
+    ExitOnFailure(hr, "failed to get IPersistFile for shortcut '%ls'", wzShortcutPath);
 
     hr = piPersistFile->Save(wzShortcutPath, TRUE);
-    ExitOnFailure1(hr, "failed to save shortcut '%ls'", wzShortcutPath);
+    ExitOnFailure(hr, "failed to save shortcut '%ls'", wzShortcutPath);
 
 LExit:
     ReleaseObject(piPersistFile);
@@ -320,7 +320,7 @@ extern "C" UINT __stdcall WixCreateInternetShortcuts(
 
         // tick the progress bar
         hr = WcaProgressMessage(COST_INTERNETSHORTCUT, FALSE);
-        ExitOnFailure1(hr, "failed to tick progress bar for shortcut: %ls", pwzShortcutPath);
+        ExitOnFailure(hr, "failed to tick progress bar for shortcut: %ls", pwzShortcutPath);
     }
 
 LExit:
@@ -372,7 +372,7 @@ extern "C" UINT __stdcall WixRollbackInternetShortcuts(
 
         // delete file
         hr = FileEnsureDelete(pwzShortcutPath);
-        ExitOnFailure1(hr, "failed to delete file '%ls'", pwzShortcutPath);
+        ExitOnFailure(hr, "failed to delete file '%ls'", pwzShortcutPath);
 
         // skip over the shortcut target and attributes
         hr = WcaReadStringFromCaData(&pwz, &pwzShortcutPath);

--- a/src/ext/ca/wixca/dll/qtexecca.cpp
+++ b/src/ext/ca/wixca/dll/qtexecca.cpp
@@ -40,9 +40,9 @@ HRESULT BuildCommandLine(
     else if (WcaIsPropertySet(szProperty))
     {
         hr = WcaGetFormattedProperty(wzProperty, ppwzCommand);
-        ExitOnFailure1(hr, "failed to get %ls", wzProperty);
+        ExitOnFailure(hr, "failed to get %ls", wzProperty);
         hr = WcaSetProperty(wzProperty, L""); // clear out the property now that we've read it
-        ExitOnFailure1(hr, "failed to set %ls", wzProperty);
+        ExitOnFailure(hr, "failed to set %ls", wzProperty);
     }
 
     if (!*ppwzCommand)

--- a/src/ext/ca/wixca/dll/serviceconfig.cpp
+++ b/src/ext/ca/wixca/dll/serviceconfig.cpp
@@ -106,7 +106,7 @@ extern "C" UINT __stdcall SchedServiceConfig(
         ExitOnFailure(hr, "Failed to get component name");
 
         hr = ::MsiGetComponentStateW(hInstall, pwzData, &isInstalled, &isAction);
-        ExitOnFailure1(hr = HRESULT_FROM_WIN32(hr), "Failed to get install state for Component: %ls", pwzData);
+        ExitOnFailure(hr = HRESULT_FROM_WIN32(hr), "Failed to get install state for Component: %ls", pwzData);
 
         if (WcaIsInstalling(isInstalled, isAction))
         {
@@ -252,7 +252,7 @@ extern "C" UINT __stdcall ExecServiceConfig(
         ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, er, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&lpMsgBuf, 0, NULL);
 #pragma prefast(pop)
 
-        ExitOnFailure1(hr, "Failed to get handle to SCM. Error: %ls", (LPWSTR)lpMsgBuf);
+        ExitOnFailure(hr, "Failed to get handle to SCM. Error: %ls", (LPWSTR)lpMsgBuf);
     }
 
     // First, get the script key out of the CustomActionData and
@@ -305,7 +305,7 @@ extern "C" UINT __stdcall ExecServiceConfig(
         //  SERVICE_CHANGE_CONFIG is needed for ChangeServiceConfig2().
         //  SERVICE_START is required in order to handle SC_ACTION_RESTART action.
         hr = GetService(hSCM, pwzServiceName, SERVICE_QUERY_CONFIG | SERVICE_CHANGE_CONFIG | SERVICE_START, &hService);
-        ExitOnFailure1(hr, "Failed to get service: %ls", pwzServiceName);
+        ExitOnFailure(hr, "Failed to get service: %ls", pwzServiceName);
 
         // If we are configuring a service that existed on the machine, we need to
         // read the existing service configuration and write it out to the rollback
@@ -390,7 +390,7 @@ extern "C" UINT __stdcall ExecServiceConfig(
 
         hr = ConfigureService(hSCM, hService, pwzServiceName, dwRestartServiceDelayInSeconds, pwzFirstFailureActionType,
                               pwzSecondFailureActionType, pwzThirdFailureActionType, dwResetPeriodInDays, pwzRebootMessage, pwzProgramCommandLine);
-        ExitOnFailure1(hr, "Failed to configure service: %ls", pwzServiceName);
+        ExitOnFailure(hr, "Failed to configure service: %ls", pwzServiceName);
 
         hr = WcaProgressMessage(COST_SERVICECONFIG, FALSE);
         ExitOnFailure(hr, "failed to send progress message");
@@ -485,7 +485,7 @@ extern "C" UINT __stdcall RollbackServiceConfig(
         ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, er, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&lpMsgBuf, 0, NULL);
 #pragma prefast(pop)
 
-        ExitOnFailure1(hr, "Failed to get handle to SCM. Error: %ls", (LPWSTR)lpMsgBuf);
+        ExitOnFailure(hr, "Failed to get handle to SCM. Error: %ls", (LPWSTR)lpMsgBuf);
 
         // Make sure we still abort, in case hSCM was NULL but no error was returned from GetLastError
         ExitOnNull(hSCM, hr, E_POINTER, "Getting handle to SCM reported success, but no handle was returned.");
@@ -544,11 +544,11 @@ extern "C" UINT __stdcall RollbackServiceConfig(
         //  SERVICE_CHANGE_CONFIG is needed for ChangeServiceConfig2().
         //  SERVICE_START is required in order to handle SC_ACTION_RESTART action.
         hr = GetService(hSCM, pwzServiceName, SERVICE_CHANGE_CONFIG | SERVICE_START, &hService);
-        ExitOnFailure1(hr, "Failed to get service: %ls", pwzServiceName);
+        ExitOnFailure(hr, "Failed to get service: %ls", pwzServiceName);
 
         hr = ConfigureService(hSCM, hService, pwzServiceName, dwRestartServiceDelayInSeconds, pwzFirstFailureActionType,
                               pwzSecondFailureActionType, pwzThirdFailureActionType, dwResetPeriodInDays, pwzRebootMessage, pwzProgramCommandLine);
-        ExitOnFailure1(hr, "Failed to configure service: %ls", pwzServiceName);
+        ExitOnFailure(hr, "Failed to configure service: %ls", pwzServiceName);
 
         hr = WcaProgressMessage(COST_SERVICECONFIG, FALSE);
         ExitOnFailure(hr, "failed to send progress message");
@@ -679,7 +679,7 @@ static HRESULT GetService(
         hr = HRESULT_FROM_WIN32(er);
         if (ERROR_SERVICE_DOES_NOT_EXIST == er)
         {
-            ExitOnFailure1(hr, "Service '%ls' does not exist on this system.", wzService);
+            ExitOnFailure(hr, "Service '%ls' does not exist on this system.", wzService);
         }
         else
         {
@@ -688,7 +688,7 @@ static HRESULT GetService(
             ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, er, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&lpMsgBuf, 0, NULL);
 #pragma prefast(pop)
 
-            ExitOnFailure2(hr, "Failed to get handle to the service '%ls'. Error: %ls", wzService, (LPWSTR)lpMsgBuf);
+            ExitOnFailure(hr, "Failed to get handle to the service '%ls'. Error: %ls", wzService, (LPWSTR)lpMsgBuf);
         }
     }
 
@@ -805,7 +805,7 @@ static HRESULT ConfigureService(
         {
             WcaLog(LOGMSG_STANDARD, "WARNING: Service \"%ls\" is not configurable on this server and will not be set.", wzServiceName);
         }
-        ExitOnFailure1(hr, "Cannot change service configuration. Error: %ls", (LPWSTR)lpMsgBuf);
+        ExitOnFailure(hr, "Cannot change service configuration. Error: %ls", (LPWSTR)lpMsgBuf);
 
         if (lpMsgBuf)
         {

--- a/src/ext/ca/wixca/dll/shellexecca.cpp
+++ b/src/ext/ca/wixca/dll/shellexecca.cpp
@@ -23,7 +23,7 @@ HRESULT ShellExec(
 
     // a reasonable working directory (not the system32 default from MSI) is the directory where the target lives
     hr = PathGetDirectory(wzTarget, &sczWorkingDirectory);
-    ExitOnFailure1(hr, "failed to get directory for target: %ls", wzTarget);
+    ExitOnFailure(hr, "failed to get directory for target: %ls", wzTarget);
     
     if (!DirExists(sczWorkingDirectory, NULL))
     {
@@ -33,7 +33,7 @@ HRESULT ShellExec(
     if (fUnelevated)
     {
         hr = ShelExecUnelevated(wzTarget, NULL, NULL, sczWorkingDirectory, SW_SHOWDEFAULT);
-        ExitOnFailure1(hr, "ShelExecUnelevated failed with target %ls", wzTarget);
+        ExitOnFailure(hr, "ShelExecUnelevated failed with target %ls", wzTarget);
     }
     else
     {
@@ -73,7 +73,7 @@ HRESULT ShellExec(
                 hr = E_FAIL;
             }
 
-            ExitOnFailure1(hr, "ShellExec failed with return code %d", int(hinst));
+            ExitOnFailure(hr, "ShellExec failed with return code %d", int(hinst));
         }
     }
 
@@ -247,13 +247,13 @@ extern "C" UINT __stdcall WixShellExecBinary(
     hFile = ::CreateFileW(pwzFilename, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to open new temp file: %ls", pwzFilename);
+        ExitWithLastError(hr, "Failed to open new temp file: %ls", pwzFilename);
     }
 
     DWORD cbWritten = 0;
     if (!::WriteFile(hFile, pbData, cbData, &cbWritten, NULL))
     {
-        ExitWithLastError1(hr, "Failed to write data to new temp file: %ls", pwzFilename);
+        ExitWithLastError(hr, "Failed to write data to new temp file: %ls", pwzFilename);
     }
 
     // close it
@@ -262,7 +262,7 @@ extern "C" UINT __stdcall WixShellExecBinary(
 
     // and run it
     hr = ShellExec(pwzFilename, FALSE);
-    ExitOnFailure1(hr, "failed to launch target: %ls", pwzFilename);
+    ExitOnFailure(hr, "failed to launch target: %ls", pwzFilename);
 
 LExit:
     ReleaseStr(pwzBinary);

--- a/src/libs/balutil/balinfo.cpp
+++ b/src/libs/balutil/balinfo.cpp
@@ -88,7 +88,7 @@ DAPI_(HRESULT) BalInfoAddRelatedBundleAsPackage(
         break;
 
     default:
-        ExitOnFailure1(hr = E_INVALIDARG, "Unknown related bundle type: %u", relationType);
+        ExitOnFailure(hr = E_INVALIDARG, "Unknown related bundle type: %u", relationType);
     }
 
     // Check to see if the bundle is already in the list of packages.

--- a/src/libs/balutil/balutil.cpp
+++ b/src/libs/balutil/balutil.cpp
@@ -45,10 +45,10 @@ DAPI_(HRESULT) BalManifestLoad(
     LPWSTR sczPath = NULL;
 
     hr = PathRelativeToModule(&sczPath, BAL_MANIFEST_FILENAME, hBootstrapperApplicationModule);
-    ExitOnFailure1(hr, "Failed to get path to bootstrapper application manifest: %ls", BAL_MANIFEST_FILENAME);
+    ExitOnFailure(hr, "Failed to get path to bootstrapper application manifest: %ls", BAL_MANIFEST_FILENAME);
 
     hr = XmlLoadDocumentFromFile(sczPath, ppixdManifest);
-    ExitOnFailure2(hr, "Failed to load bootstrapper application manifest '%ls' from path: %ls", BAL_MANIFEST_FILENAME, sczPath);
+    ExitOnFailure(hr, "Failed to load bootstrapper application manifest '%ls' from path: %ls", BAL_MANIFEST_FILENAME, sczPath);
 
 LExit:
     ReleaseStr(sczPath);

--- a/src/libs/balutil/inc/balutil.h
+++ b/src/libs/balutil/inc/balutil.h
@@ -19,18 +19,18 @@
 extern "C" {
 #endif
 
-#define BalExitOnFailure(x, f) if (FAILED(x)) { BalLogError(x, f); ExitTrace(x, f); goto LExit; }
-#define BalExitOnFailure1(x, f, s) if (FAILED(x)) { BalLogError(x, f, s); ExitTrace1(x, f, s); goto LExit; }
-#define BalExitOnFailure2(x, f, s, t) if (FAILED(x)) { BalLogError(x, f, s, t); ExitTrace2(x, f, s, t); goto LExit; }
-#define BalExitOnFailure3(x, f, s, t, u) if (FAILED(x)) { BalLogError(x, f, s, t, u); ExitTrace3(x, f, s, t, u); goto LExit; }
+#define BalExitOnFailure(x, f, ...) if (FAILED(x)) { BalLogError(x, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define BalExitOnFailure1 BalExitOnFailure
+#define BalExitOnFailure2 BalExitOnFailure
+#define BalExitOnFailure3 BalExitOnFailure
 
-#define BalExitOnRootFailure(x, f) if (FAILED(x)) { BalLogError(x, f); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f); goto LExit; }
-#define BalExitOnRootFailure1(x, f, s) if (FAILED(x)) { BalLogError(x, f, s); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
-#define BalExitOnRootFailure2(x, f, s, t) if (FAILED(x)) { BalLogError(x, f, s, t); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; }
-#define BalExitOnRootFailure3(x, f, s, t, u) if (FAILED(x)) { BalLogError(x, f, s, t, u); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace3(x, f, s, t, u); goto LExit; }
+#define BalExitOnRootFailure(x, f, ...) if (FAILED(x)) { BalLogError(x, f, __VA_ARGS__); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define BalExitOnRootFailure1 BalExitOnRootFailure
+#define BalExitOnRootFailure2 BalExitOnRootFailure
+#define BalExitOnRootFailure3 BalExitOnRootFailure
 
-#define BalExitOnNullWithLastError(p, x, f) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f); ExitTrace(x, f); goto LExit; }
-#define BalExitOnNullWithLastError1(p, x, f, s) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, s); ExitTrace1(x, f, s); goto LExit; }
+#define BalExitOnNullWithLastError(p, x, f, ...) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define BalExitOnNullWithLastError1 BalExitOnNullWithLastError
 
 #define FACILITY_WIX 500
 

--- a/src/libs/balutil/inc/balutil.h
+++ b/src/libs/balutil/inc/balutil.h
@@ -20,17 +20,8 @@ extern "C" {
 #endif
 
 #define BalExitOnFailure(x, f, ...) if (FAILED(x)) { BalLogError(x, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
-#define BalExitOnFailure1 BalExitOnFailure
-#define BalExitOnFailure2 BalExitOnFailure
-#define BalExitOnFailure3 BalExitOnFailure
-
 #define BalExitOnRootFailure(x, f, ...) if (FAILED(x)) { BalLogError(x, f, __VA_ARGS__); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
-#define BalExitOnRootFailure1 BalExitOnRootFailure
-#define BalExitOnRootFailure2 BalExitOnRootFailure
-#define BalExitOnRootFailure3 BalExitOnRootFailure
-
 #define BalExitOnNullWithLastError(p, x, f, ...) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
-#define BalExitOnNullWithLastError1 BalExitOnNullWithLastError
 
 #define FACILITY_WIX 500
 

--- a/src/libs/deputil/deputil.cpp
+++ b/src/libs/deputil/deputil.cpp
@@ -53,7 +53,7 @@ DAPI_(HRESULT) DepGetProviderInformation(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Try to open the dependency key.
     hr = RegOpen(hkHive, sczKey, KEY_READ, &hkKey);
@@ -61,7 +61,7 @@ DAPI_(HRESULT) DepGetProviderInformation(
     {
         ExitFunction1(hr = E_NOTFOUND);
     }
-    ExitOnFailure1(hr, "Failed to open the registry key for the dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to open the registry key for the dependency \"%ls\".", wzProviderKey);
 
     // Get the Id if requested and available.
     if (psczId)
@@ -71,7 +71,7 @@ DAPI_(HRESULT) DepGetProviderInformation(
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to get the id for the dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to get the id for the dependency \"%ls\".", wzProviderKey);
     }
 
     // Get the DisplayName if requested and available.
@@ -82,7 +82,7 @@ DAPI_(HRESULT) DepGetProviderInformation(
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to get the name for the dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to get the name for the dependency \"%ls\".", wzProviderKey);
     }
 
     // Get the Version if requested and available.
@@ -93,7 +93,7 @@ DAPI_(HRESULT) DepGetProviderInformation(
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to get the version for the dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to get the version for the dependency \"%ls\".", wzProviderKey);
     }
 
 LExit:
@@ -127,19 +127,19 @@ DAPI_(HRESULT) DepCheckDependency(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Try to open the key. If that fails, add the missing dependency key to the dependency array if it doesn't already exist.
     hr = RegOpen(hkHive, sczKey, KEY_READ, &hkKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the registry key for dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to open the registry key for dependency \"%ls\".", wzProviderKey);
 
         // If there are no registry values, consider the key orphaned and treat it as missing.
         hr = RegReadVersion(hkKey, vcszVersionValue, &dw64Version);
         if (E_FILENOTFOUND != hr)
         {
-            ExitOnFailure2(hr, "Failed to read the %ls registry value for dependency \"%ls\".", vcszVersionValue, wzProviderKey);
+            ExitOnFailure(hr, "Failed to read the %ls registry value for dependency \"%ls\".", vcszVersionValue, wzProviderKey);
         }
     }
 
@@ -149,15 +149,15 @@ DAPI_(HRESULT) DepCheckDependency(
         hr = DictKeyExists(sdDependencies, wzProviderKey);
         if (E_NOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Failed to check the dictionary for missing dependency \"%ls\".", wzProviderKey);
+            ExitOnFailure(hr, "Failed to check the dictionary for missing dependency \"%ls\".", wzProviderKey);
         }
         else
         {
             hr = DepDependencyArrayAlloc(prgDependencies, pcDependencies, wzProviderKey, NULL);
-            ExitOnFailure1(hr, "Failed to add the missing dependency \"%ls\" to the array.", wzProviderKey);
+            ExitOnFailure(hr, "Failed to add the missing dependency \"%ls\" to the array.", wzProviderKey);
 
             hr = DictAddKey(sdDependencies, wzProviderKey);
-            ExitOnFailure1(hr, "Failed to add the missing dependency \"%ls\" to the dictionary.", wzProviderKey);
+            ExitOnFailure(hr, "Failed to add the missing dependency \"%ls\" to the dictionary.", wzProviderKey);
         }
 
         // Exit since the check already failed.
@@ -171,7 +171,7 @@ DAPI_(HRESULT) DepCheckDependency(
         if (0 < cchMinVersion)
         {
             hr = FileVersionFromStringEx(wzMinVersion, cchMinVersion, &dw64MinVersion);
-            ExitOnFailure1(hr, "Failed to get the 64-bit version number from \"%ls\".", wzMinVersion);
+            ExitOnFailure(hr, "Failed to get the 64-bit version number from \"%ls\".", wzMinVersion);
 
             fAllowEqual = iAttributes & RequiresAttributesMinVersionInclusive;
             if (!(fAllowEqual && dw64MinVersion <= dw64Version || dw64MinVersion < dw64Version))
@@ -179,18 +179,18 @@ DAPI_(HRESULT) DepCheckDependency(
                 hr = DictKeyExists(sdDependencies, wzProviderKey);
                 if (E_NOTFOUND != hr)
                 {
-                    ExitOnFailure1(hr, "Failed to check the dictionary for the older dependency \"%ls\".", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to check the dictionary for the older dependency \"%ls\".", wzProviderKey);
                 }
                 else
                 {
                     hr = RegReadString(hkKey, vcszDisplayNameValue, &sczName);
-                    ExitOnFailure1(hr, "Failed to get the display name of the older dependency \"%ls\".", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to get the display name of the older dependency \"%ls\".", wzProviderKey);
 
                     hr = DepDependencyArrayAlloc(prgDependencies, pcDependencies, wzProviderKey, sczName);
-                    ExitOnFailure1(hr, "Failed to add the older dependency \"%ls\" to the dependencies array.", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to add the older dependency \"%ls\" to the dependencies array.", wzProviderKey);
 
                     hr = DictAddKey(sdDependencies, wzProviderKey);
-                    ExitOnFailure1(hr, "Failed to add the older dependency \"%ls\" to the unique dependency string list.", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to add the older dependency \"%ls\" to the unique dependency string list.", wzProviderKey);
                 }
 
                 // Exit since the check already failed.
@@ -206,7 +206,7 @@ DAPI_(HRESULT) DepCheckDependency(
         if (0 < cchMaxVersion)
         {
             hr = FileVersionFromStringEx(wzMaxVersion, cchMaxVersion, &dw64MaxVersion);
-            ExitOnFailure1(hr, "Failed to get the 64-bit version number from \"%ls\".", wzMaxVersion);
+            ExitOnFailure(hr, "Failed to get the 64-bit version number from \"%ls\".", wzMaxVersion);
 
             fAllowEqual = iAttributes & RequiresAttributesMaxVersionInclusive;
             if (!(fAllowEqual && dw64Version <= dw64MaxVersion || dw64Version < dw64MaxVersion))
@@ -214,18 +214,18 @@ DAPI_(HRESULT) DepCheckDependency(
                 hr = DictKeyExists(sdDependencies, wzProviderKey);
                 if (E_NOTFOUND != hr)
                 {
-                    ExitOnFailure1(hr, "Failed to check the dictionary for the newer dependency \"%ls\".", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to check the dictionary for the newer dependency \"%ls\".", wzProviderKey);
                 }
                 else
                 {
                     hr = RegReadString(hkKey, vcszDisplayNameValue, &sczName);
-                    ExitOnFailure1(hr, "Failed to get the display name of the newer dependency \"%ls\".", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to get the display name of the newer dependency \"%ls\".", wzProviderKey);
 
                     hr = DepDependencyArrayAlloc(prgDependencies, pcDependencies, wzProviderKey, sczName);
-                    ExitOnFailure1(hr, "Failed to add the newer dependency \"%ls\" to the dependencies array.", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to add the newer dependency \"%ls\" to the dependencies array.", wzProviderKey);
 
                     hr = DictAddKey(sdDependencies, wzProviderKey);
-                    ExitOnFailure1(hr, "Failed to add the newer dependency \"%ls\" to the unique dependency string list.", wzProviderKey);
+                    ExitOnFailure(hr, "Failed to add the newer dependency \"%ls\" to the unique dependency string list.", wzProviderKey);
                 }
 
                 // Exit since the check already failed.
@@ -260,17 +260,17 @@ DAPI_(HRESULT) DepCheckDependents(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Try to open the key. If that fails, the dependency information is corrupt.
     hr = RegOpen(hkHive, sczKey, KEY_READ, &hkProviderKey);
-    ExitOnFailure1(hr, "Failed to open the registry key \"%ls\". The dependency store is corrupt.", sczKey);
+    ExitOnFailure(hr, "Failed to open the registry key \"%ls\". The dependency store is corrupt.", sczKey);
 
     // Try to open the dependencies key. If that does not exist, there are no dependents.
     hr = RegOpen(hkProviderKey, vsczRegistryDependents, KEY_READ, &hkDependentsKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the registry key for dependents of \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to open the registry key for dependents of \"%ls\".", wzProviderKey);
     }
     else
     {
@@ -283,7 +283,7 @@ DAPI_(HRESULT) DepCheckDependents(
         hr = RegKeyEnum(hkDependentsKey, dwIndex, &sczDependentKey);
         if (E_NOMOREITEMS != hr)
         {
-            ExitOnFailure1(hr, "Failed to enumerate the dependents key of \"%ls\".", wzProviderKey);
+            ExitOnFailure(hr, "Failed to enumerate the dependents key of \"%ls\".", wzProviderKey);
         }
         else
         {
@@ -301,10 +301,10 @@ DAPI_(HRESULT) DepCheckDependents(
         {
             // Get the name of the dependent from the key.
             hr = GetDependencyNameFromKey(hkHive, sczDependentKey, &sczDependentName);
-            ExitOnFailure1(hr, "Failed to get the name of the dependent from the key \"%ls\".", sczDependentKey);
+            ExitOnFailure(hr, "Failed to get the name of the dependent from the key \"%ls\".", sczDependentKey);
 
             hr = DepDependencyArrayAlloc(prgDependents, pcDependents, sczDependentKey, sczDependentName);
-            ExitOnFailure1(hr, "Failed to add the dependent key \"%ls\" to the string array.", sczDependentKey);
+            ExitOnFailure(hr, "Failed to add the dependent key \"%ls\" to the string array.", sczDependentKey);
         }
     }
 
@@ -334,32 +334,32 @@ DAPI_(HRESULT) DepRegisterDependency(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Create the dependency key (or open it if it already exists).
     hr = RegCreateEx(hkHive, sczKey, KEY_WRITE, FALSE, NULL, &hkKey, &fCreated);
-    ExitOnFailure1(hr, "Failed to create the dependency registry key \"%ls\".", sczKey);
+    ExitOnFailure(hr, "Failed to create the dependency registry key \"%ls\".", sczKey);
 
     // Set the id if it was provided.
     if (wzId)
     {
         hr = RegWriteString(hkKey, NULL, wzId);
-        ExitOnFailure2(hr, "Failed to set the %ls registry value to \"%ls\".", L"default", wzId);
+        ExitOnFailure(hr, "Failed to set the %ls registry value to \"%ls\".", L"default", wzId);
     }
 
     // Set the version.
     hr = RegWriteString(hkKey, vcszVersionValue, wzVersion);
-    ExitOnFailure2(hr, "Failed to set the %ls registry value to \"%ls\".", vcszVersionValue, wzVersion);
+    ExitOnFailure(hr, "Failed to set the %ls registry value to \"%ls\".", vcszVersionValue, wzVersion);
 
     // Set the display name.
     hr = RegWriteString(hkKey, vcszDisplayNameValue, wzDisplayName);
-    ExitOnFailure2(hr, "Failed to set the %ls registry value to \"%ls\".", vcszDisplayNameValue, wzDisplayName);
+    ExitOnFailure(hr, "Failed to set the %ls registry value to \"%ls\".", vcszDisplayNameValue, wzDisplayName);
 
     // Set the attributes if non-zero.
     if (0 != iAttributes)
     {
         hr = RegWriteNumber(hkKey, vcszAttributesValue, static_cast<DWORD>(iAttributes));
-        ExitOnFailure2(hr, "Failed to set the %ls registry value to %d.", vcszAttributesValue, iAttributes);
+        ExitOnFailure(hr, "Failed to set the %ls registry value to %d.", vcszAttributesValue, iAttributes);
     }
 
 LExit:
@@ -386,7 +386,7 @@ DAPI_(HRESULT) DepDependentExists(
     hr = RegOpen(hkHive, sczDependentKey, KEY_READ, &hkDependentKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the dependent registry key at: \"%ls\".", sczDependentKey);
+        ExitOnFailure(hr, "Failed to open the dependent registry key at: \"%ls\".", sczDependentKey);
     }
 
 LExit:
@@ -414,32 +414,32 @@ DAPI_(HRESULT) DepRegisterDependent(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzDependencyProviderKey, &sczDependencyKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzDependencyProviderKey);
 
     // Create the dependency key (or open it if it already exists).
     hr = RegCreateEx(hkHive, sczDependencyKey, KEY_WRITE, FALSE, NULL, &hkDependencyKey, &fCreated);
-    ExitOnFailure1(hr, "Failed to create the dependency registry key \"%ls\".", sczDependencyKey);
+    ExitOnFailure(hr, "Failed to create the dependency registry key \"%ls\".", sczDependencyKey);
 
     // Create the subkey to register the dependent.
     hr = StrAllocFormatted(&sczKey, L"%ls\\%ls", vsczRegistryDependents, wzProviderKey);
-    ExitOnFailure2(hr, "Failed to allocate dependent subkey \"%ls\" under dependency \"%ls\".", wzProviderKey, wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to allocate dependent subkey \"%ls\" under dependency \"%ls\".", wzProviderKey, wzDependencyProviderKey);
 
     hr = RegCreateEx(hkDependencyKey, sczKey, KEY_WRITE, FALSE, NULL, &hkKey, &fCreated);
-    ExitOnFailure1(hr, "Failed to create the dependency subkey \"%ls\".", sczKey);
+    ExitOnFailure(hr, "Failed to create the dependency subkey \"%ls\".", sczKey);
 
     // Set the minimum version if not NULL.
     hr = RegWriteString(hkKey, vcszMinVersionValue, wzMinVersion);
-    ExitOnFailure2(hr, "Failed to set the %ls registry value to \"%ls\".", vcszMinVersionValue, wzMinVersion);
+    ExitOnFailure(hr, "Failed to set the %ls registry value to \"%ls\".", vcszMinVersionValue, wzMinVersion);
 
     // Set the maximum version if not NULL.
     hr = RegWriteString(hkKey, vcszMaxVersionValue, wzMaxVersion);
-    ExitOnFailure2(hr, "Failed to set the %ls registry value to \"%ls\".", vcszMaxVersionValue, wzMaxVersion);
+    ExitOnFailure(hr, "Failed to set the %ls registry value to \"%ls\".", vcszMaxVersionValue, wzMaxVersion);
 
     // Set the attributes if non-zero.
     if (0 != iAttributes)
     {
         hr = RegWriteNumber(hkKey, vcszAttributesValue, static_cast<DWORD>(iAttributes));
-        ExitOnFailure2(hr, "Failed to set the %ls registry value to %d.", vcszAttributesValue, iAttributes);
+        ExitOnFailure(hr, "Failed to set the %ls registry value to %d.", vcszAttributesValue, iAttributes);
     }
 
 LExit:
@@ -462,13 +462,13 @@ DAPI_(HRESULT) DepUnregisterDependency(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Delete the entire key including all sub-keys.
     hr = RegDelete(hkHive, sczKey, REG_KEY_DEFAULT, TRUE);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to delete the key \"%ls\".", sczKey);
+        ExitOnFailure(hr, "Failed to delete the key \"%ls\".", sczKey);
     }
 
 LExit:
@@ -495,7 +495,7 @@ DAPI_(HRESULT) DepUnregisterDependent(
     hr = RegOpen(hkHive, vsczRegistryRoot, KEY_READ, &hkRegistryRoot);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open root registry key \"%ls\".", vsczRegistryRoot);
+        ExitOnFailure(hr, "Failed to open root registry key \"%ls\".", vsczRegistryRoot);
     }
     else
     {
@@ -506,7 +506,7 @@ DAPI_(HRESULT) DepUnregisterDependent(
     hr = RegOpen(hkRegistryRoot, wzDependencyProviderKey, KEY_READ, &hkDependencyProviderKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the registry key for the dependency \"%ls\".", wzDependencyProviderKey);
+        ExitOnFailure(hr, "Failed to open the registry key for the dependency \"%ls\".", wzDependencyProviderKey);
     }
     else
     {
@@ -517,7 +517,7 @@ DAPI_(HRESULT) DepUnregisterDependent(
     hr = RegOpen(hkDependencyProviderKey, vsczRegistryDependents, KEY_READ, &hkRegistryDependents);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the dependents subkey under the dependency \"%ls\".", wzDependencyProviderKey);
+        ExitOnFailure(hr, "Failed to open the dependents subkey under the dependency \"%ls\".", wzDependencyProviderKey);
     }
     else
     {
@@ -526,11 +526,11 @@ DAPI_(HRESULT) DepUnregisterDependent(
 
     // Delete the wzProviderKey dependent sub-key.
     hr = RegDelete(hkRegistryDependents, wzProviderKey, REG_KEY_DEFAULT, TRUE);
-    ExitOnFailure2(hr, "Failed to delete the dependent \"%ls\" under the dependency \"%ls\".", wzProviderKey, wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to delete the dependent \"%ls\" under the dependency \"%ls\".", wzProviderKey, wzDependencyProviderKey);
 
     // If there are no remaining dependents, delete the Dependents subkey.
     hr = RegQueryKey(hkRegistryDependents, &cSubKeys, NULL);
-    ExitOnFailure1(hr, "Failed to get the number of dependent subkeys under the dependency \"%ls\".", wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to get the number of dependent subkeys under the dependency \"%ls\".", wzDependencyProviderKey);
     
     if (0 < cSubKeys)
     {
@@ -542,11 +542,11 @@ DAPI_(HRESULT) DepUnregisterDependent(
 
     // Fail if there are any subkeys since we just checked.
     hr = RegDelete(hkDependencyProviderKey, vsczRegistryDependents, REG_KEY_DEFAULT, FALSE);
-    ExitOnFailure1(hr, "Failed to delete the dependents subkey under the dependency \"%ls\".", wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to delete the dependents subkey under the dependency \"%ls\".", wzDependencyProviderKey);
 
     // If there are no values, delete the provider dependency key.
     hr = RegQueryKey(hkDependencyProviderKey, NULL, &cValues);
-    ExitOnFailure1(hr, "Failed to get the number of values under the dependency \"%ls\".", wzDependencyProviderKey);
+    ExitOnFailure(hr, "Failed to get the number of values under the dependency \"%ls\".", wzDependencyProviderKey);
 
     if (0 == cValues)
     {
@@ -555,7 +555,7 @@ DAPI_(HRESULT) DepUnregisterDependent(
 
         // Fail if there are any subkeys since we just checked.
         hr = RegDelete(hkRegistryRoot, wzDependencyProviderKey, REG_KEY_DEFAULT, FALSE);
-        ExitOnFailure1(hr, "Failed to delete the dependency \"%ls\".", wzDependencyProviderKey);
+        ExitOnFailure(hr, "Failed to delete the dependency \"%ls\".", wzDependencyProviderKey);
     }
 
 LExit:
@@ -667,13 +667,13 @@ static HRESULT GetDependencyNameFromKey(
 
     // Format the provider dependency registry key.
     hr = AllocDependencyKeyName(wzProviderKey, &sczKey);
-    ExitOnFailure1(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
+    ExitOnFailure(hr, "Failed to allocate the registry key for dependency \"%ls\".", wzProviderKey);
 
     // Try to open the dependency key.
     hr = RegOpen(hkHive, sczKey, KEY_READ, &hkKey);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to open the registry key for the dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to open the registry key for the dependency \"%ls\".", wzProviderKey);
     }
     else
     {
@@ -684,7 +684,7 @@ static HRESULT GetDependencyNameFromKey(
     hr = RegReadString(hkKey, vcszDisplayNameValue, psczName);
     if (E_FILENOTFOUND != hr)
     {
-        ExitOnFailure1(hr, "Failed to get the dependency name for the dependency \"%ls\".", wzProviderKey);
+        ExitOnFailure(hr, "Failed to get the dependency name for the dependency \"%ls\".", wzProviderKey);
     }
     else
     {

--- a/src/libs/dutil/acl2util.cpp
+++ b/src/libs/dutil/acl2util.cpp
@@ -91,7 +91,7 @@ extern "C" HRESULT DAPI AclGetAccountSidStringEx(
 
         if (!::ConvertSidToStringSidW(psid, &pwz))
         {
-            ExitWithLastError1(hr, "Failed to convert SID to string for Account: %ls", wzAccount);
+            ExitWithLastError(hr, "Failed to convert SID to string for Account: %ls", wzAccount);
         }
 
         hr = StrAllocString(psczSid, pwz, 0);
@@ -108,13 +108,13 @@ extern "C" HRESULT DAPI AclGetAccountSidStringEx(
                 // If the service is not installed then LookupAccountName doesn't resolve the SID, but we can calculate it.
                 LPCWSTR wzServiceName = &wzAccount[11];
                 hr = AclCalculateServiceSidString(wzServiceName, cchAccount - 11, &sczSid);
-                ExitOnFailure1(hr, "Failed to calculate the service SID for %ls", wzServiceName);
+                ExitOnFailure(hr, "Failed to calculate the service SID for %ls", wzServiceName);
 
                 *psczSid = sczSid;
                 sczSid = NULL;
             }
         }
-        ExitOnFailure1(hr, "Failed to get SID for account: %ls", wzAccount);
+        ExitOnFailure(hr, "Failed to get SID for account: %ls", wzAccount);
     }
 
 LExit:

--- a/src/libs/dutil/aclutil.cpp
+++ b/src/libs/dutil/aclutil.cpp
@@ -35,7 +35,7 @@ extern "C" HRESULT DAPI AclCheckAccess(
     if (paa->pwzAccountName)
     {
         hr = AclGetAccountSid(NULL, paa->pwzAccountName, &psid);
-        ExitOnFailure1(hr, "failed to get SID for account: %ls", paa->pwzAccountName);
+        ExitOnFailure(hr, "failed to get SID for account: %ls", paa->pwzAccountName);
     }
     else
     {
@@ -171,19 +171,19 @@ extern "C" HRESULT DAPI AclGetWellKnownSid(
         break;
     default:
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "unknown well known SID: %d", wkst);
+        ExitOnFailure(hr, "unknown well known SID: %d", wkst);
     }
 
     if (!fSuccess)
-        ExitOnLastError1(hr, "failed to allocate well known SID: %d", wkst);
+        ExitOnLastError(hr, "failed to allocate well known SID: %d", wkst);
 
     if (!::CopySid(cbSid, psid, psidTemp))
-        ExitOnLastError1(hr, "failed to create well known SID: %d", wkst);
+        ExitOnLastError(hr, "failed to create well known SID: %d", wkst);
 #else
     Assert(NULL == psidTemp);
     if (!::CreateWellKnownSid(wkst, NULL, psid, &cbSid))
     {
-        ExitWithLastError1(hr, "failed to create well known SID: %d", wkst);
+        ExitWithLastError(hr, "failed to create well known SID: %d", wkst);
     }
 #endif 
 
@@ -243,7 +243,7 @@ extern "C" HRESULT DAPI AclGetAccountSid(
             if (SECURITY_MAX_SID_SIZE < cbSid)
             {
                 PSID psidNew = static_cast<PSID>(MemReAlloc(psid, cbSid, TRUE));
-                ExitOnNullWithLastError1(psidNew, hr, "failed to allocate memory for account: %ls", wzAccount);
+                ExitOnNullWithLastError(psidNew, hr, "failed to allocate memory for account: %ls", wzAccount);
 
                 psid = psidNew;
             }
@@ -255,12 +255,12 @@ extern "C" HRESULT DAPI AclGetAccountSid(
 
             if (!::LookupAccountNameW(wzSystem, wzAccount, psid, &cbSid, pwzDomainName, &cbDomainName, &peUse))
             {
-                ExitWithLastError1(hr, "failed to lookup account: %ls", wzAccount);
+                ExitWithLastError(hr, "failed to lookup account: %ls", wzAccount);
             }
         }
         else
         {
-            ExitOnWin32Error1(er, hr, "failed to lookup account: %ls", wzAccount);
+            ExitOnWin32Error(er, hr, "failed to lookup account: %ls", wzAccount);
         }
     }
 
@@ -295,12 +295,12 @@ extern "C" HRESULT DAPI AclGetAccountSidString(
     *ppwzSid = NULL;
 
     hr = AclGetAccountSid(wzSystem, wzAccount, &psid);
-    ExitOnFailure1(hr, "failed to get SID for account: %ls", wzAccount);
+    ExitOnFailure(hr, "failed to get SID for account: %ls", wzAccount);
     Assert(::IsValidSid(psid));
 
     if (!::ConvertSidToStringSidW(psid, &pwz))
     {
-        ExitWithLastError1(hr, "failed to convert SID to string for Account: %ls", wzAccount);
+        ExitWithLastError(hr, "failed to convert SID to string for Account: %ls", wzAccount);
     }
 
     hr = StrAllocString(ppwzSid, pwz, 0);
@@ -376,7 +376,7 @@ extern "C" HRESULT DAPI AclCreateDacl(
         if (!::AddAccessDeniedAceEx(pAcl, ACL_REVISION, rgaaDeny[i].dwFlags, rgaaDeny[i].dwMask, rgaaDeny[i].psid))
 #pragma prefast(pop)
         {
-            ExitWithLastError1(hr, "failed to add access denied ACE #%d to ACL", i);
+            ExitWithLastError(hr, "failed to add access denied ACE #%d to ACL", i);
         }
     }
     for (i = 0; i < cAllow; ++i)
@@ -386,7 +386,7 @@ extern "C" HRESULT DAPI AclCreateDacl(
         if (!::AddAccessAllowedAceEx(pAcl, ACL_REVISION, rgaaAllow[i].dwFlags, rgaaAllow[i].dwMask, rgaaAllow[i].psid))
 #pragma prefast(pop)
         {
-            ExitWithLastError1(hr, "failed to add access allowed ACE #$d to ACL", i);
+            ExitWithLastError(hr, "failed to add access allowed ACE #$d to ACL", i);
         }
     }
 
@@ -441,7 +441,7 @@ extern "C" HRESULT DAPI AclAddToDacl(
         (asi.AceCount + cDeny) >= MAXSIZE_T / sizeof(ACL_ACE))
     {
         hr = E_OUTOFMEMORY;
-        ExitOnFailure1(hr, "Not enough memory to allocate %d ACEs", (asi.AceCount + cDeny));
+        ExitOnFailure(hr, "Not enough memory to allocate %d ACEs", (asi.AceCount + cDeny));
     }
 
     paaNewDeny = static_cast<ACL_ACE*>(MemAlloc(sizeof(ACL_ACE) * (asi.AceCount + cDeny), TRUE));
@@ -452,7 +452,7 @@ extern "C" HRESULT DAPI AclAddToDacl(
         (asi.AceCount + cAllow) >= MAXSIZE_T / sizeof(ACL_ACE))
     {
         hr = E_OUTOFMEMORY;
-        ExitOnFailure1(hr, "Not enough memory to allocate %d ACEs", (asi.AceCount + cAllow));
+        ExitOnFailure(hr, "Not enough memory to allocate %d ACEs", (asi.AceCount + cAllow));
     }
 
     paaNewAllow = static_cast<ACL_ACE*>(MemAlloc(sizeof(ACL_ACE) * (asi.AceCount + cAllow), TRUE));
@@ -463,7 +463,7 @@ extern "C" HRESULT DAPI AclAddToDacl(
     {
         if (!::GetAce(pAcl, i, reinterpret_cast<LPVOID*>(&pada)))
         {
-            ExitWithLastError1(hr, "failed to get ACE #%d from ACL", i);
+            ExitWithLastError(hr, "failed to get ACE #%d from ACL", i);
         }
 
         if (ACCESS_DENIED_ACE_TYPE != pada->Header.AceType)
@@ -485,7 +485,7 @@ extern "C" HRESULT DAPI AclAddToDacl(
     {
         if (!::GetAce(pAcl, i, reinterpret_cast<LPVOID*>(&paaa)))
         {
-            ExitWithLastError1(hr, "failed to get ACE #%d from ACL", i);
+            ExitWithLastError(hr, "failed to get ACE #%d from ACL", i);
         }
 
         if (ACCESS_ALLOWED_ACE_TYPE != paaa->Header.AceType)
@@ -572,7 +572,7 @@ extern "C" HRESULT DAPI AclCreateDaclOld(
         if (paa[i].pwzAccountName)
         {
             hr = AclGetAccountSid(NULL, paa[i].pwzAccountName, ppsid + i);
-            ExitOnFailure1(hr, "failed to get SID for account: %ls", paa[i].pwzAccountName);
+            ExitOnFailure(hr, "failed to get SID for account: %ls", paa[i].pwzAccountName);
         }
         else
         {
@@ -583,7 +583,7 @@ extern "C" HRESULT DAPI AclCreateDaclOld(
                 paa[i].nSubAuthority[6], paa[i].nSubAuthority[7], 
                 (void**)(ppsid + i))))
             {
-                ExitWithLastError1(hr, "failed to initialize SIDs #%u", i);
+                ExitWithLastError(hr, "failed to initialize SIDs #%u", i);
             }
         }
 
@@ -781,11 +781,11 @@ extern "C" HRESULT DAPI AclCreateSecurityDescriptorFromString(
     va_start(args, wzSddlFormat);
     hr = StrAllocFormattedArgs(&pwzSddl, wzSddlFormat, args);
     va_end(args);
-    ExitOnFailure1(hr, "failed to create SDDL string for format: %ls", wzSddlFormat);
+    ExitOnFailure(hr, "failed to create SDDL string for format: %ls", wzSddlFormat);
 
     if (!::ConvertStringSecurityDescriptorToSecurityDescriptorW(pwzSddl, SDDL_REVISION_1, &psd, &cbSD))
     {
-        ExitWithLastError1(hr, "failed to create security descriptor from SDDL: %ls", pwzSddl);
+        ExitWithLastError(hr, "failed to create security descriptor from SDDL: %ls", pwzSddl);
     }
 
     *ppsd = static_cast<SECURITY_DESCRIPTOR*>(MemAlloc(cbSD, FALSE));
@@ -872,7 +872,7 @@ extern "C" HRESULT DAPI AclGetSecurityDescriptor(
 
     // get the security descriptor for the object
     er = ::GetNamedSecurityInfoW(const_cast<LPWSTR>(wzObject), sot, securityInformation, NULL, NULL, NULL, NULL, &psd);
-    ExitOnWin32Error1(er, hr, "failed to get security info from object: %ls", wzObject);
+    ExitOnWin32Error(er, hr, "failed to get security info from object: %ls", wzObject);
     Assert(::IsValidSecurityDescriptor(psd));
 
     // copy the self-relative security descriptor
@@ -929,7 +929,7 @@ extern "C" HRESULT DAPI AclSetSecurityWithRetry(
         DWORD er = ::SetNamedSecurityInfoW(sczObject, sot, securityInformation, psidOwner, psidGroup, pDacl, pSacl);
         hr = HRESULT_FROM_WIN32(er);
     }
-    ExitOnRootFailure2(hr, "Failed to set security on object '%ls' after %u retries.", wzObject, i);
+    ExitOnRootFailure(hr, "Failed to set security on object '%ls' after %u retries.", wzObject, i);
 
 LExit:
     ReleaseStr(sczObject);

--- a/src/libs/dutil/apuputil.cpp
+++ b/src/libs/dutil/apuputil.cpp
@@ -477,7 +477,7 @@ static HRESULT FilterEntries(
             DWORD cNewFilteredEntries = *pcFilteredEntries + 1;
 
             hr = ::SizeTMult(sizeof(APPLICATION_UPDATE_ENTRY), cNewFilteredEntries, &cbAllocSize);
-            ExitOnFailure1(hr, "Overflow while calculating alloc size for more entries - number of entries: %u", cNewFilteredEntries);
+            ExitOnFailure(hr, "Overflow while calculating alloc size for more entries - number of entries: %u", cNewFilteredEntries);
 
             if (*prgFilteredEntries)
             {

--- a/src/libs/dutil/atomutil.cpp
+++ b/src/libs/dutil/atomutil.cpp
@@ -405,7 +405,7 @@ static HRESULT ParseAtomFeed(
         else
         {
             hr = ParseAtomUnknownElement(pNode, &pNewFeed->pUnknownElements);
-            ExitOnFailure1(hr, "Failed to parse unknown ATOM feed element: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Failed to parse unknown ATOM feed element: %ls", bstrNodeName);
         }
 
         ReleaseNullBSTR(bstrNodeName);
@@ -461,12 +461,12 @@ template<class T> static HRESULT AllocateAtomType(
     T* prgT = NULL;
 
     hr = XmlSelectNodes(pixnParent, wzT, &pNodeList);
-    ExitOnFailure1(hr, "Failed to select all ATOM %ls.", wzT);
+    ExitOnFailure(hr, "Failed to select all ATOM %ls.", wzT);
 
     if (S_OK == hr)
     {
         hr = pNodeList->get_length(&cT);
-        ExitOnFailure1(hr, "Failed to count the number of ATOM %ls.", wzT);
+        ExitOnFailure(hr, "Failed to count the number of ATOM %ls.", wzT);
 
         if (cT == 0)
         {
@@ -596,7 +596,7 @@ static HRESULT ParseAtomCategory(
     while (S_OK == (hr = XmlNextElement(pNodeList, &pNode, &bstrNodeName)))
     {
         hr = ParseAtomUnknownElement(pNode, &pCategory->pUnknownElements);
-        ExitOnFailure1(hr, "Failed to parse unknown ATOM category element: %ls", bstrNodeName);
+        ExitOnFailure(hr, "Failed to parse unknown ATOM category element: %ls", bstrNodeName);
 
         ReleaseNullBSTR(bstrNodeName);
         ReleaseNullObject(pNode);
@@ -660,7 +660,7 @@ static HRESULT ParseAtomContent(
     while (S_OK == (hr = XmlNextElement(pNodeList, &pNode, &bstrNodeName)))
     {
         hr = ParseAtomUnknownElement(pNode, &pContent->pUnknownElements);
-        ExitOnFailure1(hr, "Failed to parse unknown ATOM content element: %ls", bstrNodeName);
+        ExitOnFailure(hr, "Failed to parse unknown ATOM content element: %ls", bstrNodeName);
 
         ReleaseNullBSTR(bstrNodeName);
         ReleaseNullObject(pNode);
@@ -782,7 +782,7 @@ static HRESULT ParseAtomEntry(
         else
         {
             hr = ParseAtomUnknownElement(pNode, &pEntry->pUnknownElements);
-            ExitOnFailure1(hr, "Failed to parse unknown ATOM entry element: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Failed to parse unknown ATOM entry element: %ls", bstrNodeName);
         }
 
         ReleaseNullBSTR(bstrNodeName);
@@ -872,7 +872,7 @@ static HRESULT ParseAtomLink(
         else
         {
             hr = ParseAtomUnknownAttribute(pNode, &pLink->pUnknownAttributes);
-            ExitOnFailure1(hr, "Failed to parse unknown ATOM link attribute: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Failed to parse unknown ATOM link attribute: %ls", bstrNodeName);
         }
 
         ReleaseNullBSTR(bstrNodeName);
@@ -887,7 +887,7 @@ static HRESULT ParseAtomLink(
     while (S_OK == (hr = XmlNextElement(pNodeList, &pNode, &bstrNodeName)))
     {
         hr = ParseAtomUnknownElement(pNode, &pLink->pUnknownElements);
-        ExitOnFailure1(hr, "Failed to parse unknown ATOM link element: %ls", bstrNodeName);
+        ExitOnFailure(hr, "Failed to parse unknown ATOM link element: %ls", bstrNodeName);
 
         ReleaseNullBSTR(bstrNodeName);
         ReleaseNullObject(pNode);

--- a/src/libs/dutil/butil.cpp
+++ b/src/libs/dutil/butil.cpp
@@ -89,7 +89,7 @@ extern "C" HRESULT DAPI BundleGetBundleInfo(
             ExitOnFailure(hr, "Failed to format dword property as string.");
             break;
         default:
-            ExitOnFailure1(hr = E_NOTIMPL, "Reading bundle info of type 0x%x not implemented.", dwType);
+            ExitOnFailure(hr = E_NOTIMPL, "Reading bundle info of type 0x%x not implemented.", dwType);
 
     }
 
@@ -219,7 +219,7 @@ HRESULT DAPI BundleEnumRelatedBundle(
                 break;
 
             default:
-                ExitOnFailure1(hr = E_NOTIMPL, "BundleUpgradeCode of type 0x%x not implemented.", dwType);
+                ExitOnFailure(hr = E_NOTIMPL, "BundleUpgradeCode of type 0x%x not implemented.", dwType);
 
         }
 

--- a/src/libs/dutil/cabcutil.cpp
+++ b/src/libs/dutil/cabcutil.cpp
@@ -207,7 +207,7 @@ extern "C" HRESULT DAPI CabCBegin(
         if((MAX_PATH - 1) <= cchPathBuffer || 0 == cchPathBuffer)
         {
             hr = E_INVALIDARG;
-            ExitOnFailure1(hr, "Cab directory had invalid length: %u", cchPathBuffer);
+            ExitOnFailure(hr, "Cab directory had invalid length: %u", cchPathBuffer);
         }
 
         hr = ::StringCchCopyW(wzPathBuffer, countof(wzPathBuffer), wzCabDir);
@@ -292,10 +292,10 @@ extern "C" HRESULT DAPI CabCBegin(
 
     // Remember the path to the cabinet.
     hr= ::StringCchCopyW(pcd->wzCabinetPath, countof(pcd->wzCabinetPath), wzPathBuffer);
-    ExitOnFailure1(hr, "Failed to copy cabinet path from path: %ls", wzPathBuffer);
+    ExitOnFailure(hr, "Failed to copy cabinet path from path: %ls", wzPathBuffer);
 
     hr = ::StringCchCatW(pcd->wzCabinetPath, countof(pcd->wzCabinetPath), wzCab);
-    ExitOnFailure1(hr, "Failed to concat to cabinet path cabinet name: %ls", wzCab);
+    ExitOnFailure(hr, "Failed to concat to cabinet path cabinet name: %ls", wzCab);
 
     // Get the empty file to use as the blank marker for duplicates.
     if (!::GetTempPathW(countof(wzTempPath), wzTempPath))
@@ -342,12 +342,12 @@ extern "C" HRESULT DAPI CabCBegin(
         }
         else
         {
-            ExitWithLastError2(hr, "failed to create FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
+            ExitWithLastError(hr, "failed to create FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
         }
 
         pcd->fGoodCab = FALSE;
 
-        ExitOnFailure2(hr, "failed to create FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
+        ExitOnFailure(hr, "failed to create FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
     }
 
     *phContext = pcd;
@@ -399,7 +399,7 @@ extern "C" HRESULT DAPI CabCAddFile(
     PMSIFILEHASHINFO pmfLocalHash = pmfHash;
 
     hr = StrAllocString(&sczUpperCaseFile, wzFile, 0);
-    ExitOnFailure1(hr, "Failed to allocate new string for file %ls", wzFile);
+    ExitOnFailure(hr, "Failed to allocate new string for file %ls", wzFile);
 
     // Modifies the string in-place
     StrStringToUpper(sczUpperCaseFile);
@@ -410,25 +410,25 @@ extern "C" HRESULT DAPI CabCAddFile(
     {
         // Store file size, primarily used to determine which files to hash for duplicates
         hr = FileSize(wzFile, &llFileSize);
-        ExitOnFailure1(hr, "Failed to check size of file %ls", wzFile);
+        ExitOnFailure(hr, "Failed to check size of file %ls", wzFile);
 
         hr = CheckForDuplicateFile(pcd, &pcfDuplicate, sczUpperCaseFile, &pmfLocalHash, llFileSize);
-        ExitOnFailure1(hr, "Failed while checking for duplicate of file: %ls", wzFile);
+        ExitOnFailure(hr, "Failed while checking for duplicate of file: %ls", wzFile);
     }
 
     if (pcfDuplicate) // This will be null for smart cabbing case
     {
         DWORD index;
         hr = ::PtrdiffTToDWord(pcfDuplicate - pcd->prgFiles, &index);
-        ExitOnFailure1(hr, "Failed to calculate index of file name: %ls", pcfDuplicate->pwzSourcePath);
+        ExitOnFailure(hr, "Failed to calculate index of file name: %ls", pcfDuplicate->pwzSourcePath);
 
         hr = AddDuplicateFile(pcd, index, sczUpperCaseFile, wzToken, pcd->dwLastFileIndex);
-        ExitOnFailure1(hr, "Failed to add duplicate of file name: %ls", pcfDuplicate->pwzSourcePath);
+        ExitOnFailure(hr, "Failed to add duplicate of file name: %ls", pcfDuplicate->pwzSourcePath);
     }
     else
     {
         hr = AddNonDuplicateFile(pcd, sczUpperCaseFile, wzToken, pmfLocalHash, llFileSize, pcd->dwLastFileIndex);
-        ExitOnFailure1(hr, "Failed to add non-duplicated file: %ls", wzFile);
+        ExitOnFailure(hr, "Failed to add non-duplicated file: %ls", wzFile);
     }
 
     ++pcd->dwLastFileIndex;
@@ -503,13 +503,13 @@ extern "C" HRESULT DAPI CabCFinish(
             {
                 LPCWSTR pwzTemp = pcd->prgFiles[dwArrayFileIndex].pwzToken;
                 hr = StrAnsiAllocString(&pszFileToken, pwzTemp, 0, CP_ACP);
-                ExitOnFailure1(hr, "failed to convert file token to ANSI: %ls", pwzTemp);
+                ExitOnFailure(hr, "failed to convert file token to ANSI: %ls", pwzTemp);
             }
             else
             {
                 LPCWSTR pwzTemp = FileFromPath(fileInfo.wzSourcePath);
                 hr = StrAnsiAllocString(&pszFileToken, pwzTemp, 0, CP_ACP);
-                ExitOnFailure1(hr, "failed to convert file name to ANSI: %ls", pwzTemp);
+                ExitOnFailure(hr, "failed to convert file name to ANSI: %ls", pwzTemp);
             }
 
             if (pcd->prgFiles[dwArrayFileIndex].fHasDuplicates)
@@ -538,13 +538,13 @@ extern "C" HRESULT DAPI CabCFinish(
             {
                 LPCWSTR pwzTemp = pcd->prgDuplicates[dwDupeArrayFileIndex].pwzToken;
                 hr = StrAnsiAllocString(&pszFileToken, pwzTemp, 0, CP_ACP);
-                ExitOnFailure1(hr, "failed to convert duplicate file token to ANSI: %ls", pwzTemp);
+                ExitOnFailure(hr, "failed to convert duplicate file token to ANSI: %ls", pwzTemp);
             }
             else
             {
                 LPCWSTR pwzTemp = FileFromPath(fileInfo.wzSourcePath);
                 hr = StrAnsiAllocString(&pszFileToken, pwzTemp, 0, CP_ACP);
-                ExitOnFailure1(hr, "failed to convert duplicate file name to ANSI: %ls", pwzTemp);
+                ExitOnFailure(hr, "failed to convert duplicate file name to ANSI: %ls", pwzTemp);
             }
 
             // Flush afterward only if this isn't a duplicate of the previous file, and at least one non-duplicate file remains to be added to the cab
@@ -570,7 +570,7 @@ extern "C" HRESULT DAPI CabCFinish(
         {
             if (!::FCIFlushFolder(pcd->hfci, CabCGetNextCabinet, CabCStatus))
             {
-                ExitWithLastError2(hr, "failed to flush FCI folder before adding file, Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
+                ExitWithLastError(hr, "failed to flush FCI folder before adding file, Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
             }
             pcd->llBytesSinceLastFlush = 0;
         }
@@ -594,10 +594,10 @@ extern "C" HRESULT DAPI CabCFinish(
             }
             else
             {
-                ExitWithLastError3(hr, "failed to add file to FCI object Oper: 0x%x Type: 0x%x File: %ls", pcd->erf.erfOper, pcd->erf.erfType, fileInfo.wzSourcePath);
+                ExitWithLastError(hr, "failed to add file to FCI object Oper: 0x%x Type: 0x%x File: %ls", pcd->erf.erfOper, pcd->erf.erfType, fileInfo.wzSourcePath);
             }
 
-            ExitOnFailure3(hr, "failed to add file to FCI object Oper: 0x%x Type: 0x%x File: %ls", pcd->erf.erfOper, pcd->erf.erfType, fileInfo.wzSourcePath);  // TODO: can these be converted to HRESULTS?
+            ExitOnFailure(hr, "failed to add file to FCI object Oper: 0x%x Type: 0x%x File: %ls", pcd->erf.erfOper, pcd->erf.erfType, fileInfo.wzSourcePath);  // TODO: can these be converted to HRESULTS?
         }
 
         // For Cabinet Splitting case, check for pcd->hrLastError that may be set as result of Error in CabCGetNextCabinet
@@ -612,7 +612,7 @@ extern "C" HRESULT DAPI CabCFinish(
         {
             if (!::FCIFlushFolder(pcd->hfci, CabCGetNextCabinet, CabCStatus))
             {
-                ExitWithLastError2(hr, "failed to flush FCI folder after adding file, Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
+                ExitWithLastError(hr, "failed to flush FCI folder after adding file, Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);
             }
             pcd->llBytesSinceLastFlush = 0;
         }
@@ -630,10 +630,10 @@ extern "C" HRESULT DAPI CabCFinish(
         }
         else
         {
-            ExitWithLastError2(hr, "failed while creating CAB FCI object Oper: 0x%x Type: 0x%x File: %s", pcd->erf.erfOper, pcd->erf.erfType);
+            ExitWithLastError(hr, "failed while creating CAB FCI object Oper: 0x%x Type: 0x%x File: %s", pcd->erf.erfOper, pcd->erf.erfType);
         }
 
-        ExitOnFailure2(hr, "failed while creating CAB FCI object Oper: 0x%x Type: 0x%x File: %s", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
+        ExitOnFailure(hr, "failed while creating CAB FCI object Oper: 0x%x Type: 0x%x File: %s", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
     }
 
     // Only flush the cabinet if we actually succeeded in previous calls - otherwise we just waste time (a lot on big cabs)
@@ -641,13 +641,13 @@ extern "C" HRESULT DAPI CabCFinish(
     {
         // If we have a last error, use that, otherwise return the useless error
         hr = FAILED(pcd->hrLastError) ? pcd->hrLastError : E_FAIL;
-        ExitOnFailure2(hr, "failed to flush FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
+        ExitOnFailure(hr, "failed to flush FCI object Oper: 0x%x Type: 0x%x", pcd->erf.erfOper, pcd->erf.erfType);  // TODO: can these be converted to HRESULTS?
     }
 
     if (pcd->fGoodCab && pcd->cDuplicates)
     {
         hr = UpdateDuplicateFiles(pcd);
-        ExitOnFailure1(hr, "Failed to update duplicates in cabinet: %ls", pcd->wzCabinetPath);
+        ExitOnFailure(hr, "Failed to update duplicates in cabinet: %ls", pcd->wzCabinetPath);
     }
 
 LExit:
@@ -747,7 +747,7 @@ static HRESULT CheckForDuplicateFile(
 
                 pcd->prgFiles[i].pmfHash->dwFileHashInfoSize = sizeof(MSIFILEHASHINFO);
                 er = ::MsiGetFileHashW(pcd->prgFiles[i].pwzSourcePath, 0, pcd->prgFiles[i].pmfHash);
-                ExitOnWin32Error1(er, hr, "Failed while getting MSI file hash of candidate duplicate file: %ls", pcd->prgFiles[i].pwzSourcePath);
+                ExitOnWin32Error(er, hr, "Failed while getting MSI file hash of candidate duplicate file: %ls", pcd->prgFiles[i].pwzSourcePath);
             }
 
             // If our own file hasn't yet been hashed, hash it
@@ -758,7 +758,7 @@ static HRESULT CheckForDuplicateFile(
 
                 (*ppmfHash)->dwFileHashInfoSize = sizeof(MSIFILEHASHINFO);
                 er = ::MsiGetFileHashW(wzFileName, 0, *ppmfHash);
-                ExitOnWin32Error1(er, hr, "Failed while getting MSI file hash of file: %ls", pcd->prgFiles[i].pwzSourcePath);
+                ExitOnWin32Error(er, hr, "Failed while getting MSI file hash of file: %ls", pcd->prgFiles[i].pwzSourcePath);
             }
 
             // If the two file hashes are both of the expected size, and they match, we've got a match, so return it!
@@ -824,12 +824,12 @@ static HRESULT AddDuplicateFile(
     pcd->prgFiles[dwFileArrayIndex].fHasDuplicates = TRUE; // Mark original file as having duplicates
 
     hr = StrAllocString(&pcd->prgDuplicates[pcd->cDuplicates].pwzSourcePath, wzSourcePath, 0);
-    ExitOnFailure1(hr, "Failed to copy duplicate file path: %ls", wzSourcePath);
+    ExitOnFailure(hr, "Failed to copy duplicate file path: %ls", wzSourcePath);
 
     if (wzToken && *wzToken)
     {
         hr = StrAllocString(&pcd->prgDuplicates[pcd->cDuplicates].pwzToken, wzToken, 0);
-        ExitOnFailure1(hr, "Failed to copy duplicate file token: %ls", wzToken);
+        ExitOnFailure(hr, "Failed to copy duplicate file token: %ls", wzToken);
     }
 
     ++pcd->cDuplicates;
@@ -889,12 +889,12 @@ static HRESULT AddNonDuplicateFile(
     }
 
     hr = StrAllocString(&pcf->pwzSourcePath, wzFile, 0);
-    ExitOnFailure1(hr, "Failed to copy file path: %ls", wzFile);
+    ExitOnFailure(hr, "Failed to copy file path: %ls", wzFile);
 
     if (wzToken && *wzToken)
     {
         hr = StrAllocString(&pcf->pwzToken, wzToken, 0);
-        ExitOnFailure1(hr, "Failed to copy file token: %ls", wzToken);
+        ExitOnFailure(hr, "Failed to copy file token: %ls", wzToken);
     }
 
     ++pcd->cFilePaths;
@@ -923,14 +923,14 @@ static HRESULT UpdateDuplicateFiles(
     hCabinet = ::CreateFileW(pcd->wzCabinetPath, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == hCabinet)
     {
-        ExitWithLastError1(hr, "Failed to open cabinet: %ls", pcd->wzCabinetPath);
+        ExitWithLastError(hr, "Failed to open cabinet: %ls", pcd->wzCabinetPath);
     }
 
     // Shouldn't need more than 16 MB to get the whole cabinet header into memory so use that as
     // the upper bound for the memory map.
     if (!::GetFileSizeEx(hCabinet, &liCabinetSize))
     {
-        ExitWithLastError1(hr, "Failed to get size of cabinet: %ls", pcd->wzCabinetPath);
+        ExitWithLastError(hr, "Failed to get size of cabinet: %ls", pcd->wzCabinetPath);
     }
 
     if (0 == liCabinetSize.HighPart && liCabinetSize.LowPart < MAX_CABINET_HEADER_SIZE)
@@ -946,11 +946,11 @@ static HRESULT UpdateDuplicateFiles(
     hCabinetMapping = ::CreateFileMappingW(hCabinet, NULL, PAGE_READWRITE | SEC_COMMIT, 0, cbCabinet, NULL);
     if (NULL == hCabinetMapping || INVALID_HANDLE_VALUE == hCabinetMapping)
     {
-        ExitWithLastError1(hr, "Failed to memory map cabinet file: %ls", pcd->wzCabinetPath);
+        ExitWithLastError(hr, "Failed to memory map cabinet file: %ls", pcd->wzCabinetPath);
     }
 
     pv = ::MapViewOfFile(hCabinetMapping, FILE_MAP_WRITE, 0, 0, 0);
-    ExitOnNullWithLastError1(pv, hr, "Failed to map view of cabinet file: %ls", pcd->wzCabinetPath);
+    ExitOnNullWithLastError(pv, hr, "Failed to map view of cabinet file: %ls", pcd->wzCabinetPath);
 
     pCabinetHeader = static_cast<MS_CABINET_HEADER*>(pv);
 
@@ -959,7 +959,7 @@ static HRESULT UpdateDuplicateFiles(
         const CABC_DUPLICATEFILE *pDuplicateFile = pcd->prgDuplicates + i;
 
         hr = DuplicateFile(pCabinetHeader, pcd, pDuplicateFile);
-        ExitOnFailure2(hr, "Failed to find cabinet file items at index: %d and %d", pDuplicateFile->dwFileArrayIndex, pDuplicateFile->dwDuplicateCabFileIndex);
+        ExitOnFailure(hr, "Failed to find cabinet file items at index: %d and %d", pDuplicateFile->dwFileArrayIndex, pDuplicateFile->dwDuplicateCabFileIndex);
     }
 
 LExit:
@@ -994,7 +994,7 @@ static HRESULT DuplicateFile(
         pDuplicate->dwDuplicateCabFileIndex <= pcd->prgFiles[pDuplicate->dwFileArrayIndex].dwCabFileIndex)
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure3(hr, "Unexpected duplicate file indices, header cFiles: %d, file index: %d, duplicate index: %d", pHeader->cFiles, pcd->prgFiles[pDuplicate->dwFileArrayIndex].dwCabFileIndex, pDuplicate->dwDuplicateCabFileIndex);
+        ExitOnFailure(hr, "Unexpected duplicate file indices, header cFiles: %d, file index: %d, duplicate index: %d", pHeader->cFiles, pcd->prgFiles[pDuplicate->dwFileArrayIndex].dwCabFileIndex, pDuplicate->dwDuplicateCabFileIndex);
     }
 
     // Step through each cabinet items until we get to the original
@@ -1022,7 +1022,7 @@ static HRESULT DuplicateFile(
     if (0 != pDuplicateItem->cbFile)
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "Failed because duplicate file does not have a file size of zero: %d", pDuplicateItem->cbFile);
+        ExitOnFailure(hr, "Failed because duplicate file does not have a file size of zero: %d", pDuplicateItem->cbFile);
     }
 
     pDuplicateItem->cbFile = pOriginalItem->cbFile;
@@ -1159,7 +1159,7 @@ static __callback INT_PTR DIAMONDAPI CabCOpen(
 
     if (INVALID_HANDLE_VALUE == reinterpret_cast<HANDLE>(pFile))
     {
-        ExitOnLastError1(hr, "failed to open file: %s", pszFile);
+        ExitOnLastError(hr, "failed to open file: %s", pszFile);
     }
 
 LExit:
@@ -1253,7 +1253,7 @@ static __callback long FAR DIAMONDAPI CabCSeek(
     default :
         dwMoveMethod = 0;
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "unexpected seektype in FCISeek(): %d", seektype);
+        ExitOnFailure(hr, "unexpected seektype in FCISeek(): %d", seektype);
     }
 
     // SetFilePointer returns -1 if it fails (this will cause FDI to quit with an FDIERROR_USER_ABORT error.
@@ -1263,7 +1263,7 @@ static __callback long FAR DIAMONDAPI CabCSeek(
     if (DWORD_MAX == lMove)
     {
         *err = ::GetLastError();
-        ExitOnLastError1(hr, "failed to move file pointer %d bytes", dist);
+        ExitOnLastError(hr, "failed to move file pointer %d bytes", dist);
     }
 
 LExit:
@@ -1498,7 +1498,7 @@ static __callback INT_PTR DIAMONDAPI CabCGetOpenInfo(
 
     if (!::GetFileAttributesExW(pFileInfo->wzSourcePath, GetFileExInfoStandard, &fad))
     {
-        ExitWithLastError1(hr, "Failed to get file attributes on '%s'.", pFileInfo->wzSourcePath);
+        ExitWithLastError(hr, "Failed to get file attributes on '%s'.", pFileInfo->wzSourcePath);
     }
 
     // Set the attributes but only allow the few attributes that CAB supports.
@@ -1512,7 +1512,7 @@ static __callback INT_PTR DIAMONDAPI CabCGetOpenInfo(
         // found. This would create further problems if the file was written to the CAB without this value. Windows
         // Installer would then fail to extract the file.
         hr = UtcFileTimeToLocalDosDateTime(&fad.ftCreationTime, pdate, ptime);
-        ExitOnFailure1(hr, "Filed to read a valid file time stucture on file '%s'.", pszName);
+        ExitOnFailure(hr, "Filed to read a valid file time stucture on file '%s'.", pszName);
     }
 
     iResult = CabCOpen(pszFilePlusMagic, _O_BINARY|_O_RDONLY, 0, err, pv);

--- a/src/libs/dutil/certutil.cpp
+++ b/src/libs/dutil/certutil.cpp
@@ -289,7 +289,7 @@ extern "C" HRESULT DAPI CertInstallSingleCertificate(
 
     if (!::CertSetCertificateContextProperty(pCertContext, CERT_FRIENDLY_NAME_PROP_ID, 0, &blob))
     {
-        ExitWithLastError1(hr, "Failed to set the friendly name of the certificate: %ls", wzName);
+        ExitWithLastError(hr, "Failed to set the friendly name of the certificate: %ls", wzName);
     }
 
     if (!::CertAddCertificateContextToStore(hStore, pCertContext, CERT_STORE_ADD_REPLACE_EXISTING, NULL))

--- a/src/libs/dutil/conutil.cpp
+++ b/src/libs/dutil/conutil.cpp
@@ -189,14 +189,14 @@ extern "C" HRESULT DAPI ConsoleWrite(
     va_start(args, szFormat);
     hr = StrAnsiAllocFormattedArgs(&pszOutput, szFormat, args);
     va_end(args);
-    ExitOnFailure1(hr, "failed to format message: \"%s\"", szFormat);
+    ExitOnFailure(hr, "failed to format message: \"%s\"", szFormat);
 
     cchOutput = lstrlenA(pszOutput);
     while (cbTotal < (sizeof(*pszOutput) * cchOutput))
     {
         if (!::WriteFile(vhStdOut, reinterpret_cast<BYTE*>(pszOutput) + cbTotal, cchOutput * sizeof(*pszOutput) - cbTotal, &cbWrote, NULL))
         {
-            ExitOnLastError1(hr, "failed to write output to console: %s", pszOutput);
+            ExitOnLastError(hr, "failed to write output to console: %s", pszOutput);
         }
 
         cbTotal += cbWrote;
@@ -247,7 +247,7 @@ extern "C" HRESULT DAPI ConsoleWriteLine(
     va_start(args, szFormat);
     hr = StrAnsiAllocFormattedArgs(&pszOutput, szFormat, args);
     va_end(args);
-    ExitOnFailure1(hr, "failed to format message: \"%s\"", szFormat);
+    ExitOnFailure(hr, "failed to format message: \"%s\"", szFormat);
 
     //
     // write the string
@@ -256,7 +256,7 @@ extern "C" HRESULT DAPI ConsoleWriteLine(
     while (cbTotal < (sizeof(*pszOutput) * cchOutput))
     {
         if (!::WriteFile(vhStdOut, reinterpret_cast<BYTE*>(pszOutput) + cbTotal, cchOutput * sizeof(*pszOutput) - cbTotal, &cbWrote, NULL))
-            ExitOnLastError1(hr, "failed to write output to console: %s", pszOutput);
+            ExitOnLastError(hr, "failed to write output to console: %s", pszOutput);
 
         cbTotal += cbWrote;
     }
@@ -300,7 +300,7 @@ HRESULT ConsoleWriteError(
     va_start(args, szFormat);
     hr = StrAnsiAllocFormattedArgs(&pszMessage, szFormat, args);
     va_end(args);
-    ExitOnFailure1(hr, "failed to format error message: \"%s\"", szFormat);
+    ExitOnFailure(hr, "failed to format error message: \"%s\"", szFormat);
 
     if (FAILED(hrError))
     {

--- a/src/libs/dutil/cryputil.cpp
+++ b/src/libs/dutil/cryputil.cpp
@@ -191,7 +191,7 @@ extern "C" HRESULT DAPI CrypHashFile(
     }
 
     hr = CrypHashFileHandle(hFile, dwProvType, algid, pbHash, cbHash, pqwBytesHashed);
-    ExitOnFailure1(hr, "Failed to hash file: %ls", wzFilePath);
+    ExitOnFailure(hr, "Failed to hash file: %ls", wzFilePath);
 
 LExit:
     ReleaseFileHandle(hFile);

--- a/src/libs/dutil/dictutil.cpp
+++ b/src/libs/dutil/dictutil.cpp
@@ -237,7 +237,7 @@ extern "C" HRESULT DAPI DictCreateStringListFromArray(
         else
         {
             hr = DictAddKey(sd, wzKey);
-            ExitOnFailure1(hr, "Failed to add \"%ls\" to the string dictionary.", wzKey);
+            ExitOnFailure(hr, "Failed to add \"%ls\" to the string dictionary.", wzKey);
         }
     }
 
@@ -296,7 +296,7 @@ extern "C" HRESULT DAPI DictAddKey(
     if (DICT_STRING_LIST != psd->dtType)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Tried to add key without value to wrong dictionary type! This dictionary type is: %d", psd->dtType);
+        ExitOnFailure(hr, "Tried to add key without value to wrong dictionary type! This dictionary type is: %d", psd->dtType);
     }
 
     if ((psd->dwNumItems + 1) >= MAX_BUCKET_SIZES[psd->dwBucketSizeIndex] / MAX_BUCKETS_TO_ITEMS_RATIO)
@@ -353,7 +353,7 @@ extern "C" HRESULT DAPI DictAddValue(
     if (DICT_EMBEDDED_KEY != psd->dtType)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Tried to add key/value pair to wrong dictionary type! This dictionary type is: %d", psd->dtType);
+        ExitOnFailure(hr, "Tried to add key/value pair to wrong dictionary type! This dictionary type is: %d", psd->dtType);
     }
 
     wzKey = GetKey(psd, pvValue);
@@ -404,7 +404,7 @@ extern "C" HRESULT DAPI DictGetValue(
     if (DICT_EMBEDDED_KEY != psd->dtType)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Tried to lookup value in wrong dictionary type! This dictionary type is: %d", psd->dtType);
+        ExitOnFailure(hr, "Tried to lookup value in wrong dictionary type! This dictionary type is: %d", psd->dtType);
     }
 
     hr = GetValue(psd, pszString, ppvValue);
@@ -615,7 +615,7 @@ static HRESULT GetInsertIndex(
         {
             // The dict table is full - this error seems to be a reasonably close match 
             hr = HRESULT_FROM_WIN32(ERROR_DATABASE_FULL);
-            ExitOnRootFailure1(hr, "Failed to add item '%ls' to dict table because dict table is full of items", pszString);
+            ExitOnRootFailure(hr, "Failed to add item '%ls' to dict table because dict table is full of items", pszString);
         }
     }
 
@@ -718,7 +718,7 @@ static HRESULT GrowDictionary(
     ExitOnFailure(hr, "Overflow while calculating allocation size to grow dictionary");
 
     ppvNewBuckets = static_cast<void**>(MemAlloc(cbAllocSize, TRUE));
-    ExitOnNull1(ppvNewBuckets, hr, E_OUTOFMEMORY, "Failed to allocate %u buckets while growing dictionary", MAX_BUCKET_SIZES[dwNewBucketSizeIndex]);
+    ExitOnNull(ppvNewBuckets, hr, E_OUTOFMEMORY, "Failed to allocate %u buckets while growing dictionary", MAX_BUCKET_SIZES[dwNewBucketSizeIndex]);
 
     for (DWORD i = 0; i < psd->dwNumItems; ++i)
     {

--- a/src/libs/dutil/dirutil.cpp
+++ b/src/libs/dutil/dirutil.cpp
@@ -127,7 +127,7 @@ extern "C" HRESULT DAPI DirEnsureExists(
         *pwzLastSlash = L'\0'; // null terminate the parent path
         hr = DirEnsureExists(wzPath, psa);   // recurse!
         *pwzLastSlash = L'\\';  // put the slash back
-        ExitOnFailureDebugTrace1(hr, "failed to create path: %ls", wzPath);
+        ExitOnFailureDebugTrace(hr, "failed to create path: %ls", wzPath);
 
         // try to create the directory now that all parents are created
         if (!::CreateDirectoryW(wzPath, psa))
@@ -208,7 +208,7 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
             er = ERROR_PATH_NOT_FOUND;
         }
         hr = HRESULT_FROM_WIN32(er);
-        ExitOnRootFailure1(hr, "Failed to get attributes for path: %ls", wzPath);
+        ExitOnRootFailure(hr, "Failed to get attributes for path: %ls", wzPath);
     }
 
     if (dwAttrib & FILE_ATTRIBUTE_DIRECTORY)
@@ -217,7 +217,7 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
         {
             if (!::SetFileAttributesW(wzPath, FILE_ATTRIBUTE_NORMAL))
             {
-                ExitWithLastError1(hr, "Failed to remove read-only attribute from path: %ls", wzPath);
+                ExitWithLastError(hr, "Failed to remove read-only attribute from path: %ls", wzPath);
             }
         }
 
@@ -234,12 +234,12 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
 
             // Delete everything in this directory.
             hr = PathConcat(wzPath, L"*.*", &sczDelete);
-            ExitOnFailure1(hr, "Failed to concat wild cards to string: %ls", wzPath);
+            ExitOnFailure(hr, "Failed to concat wild cards to string: %ls", wzPath);
 
             hFind = ::FindFirstFileW(sczDelete, &wfd);
             if (INVALID_HANDLE_VALUE == hFind)
             {
-                ExitWithLastError1(hr, "failed to get first file in directory: %ls", wzPath);
+                ExitWithLastError(hr, "failed to get first file in directory: %ls", wzPath);
             }
 
             do
@@ -254,18 +254,18 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
                 wfd.cFileName[MAX_PATH - 1] = L'\0';
 
                 hr = PathConcat(wzPath, wfd.cFileName, &sczDelete);
-                ExitOnFailure2(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzPath);
+                ExitOnFailure(hr, "Failed to concat filename '%ls' to directory: %ls", wfd.cFileName, wzPath);
 
                 if (fRecurse && wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
                 {
                     hr = PathBackslashTerminate(&sczDelete);
-                    ExitOnFailure1(hr, "Failed to ensure path is backslash terminated: %ls", sczDelete);
+                    ExitOnFailure(hr, "Failed to ensure path is backslash terminated: %ls", sczDelete);
 
                     hr = DirEnsureDeleteEx(sczDelete, dwFlags); // recursive call
                     if (FAILED(hr))
                     {
                       // if we failed to delete a subdirectory, keep trying to finish any remaining files
-                      ExitTrace1(hr, "Failed to delete subdirectory; continuing: %ls", sczDelete);
+                      ExitTrace(hr, "Failed to delete subdirectory; continuing: %ls", sczDelete);
                       hr = S_OK;
                     }
                 }
@@ -275,7 +275,7 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
                     {
                         if (!::SetFileAttributesW(sczDelete, FILE_ATTRIBUTE_NORMAL))
                         {
-                            ExitWithLastError1(hr, "Failed to remove attributes from file: %ls", sczDelete);
+                            ExitWithLastError(hr, "Failed to remove attributes from file: %ls", sczDelete);
                         }
                     }
 
@@ -301,7 +301,7 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
                         }
                         else
                         {
-                            ExitWithLastError1(hr, "Failed to delete file: %ls", sczDelete);
+                            ExitWithLastError(hr, "Failed to delete file: %ls", sczDelete);
                         }
                     }
                 }
@@ -314,7 +314,7 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
             }
             else
             {
-                ExitWithLastError1(hr, "Failed while looping through files in directory: %ls", wzPath);
+                ExitWithLastError(hr, "Failed while looping through files in directory: %ls", wzPath);
             }
         }
 
@@ -329,13 +329,13 @@ extern "C" HRESULT DAPI DirEnsureDeleteEx(
                 }
             }
 
-            ExitOnRootFailure1(hr, "Failed to remove directory: %ls", wzPath);
+            ExitOnRootFailure(hr, "Failed to remove directory: %ls", wzPath);
         }
     }
     else
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "Directory delete cannot delete file: %ls", wzPath);
+        ExitOnFailure(hr, "Directory delete cannot delete file: %ls", wzPath);
     }
 
     Assert(S_OK == hr);
@@ -398,7 +398,7 @@ extern "C" HRESULT DAPI DirSetCurrent(
 
     if (!::SetCurrentDirectoryW(wzDirectory))
     {
-        ExitWithLastError1(hr, "Failed to set current directory to: %ls", wzDirectory);
+        ExitWithLastError(hr, "Failed to set current directory to: %ls", wzDirectory);
     }
 
 LExit:

--- a/src/libs/dutil/dutil.cpp
+++ b/src/libs/dutil/dutil.cpp
@@ -408,7 +408,7 @@ extern "C" void DAPI Dutil_RootFailure(
     UNREFERENCED_PARAMETER(hrError);
 #endif // DEBUG
 
-    TraceError2(hrError, "Root failure at %s:%d", szFile, iLine);
+    TraceError(hrError, "Root failure at %s:%d", szFile, iLine);
 }
 
 /*******************************************************************
@@ -457,10 +457,10 @@ extern "C" HRESULT DAPI LoadSystemLibraryWithPath(
     }
 
     hr = ::StringCchCatW(wzPath, MAX_PATH, wzModuleName);
-    ExitOnRootFailure1(hr, "Failed to create the fully-qualified path to %ls.", wzModuleName);
+    ExitOnRootFailure(hr, "Failed to create the fully-qualified path to %ls.", wzModuleName);
 
     *phModule = ::LoadLibraryW(wzPath);
-    ExitOnNullWithLastError1(*phModule, hr, "Failed to load the library %ls.", wzModuleName);
+    ExitOnNullWithLastError(*phModule, hr, "Failed to load the library %ls.", wzModuleName);
 
     if (psczPath)
     {

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -79,7 +79,7 @@ extern "C" HRESULT DAPI FileResolvePath(
     cch = ::ExpandEnvironmentStringsW(wzRelativePath, pwzExpandedPath, cchExpandedPath);
     if (0 == cch)
     {
-        ExitWithLastError1(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
+        ExitWithLastError(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
     }
     else if (cchExpandedPath < cch)
     {
@@ -90,7 +90,7 @@ extern "C" HRESULT DAPI FileResolvePath(
         cch = ::ExpandEnvironmentStringsW(wzRelativePath, pwzExpandedPath, cchExpandedPath);
         if (0 == cch)
         {
-            ExitWithLastError1(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
+            ExitWithLastError(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
         }
         else if (cchExpandedPath < cch)
         {
@@ -109,7 +109,7 @@ extern "C" HRESULT DAPI FileResolvePath(
     cch = ::GetFullPathNameW(pwzExpandedPath, cchFullPath, pwzFullPath, &wzFileName);
     if (0 == cch)
     {
-        ExitWithLastError1(hr, "Failed to get full path for string: %ls", pwzExpandedPath);
+        ExitWithLastError(hr, "Failed to get full path for string: %ls", pwzExpandedPath);
     }
     else if (cchFullPath < cch)
     {
@@ -120,7 +120,7 @@ extern "C" HRESULT DAPI FileResolvePath(
         cch = ::GetFullPathNameW(pwzExpandedPath, cchFullPath, pwzFullPath, &wzFileName);
         if (0 == cch)
         {
-            ExitWithLastError1(hr, "Failed to get full path for string: %ls", pwzExpandedPath);
+            ExitWithLastError(hr, "Failed to get full path for string: %ls", pwzExpandedPath);
         }
         else if (cchFullPath < cch)
         {
@@ -176,7 +176,7 @@ __out LPWSTR *ppwzFileNameNoExtension
     if (0 != err)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "failed to parse filename: %ls", wzFileName);
+        ExitOnFailure(hr, "failed to parse filename: %ls", wzFileName);
     }
    
     *ppwzFileNameNoExtension = pwzFileNameNoExtension;
@@ -204,7 +204,7 @@ extern "C" HRESULT DAPI FileChangeExtension(
     LPWSTR sczFileName = NULL;
 
     hr = FileStripExtension(wzFileName, &sczFileName);
-    ExitOnFailure1(hr, "Failed to strip extension from file name: %ls", wzFileName);
+    ExitOnFailure(hr, "Failed to strip extension from file name: %ls", wzFileName);
 
     hr = StrAllocConcat(&sczFileName, wzNewExtension, 0);
     ExitOnFailure(hr, "Failed to add new extension.");
@@ -285,20 +285,20 @@ extern "C" HRESULT DAPI FileVersion(
 
     if (0 == (cbVerBuffer = ::GetFileVersionInfoSizeW(wzFilename, &dwHandle)))
     {
-        ExitOnLastErrorDebugTrace1(hr, "failed to get version info for file: %ls", wzFilename);
+        ExitOnLastErrorDebugTrace(hr, "failed to get version info for file: %ls", wzFilename);
     }
 
     pVerBuffer = ::GlobalAlloc(GMEM_FIXED, cbVerBuffer);
-    ExitOnNullDebugTrace1(pVerBuffer, hr, E_OUTOFMEMORY, "failed to allocate version info for file: %ls", wzFilename);
+    ExitOnNullDebugTrace(pVerBuffer, hr, E_OUTOFMEMORY, "failed to allocate version info for file: %ls", wzFilename);
 
     if (!::GetFileVersionInfoW(wzFilename, dwHandle, cbVerBuffer, pVerBuffer))
     {
-        ExitOnLastErrorDebugTrace1(hr, "failed to get version info for file: %ls", wzFilename);
+        ExitOnLastErrorDebugTrace(hr, "failed to get version info for file: %ls", wzFilename);
     }
 
     if (!::VerQueryValueW(pVerBuffer, L"\\", (void**)&pvsFileInfo, &cbFileInfo))
     {
-        ExitOnLastErrorDebugTrace1(hr, "failed to get version value for file: %ls", wzFilename);
+        ExitOnLastErrorDebugTrace(hr, "failed to get version value for file: %ls", wzFilename);
     }
 
     *pdwVerMajor = pvsFileInfo->dwFileVersionMS;
@@ -560,11 +560,11 @@ extern "C" HRESULT DAPI FileSize(
     hFile = ::CreateFileW(pwzFileName, FILE_READ_ATTRIBUTES, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to open file %ls while checking file size", pwzFileName);
+        ExitWithLastError(hr, "Failed to open file %ls while checking file size", pwzFileName);
     }
 
     hr = FileSizeByHandle(hFile, pllSize);
-    ExitOnFailure1(hr, "Failed to check size of file %ls by handle", pwzFileName);
+    ExitOnFailure(hr, "Failed to check size of file %ls by handle", pwzFileName);
 
 LExit:
     ReleaseFileHandle(hFile);
@@ -884,12 +884,12 @@ extern "C" HRESULT DAPI FileReadPartialEx(
         {
             ExitFunction1(hr = E_FILENOTFOUND);
         }
-        ExitOnWin32Error1(er, hr, "Failed to open file: %ls", wzSrcPath);
+        ExitOnWin32Error(er, hr, "Failed to open file: %ls", wzSrcPath);
     }
 
     if (!::GetFileSizeEx(hFile, &liFileSize))
     {
-        ExitWithLastError1(hr, "Failed to get size of file: %ls", wzSrcPath);
+        ExitWithLastError(hr, "Failed to get size of file: %ls", wzSrcPath);
     }
 
     if (fSeek)
@@ -897,13 +897,13 @@ extern "C" HRESULT DAPI FileReadPartialEx(
         if (cbStartPosition > liFileSize.QuadPart)
         {
             hr = E_INVALIDARG;
-            ExitOnFailure3(hr, "Start position %d bigger than file '%ls' size %d", cbStartPosition, wzSrcPath, liFileSize.QuadPart);
+            ExitOnFailure(hr, "Start position %d bigger than file '%ls' size %d", cbStartPosition, wzSrcPath, liFileSize.QuadPart);
         }
 
         DWORD dwErr = ::SetFilePointer(hFile, cbStartPosition, NULL, FILE_CURRENT);
         if (INVALID_SET_FILE_POINTER == dwErr)
         {
-            ExitOnLastError1(hr, "Failed to seek position %d", cbStartPosition);
+            ExitOnLastError(hr, "Failed to seek position %d", cbStartPosition);
         }
     }
     else
@@ -921,7 +921,7 @@ extern "C" HRESULT DAPI FileReadPartialEx(
         if (cbMaxRead < liFileSize.QuadPart - cbStartPosition)
         {
             hr = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
-            ExitOnRootFailure1(hr, "Failed to load file: %ls, too large.", wzSrcPath);
+            ExitOnRootFailure(hr, "Failed to load file: %ls, too large.", wzSrcPath);
         }
     }
 
@@ -935,7 +935,7 @@ extern "C" HRESULT DAPI FileReadPartialEx(
         }
 
         LPVOID pv = MemReAlloc(*ppbDest, cbData, TRUE);
-        ExitOnNull1(pv, hr, E_OUTOFMEMORY, "Failed to re-allocate memory to read in file: %ls", wzSrcPath);
+        ExitOnNull(pv, hr, E_OUTOFMEMORY, "Failed to re-allocate memory to read in file: %ls", wzSrcPath);
 
         pbData = static_cast<BYTE*>(pv);
     }
@@ -948,7 +948,7 @@ extern "C" HRESULT DAPI FileReadPartialEx(
         }
 
         pbData = static_cast<BYTE*>(MemAlloc(cbData, TRUE));
-        ExitOnNull1(pbData, hr, E_OUTOFMEMORY, "Failed to allocate memory to read in file: %ls", wzSrcPath);
+        ExitOnNull(pbData, hr, E_OUTOFMEMORY, "Failed to allocate memory to read in file: %ls", wzSrcPath);
     }
 
     DWORD cbTotalRead = 0;
@@ -961,7 +961,7 @@ extern "C" HRESULT DAPI FileReadPartialEx(
 
         if (!::ReadFile(hFile, pbData + cbTotalRead, cbRemaining, &cbRead, NULL))
         {
-            ExitWithLastError1(hr, "Failed to read from file: %ls", wzSrcPath);
+            ExitWithLastError(hr, "Failed to read from file: %ls", wzSrcPath);
         }
 
         cbTotalRead += cbRead;
@@ -970,7 +970,7 @@ extern "C" HRESULT DAPI FileReadPartialEx(
     if (cbTotalRead != cbData)
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "Failed to completely read file: %ls", wzSrcPath);
+        ExitOnFailure(hr, "Failed to completely read file: %ls", wzSrcPath);
     }
 
     *ppbDest = pbData;
@@ -1002,10 +1002,10 @@ extern "C" HRESULT DAPI FileWrite(
 
     // Open the file
     hFile = ::CreateFileW(pwzFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, dwFlagsAndAttributes, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file: %ls", pwzFileName);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "Failed to open file: %ls", pwzFileName);
 
     hr = FileWriteHandle(hFile, pbData, cbData);
-    ExitOnFailure1(hr, "Failed to write to file: %ls", pwzFileName);
+    ExitOnFailure(hr, "Failed to write to file: %ls", pwzFileName);
 
     if (pHandle)
     {
@@ -1135,12 +1135,12 @@ extern "C" HRESULT DAPI FileEnsureCopy(
             *pwzLastSlash = L'\0'; // null terminate
             hr = DirEnsureExists(wzTarget, NULL);
             *pwzLastSlash = L'\\'; // now put the slash back
-            ExitOnFailureDebugTrace2(hr, "failed to create directory while copying file: '%ls' to: '%ls'", wzSource, wzTarget);
+            ExitOnFailureDebugTrace(hr, "failed to create directory while copying file: '%ls' to: '%ls'", wzSource, wzTarget);
 
             // try to copy again
             if (!::CopyFileW(wzSource, wzTarget, fOverwrite))
             {
-                ExitOnLastErrorDebugTrace2(hr, "failed to copy file: '%ls' to: '%ls'", wzSource, wzTarget);
+                ExitOnLastErrorDebugTrace(hr, "failed to copy file: '%ls' to: '%ls'", wzSource, wzTarget);
             }
         }
         else // no path was specified so just return the error
@@ -1189,7 +1189,7 @@ extern "C" HRESULT DAPI FileEnsureCopyWithRetry(
             break; // no reason to retry these errors.
         }
     }
-    ExitOnFailure3(hr, "Failed to copy file: '%ls' to: '%ls' after %u retries.", wzSource, wzTarget, i);
+    ExitOnFailure(hr, "Failed to copy file: '%ls' to: '%ls' after %u retries.", wzSource, wzTarget, i);
 
 LExit:
     return hr;
@@ -1263,12 +1263,12 @@ extern "C" HRESULT DAPI FileEnsureMove(
             *pwzLastSlash = L'\0'; // null terminate
             hr = DirEnsureExists(wzTarget, NULL);
             *pwzLastSlash = L'\\'; // now put the slash back
-            ExitOnFailureDebugTrace2(hr, "failed to create directory while moving file: '%ls' to: '%ls'", wzSource, wzTarget);
+            ExitOnFailureDebugTrace(hr, "failed to create directory while moving file: '%ls' to: '%ls'", wzSource, wzTarget);
 
             // try to move again
             if (!::MoveFileExW(wzSource, wzTarget, dwFlags))
             {
-                ExitOnLastErrorDebugTrace2(hr, "failed to move file: '%ls' to: '%ls'", wzSource, wzTarget);
+                ExitOnLastErrorDebugTrace(hr, "failed to move file: '%ls' to: '%ls'", wzSource, wzTarget);
             }
         }
         else // no path was specified so just return the error
@@ -1313,7 +1313,7 @@ extern "C" HRESULT DAPI FileEnsureMoveWithRetry(
 
         hr = FileEnsureMove(wzSource, wzTarget, fOverwrite, fAllowCopy);
     }
-    ExitOnFailure3(hr, "Failed to move file: '%ls' to: '%ls' after %u retries.", wzSource, wzTarget, i);
+    ExitOnFailure(hr, "Failed to move file: '%ls' to: '%ls' after %u retries.", wzSource, wzTarget, i);
 
 LExit:
     return hr;
@@ -1361,7 +1361,7 @@ extern "C" HRESULT DAPI FileCreateTemp(
                 hr = S_OK;
                 continue;
             }
-            ExitOnFailureDebugTrace1(hr, "failed to create file: %ls", pszTempFile);
+            ExitOnFailureDebugTrace(hr, "failed to create file: %ls", pszTempFile);
         }
     }
 
@@ -1426,7 +1426,7 @@ extern "C" HRESULT DAPI FileCreateTempW(
                 hr = S_OK;
                 continue;
             }
-            ExitOnFailureDebugTrace1(hr, "failed to create file: %ls", pwzTempFile);
+            ExitOnFailureDebugTrace(hr, "failed to create file: %ls", pwzTempFile);
         }
     }
 
@@ -1467,19 +1467,19 @@ extern "C" HRESULT DAPI FileIsSame(
     BY_HANDLE_FILE_INFORMATION fileInfo2 = { };
 
     hFile1 = ::CreateFileW(wzFile1, FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile1, hr, "Failed to open file 1. File = '%ls'", wzFile1);
+    ExitOnInvalidHandleWithLastError(hFile1, hr, "Failed to open file 1. File = '%ls'", wzFile1);
 
     hFile2 = ::CreateFileW(wzFile2, FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile2, hr, "Failed to open file 2. File = '%ls'", wzFile2);
+    ExitOnInvalidHandleWithLastError(hFile2, hr, "Failed to open file 2. File = '%ls'", wzFile2);
 
     if (!::GetFileInformationByHandle(hFile1, &fileInfo1))
     {
-        ExitWithLastError1(hr, "Failed to get information for file 1. File = '%ls'", wzFile1);
+        ExitWithLastError(hr, "Failed to get information for file 1. File = '%ls'", wzFile1);
     }
 
     if (!::GetFileInformationByHandle(hFile2, &fileInfo2))
     {
-        ExitWithLastError1(hr, "Failed to get information for file 2. File = '%ls'", wzFile2);
+        ExitWithLastError(hr, "Failed to get information for file 2. File = '%ls'", wzFile2);
     }
 
     *lpfSameFile = fileInfo1.dwVolumeSerialNumber == fileInfo2.dwVolumeSerialNumber &&
@@ -1510,13 +1510,13 @@ extern "C" HRESULT DAPI FileEnsureDelete(
         {
             if (!::SetFileAttributesW(wzFile, FILE_ATTRIBUTE_NORMAL))
             {
-                ExitOnLastError1(hr, "Failed to remove attributes from file: %ls", wzFile);
+                ExitOnLastError(hr, "Failed to remove attributes from file: %ls", wzFile);
             }
         }
 
         if (!::DeleteFileW(wzFile))
         {
-            ExitOnLastError1(hr, "Failed to delete file: %ls", wzFile);
+            ExitOnLastError(hr, "Failed to delete file: %ls", wzFile);
         }
     }
 
@@ -1538,11 +1538,11 @@ extern "C" HRESULT DAPI FileGetTime(
     HANDLE hFile = NULL;
 
     hFile = ::CreateFileW(wzFile, FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
 
     if (!::GetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime))
     {
-        ExitWithLastError1(hr, "Failed to get file time for file. File = '%ls'", wzFile);
+        ExitWithLastError(hr, "Failed to get file time for file. File = '%ls'", wzFile);
     }
 
 LExit:
@@ -1564,11 +1564,11 @@ extern "C" HRESULT DAPI FileSetTime(
     HANDLE hFile = NULL;
 
     hFile = ::CreateFileW(wzFile, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, 0, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
 
     if (!::SetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime))
     {
-        ExitWithLastError1(hr, "Failed to set file time for file. File = '%ls'", wzFile);
+        ExitWithLastError(hr, "Failed to set file time for file. File = '%ls'", wzFile);
     }
 
 LExit:
@@ -1589,16 +1589,16 @@ extern "C" HRESULT DAPI FileResetTime(
     FILETIME ftCreateTime;
 
     hFile = ::CreateFileW(wzFile, FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
-    ExitOnInvalidHandleWithLastError1(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
+    ExitOnInvalidHandleWithLastError(hFile, hr, "Failed to open file. File = '%ls'", wzFile);
     
     if (!::GetFileTime(hFile, &ftCreateTime, NULL, NULL))
     {
-        ExitWithLastError1(hr, "Failed to get file time for file. File = '%ls'", wzFile);
+        ExitWithLastError(hr, "Failed to get file time for file. File = '%ls'", wzFile);
     }
 
     if (!::SetFileTime(hFile, NULL, NULL, &ftCreateTime))
     {
-        ExitWithLastError1(hr, "Failed to reset file time for file. File = '%ls'", wzFile);
+        ExitWithLastError(hr, "Failed to reset file time for file. File = '%ls'", wzFile);
     }
 
 LExit:
@@ -1626,34 +1626,34 @@ extern "C" HRESULT DAPI FileExecutableArchitecture(
     hFile = ::CreateFileW(wzFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     if (hFile == INVALID_HANDLE_VALUE)
     {
-        ExitWithLastError1(hr, "Failed to open file: %ls", wzFile);
+        ExitWithLastError(hr, "Failed to open file: %ls", wzFile);
     }
 
     if (!::ReadFile(hFile, &DosImageHeader, sizeof(DosImageHeader), &cbRead, NULL))
     {
-        ExitWithLastError1(hr, "Failed to read DOS header from file: %ls", wzFile);
+        ExitWithLastError(hr, "Failed to read DOS header from file: %ls", wzFile);
     }
 
     if (DosImageHeader.e_magic != IMAGE_DOS_SIGNATURE)
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-        ExitOnRootFailure1(hr, "Read invalid DOS header from file: %ls", wzFile);
+        ExitOnRootFailure(hr, "Read invalid DOS header from file: %ls", wzFile);
     }
 
     if (INVALID_SET_FILE_POINTER == ::SetFilePointer(hFile, DosImageHeader.e_lfanew, NULL, FILE_BEGIN))
     {
-        ExitWithLastError1(hr, "Failed to seek the NT header in file: %ls", wzFile);
+        ExitWithLastError(hr, "Failed to seek the NT header in file: %ls", wzFile);
     }
 
     if (!::ReadFile(hFile, &NtImageHeader, sizeof(NtImageHeader), &cbRead, NULL))
     {
-        ExitWithLastError1(hr, "Failed to read NT header from file: %ls", wzFile);
+        ExitWithLastError(hr, "Failed to read NT header from file: %ls", wzFile);
     }
 
     if (NtImageHeader.Signature != IMAGE_NT_SIGNATURE)
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
-        ExitOnRootFailure1(hr, "Read invalid NT header from file: %ls", wzFile);
+        ExitOnRootFailure(hr, "Read invalid NT header from file: %ls", wzFile);
     }
 
     if (IMAGE_SUBSYSTEM_NATIVE == NtImageHeader.OptionalHeader.Subsystem ||
@@ -1680,7 +1680,7 @@ extern "C" HRESULT DAPI FileExecutableArchitecture(
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
     }
-    ExitOnFailure3(hr, "Unexpected subsystem: %d machine type: %d specified in NT header from file: %ls", NtImageHeader.OptionalHeader.Subsystem, NtImageHeader.FileHeader.Machine, wzFile);
+    ExitOnFailure(hr, "Unexpected subsystem: %d machine type: %d specified in NT header from file: %ls", NtImageHeader.OptionalHeader.Subsystem, NtImageHeader.FileHeader.Machine, wzFile);
 
 LExit:
     if (hFile != INVALID_HANDLE_VALUE)
@@ -1710,7 +1710,7 @@ extern "C" HRESULT DAPI FileToString(
 
     // Check if the file is ANSI
     hr = FileRead(&pbFullFileBuffer, &cbFullFileBuffer, wzFile);
-    ExitOnFailure1(hr, "Failed to read file: %ls", wzFile);
+    ExitOnFailure(hr, "Failed to read file: %ls", wzFile);
 
     if (0 == cbFullFileBuffer)
     {
@@ -1727,7 +1727,7 @@ extern "C" HRESULT DAPI FileToString(
         }
 
         hr = StrAllocStringAnsi(&sczFileText, reinterpret_cast<LPCSTR>(pbFullFileBuffer + 3), cbFullFileBuffer - 3, CP_UTF8);
-        ExitOnFailure1(hr, "Failed to convert file %ls from UTF-8 as its BOM indicated", wzFile);
+        ExitOnFailure(hr, "Failed to convert file %ls from UTF-8 as its BOM indicated", wzFile);
 
         *psczString = sczFileText;
         sczFileText = NULL;
@@ -1767,7 +1767,7 @@ extern "C" HRESULT DAPI FileToString(
             {
                 if (E_OUTOFMEMORY == hr)
                 {
-                    ExitOnFailure1(hr, "Failed to convert file %ls from UTF-8", wzFile);
+                    ExitOnFailure(hr, "Failed to convert file %ls from UTF-8", wzFile);
                 }
             }
             else
@@ -1855,7 +1855,7 @@ extern "C" HRESULT DAPI FileFromString(
     }
 
     hr = FileWrite(wzFile, dwFlagsAndAttributes, pcbFullFileBuffer, cbFullFileBuffer, NULL);
-    ExitOnFailure1(hr, "Failed to write file from string to: %ls", wzFile);
+    ExitOnFailure(hr, "Failed to write file from string to: %ls", wzFile);
 
 LExit:
     ReleaseStr(sczUtf8String);

--- a/src/libs/dutil/gdiputil.cpp
+++ b/src/libs/dutil/gdiputil.cpp
@@ -105,7 +105,7 @@ extern "C" HRESULT DAPI GdipBitmapFromFile(
     ExitOnNull(pBitmap, hr, E_OUTOFMEMORY, "Failed to allocate bitmap from file.");
 
     gs = pBitmap->GetLastStatus();
-    ExitOnGdipFailure1(gs, hr, "Failed to load bitmap from file: %ls", wzFileName);
+    ExitOnGdipFailure(gs, hr, "Failed to load bitmap from file: %ls", wzFileName);
 
     *ppBitmap = pBitmap;
     pBitmap = NULL;

--- a/src/libs/dutil/iis7util.cpp
+++ b/src/libs/dutil/iis7util.cpp
@@ -30,10 +30,10 @@ extern "C" HRESULT DAPI Iis7PutPropertyVariant(
     ExitOnNull(bstrPropName, hr, E_OUTOFMEMORY, "failed SysAllocString");
 
     hr = pElement->GetPropertyByName(bstrPropName, &pProperty);
-    ExitOnFailure1(hr, "Failed to get property object for %ls", wzPropName);
+    ExitOnFailure(hr, "Failed to get property object for %ls", wzPropName);
 
     hr = pProperty->put_Value(vtPut);
-    ExitOnFailure1(hr, "Failed to set property value for %ls", wzPropName);
+    ExitOnFailure(hr, "Failed to set property value for %ls", wzPropName);
 
 LExit:
     ReleaseBSTR(bstrPropName);
@@ -106,10 +106,10 @@ extern "C" HRESULT DAPI Iis7GetPropertyVariant(
     ExitOnNull(bstrPropName, hr, E_OUTOFMEMORY, "failed SysAllocString");
 
     hr = pElement->GetPropertyByName(bstrPropName, &pProperty);
-    ExitOnFailure1(hr, "Failed to get property object for %ls", wzPropName);
+    ExitOnFailure(hr, "Failed to get property object for %ls", wzPropName);
 
     hr = pProperty->get_Value(vtGet);
-    ExitOnFailure1(hr, "Failed to get property value for %ls", wzPropName);
+    ExitOnFailure(hr, "Failed to get property value for %ls", wzPropName);
 
 LExit:
     ReleaseBSTR(bstrPropName);
@@ -130,12 +130,12 @@ extern "C" HRESULT DAPI Iis7GetPropertyString(
 
     ::VariantInit(&vtGet);
     hr = Iis7GetPropertyVariant(pElement, wzPropName, &vtGet);
-    ExitOnFailure1(hr, "Failed to get iis7 property variant with name: %ls", wzPropName);
+    ExitOnFailure(hr, "Failed to get iis7 property variant with name: %ls", wzPropName);
 
     if (!ISSTRINGVARIANT(vtGet.vt))
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "Tried to get property as a string, but type was %d instead.", vtGet.vt);
+        ExitOnFailure(hr, "Tried to get property as a string, but type was %d instead.", vtGet.vt);
     }
 
     hr = StrAllocString(psczGet, vtGet.bstrVal, 0);
@@ -209,13 +209,13 @@ BOOL CompareVariantPath(
     if (ISSTRINGVARIANT(pVariant1->vt))
     {
         hr = PathExpand(&wzValue1, pVariant1->bstrVal, PATH_EXPAND_ENVIRONMENT | PATH_EXPAND_FULLPATH);
-        ExitOnFailure1(hr, "Failed to expand path %ls", pVariant1->bstrVal);
+        ExitOnFailure(hr, "Failed to expand path %ls", pVariant1->bstrVal);
     }
 
     if (ISSTRINGVARIANT(pVariant2->vt))
     {
         hr = PathExpand(&wzValue2, pVariant2->bstrVal, PATH_EXPAND_ENVIRONMENT | PATH_EXPAND_FULLPATH);
-        ExitOnFailure1(hr, "Failed to expand path %ls", pVariant2->bstrVal);
+        ExitOnFailure(hr, "Failed to expand path %ls", pVariant2->bstrVal);
     }
 
     fEqual = CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, wzValue1, -1, wzValue2, -1);
@@ -260,7 +260,7 @@ extern "C" BOOL DAPI Iis7IsMatchingAppHostElement(
     }
 
     hr = Iis7GetPropertyVariant(pElement, pComparison->sczAttributeName, &vPropValue);
-    ExitOnFailure2(hr, "Failed to get value of %ls attribute of %ls element", pComparison->sczAttributeName, pComparison->sczElementName);
+    ExitOnFailure(hr, "Failed to get value of %ls attribute of %ls element", pComparison->sczAttributeName, pComparison->sczElementName);
 
     if (TRUE == pComparator(pComparison->pvAttributeValue, &vPropValue))
     {

--- a/src/libs/dutil/inc/conutil.h
+++ b/src/libs/dutil/inc/conutil.h
@@ -6,7 +6,7 @@
 //   The license and further copyright text can be found in the file
 //   LICENSE.TXT at the root directory of the distribution.
 // </copyright>
-// 
+//
 // <summary>
 //    Console helper functions.
 // </summary>
@@ -16,37 +16,15 @@
 extern "C" {
 #endif
 
-#define ConsoleExitOnFailure(x, c, f) if (FAILED(x)) { ConsoleWriteError(x, c, f); ExitTrace(x, f); goto LExit; }
-#define ConsoleExitOnFailure1(x, c, f, s) if (FAILED(x)) { ConsoleWriteError(x, c, f, s, NULL); ExitTrace1(x, f, s); goto LExit; }
-#define ConsoleExitOnFailure2(x, c, f, s, t) if (FAILED(x)) { ConsoleWriteError(x, c, f, s, t); ExitTrace2(x, f, s, t); goto LExit; }
-#define ConsoleExitOnFailure3(x, c, f, s, t, u) if (FAILED(x)) { ConsoleWriteError(x, c, f, s, t, u); ExitTrace3(x, f, s, t, u); goto LExit; }
-
-#define ConsoleExitOnLastError(x, c, f) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ConsoleWriteError(x, c, f); ExitTrace(x, f); goto LExit; } }
-#define ConsoleExitOnLastError1(x, c, f, s) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ConsoleWriteError(x, c, f, s, NULL); ExitTrace1(x, f, s); goto LExit; } }
-#define ConsoleExitOnLastError2(x, c, f, s, t) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ConsoleWriteError(x, c, f, s, t); ExitTrace2(x, f, s, t); goto LExit; } }
-#define ConsoleExitOnLastError3(x, c, f, s, t, u) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ConsoleWriteError(x, c, f, s, t, u); ExitTrace3(x, f, s, t, u); goto LExit; } }
-
-#define ConsoleExitOnNull(p, x, e, c, f) if (NULL == p) { x = e; ConsoleWriteError(x, c, f); ExitTrace(x, f); goto LExit; }
-#define ConsoleExitOnNull1(p, x, e, c, f, s) if (NULL == p) { x = e; ConsoleWriteError(x, c, f, s, NULL); ExitTrace1(x, f, s); goto LExit; }
-#define ConsoleExitOnNull2(p, x, e, c, f, s, t) if (NULL == p) { x = e; ConsoleWriteError(x, c, f, s, t); ExitTrace2(x, f, s, t); goto LExit; }
-#define ConsoleExitOnNull3(p, x, e, c, f, s, t, u) if (NULL == p) { x = e; ConsoleWriteError(x, c, f, s, t, u); ExitTrace2(x, f, s, t, u); goto LExit; }
+#define ConsoleExitOnFailure(x, c, f, ...) if (FAILED(x)) { ConsoleWriteError(x, c, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define ConsoleExitOnLastError(x, c, f, ...) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ConsoleWriteError(x, c, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; } }
+#define ConsoleExitOnNull(p, x, e, c, f, ...) if (NULL == p) { x = e; ConsoleWriteError(x, c, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
 
 
 // the following macros need to go away
-#define ConsoleTrace(l, f) { ConsoleWriteLine(CONSOLE_COLOR_NORMAL, f); Trace(l, f); }
-#define ConsoleTrace1(l, f, s) { ConsoleWriteLine(CONSOLE_COLOR_NORMAL, f, s); Trace1(l, f, s); }
-#define ConsoleTrace2(l, f, s, t) { ConsoleWriteLine(CONSOLE_COLOR_NORMAL, f, s, t); Trace2(l, f, s, t); }
-#define ConsoleTrace3(l, f, s, t, u) { ConsoleWriteLine(CONSOLE_COLOR_NORMAL, f, s, t, u); Trace3(l, f, s, t, u); }
-
-#define ConsoleWarning(f) { ConsoleWriteLine(CONSOLE_COLOR_YELLOW, f); Trace(REPORT_STANDARD, f); }
-#define ConsoleWarning1(f, s) { ConsoleWriteLine(CONSOLE_COLOR_YELLOW, f, s); Trace1(REPORT_STANDARD, f, s); }
-#define ConsoleWarning2(f, s, t) { ConsoleWriteLine(CONSOLE_COLOR_YELLOW, f, s, t); Trace2(REPORT_STANDARD, f, s, t); }
-#define ConsoleWarning3(f, s, t, u) { ConsoleWriteLine(CONSOLE_COLOR_YELLOW, f, s, t, u); Trace3(REPORT_STANDARD, f, s, t, u); }
-
-#define ConsoleError(x, f) { ConsoleWriteError(x, CONSOLE_COLOR_RED, f); TraceError(x, f); }
-#define ConsoleError1(x, f, s) { ConsoleWriteError(x, CONSOLE_COLOR_RED, f, s); TraceError1(x, f, s); }
-#define ConsoleError2(x, f, s, t) { ConsoleWriteError(x, CONSOLE_COLOR_RED, f, s, t); TraceError2(x, f, s, t); }
-#define ConsoleError3(x, f, s, t, u) { ConsoleWriteError(x, CONSOLE_COLOR_RED, f, s, t, u); TraceError3(x, f, s, t, u); }
+#define ConsoleTrace(l, f, ...) { ConsoleWriteLine(CONSOLE_COLOR_NORMAL, f, __VA_ARGS__); Trace(l, f, __VA_ARGS__); }
+#define ConsoleWarning(f, ...) { ConsoleWriteLine(CONSOLE_COLOR_YELLOW, f, __VA_ARGS__); Trace(REPORT_STANDARD, f, __VA_ARGS__); }
+#define ConsoleError(x, f, ...) { ConsoleWriteError(x, CONSOLE_COLOR_RED, f, __VA_ARGS__); TraceError(x, f, __VA_ARGS__); }
 
 
 // enums

--- a/src/libs/dutil/inc/dutil.h
+++ b/src/libs/dutil/inc/dutil.h
@@ -62,20 +62,9 @@ void DAPI Dutil_RootFailure(__in_z LPCSTR szFile, __in int iLine, __in HRESULT h
 
 #define TraceSetLevel(l, f) (void)Dutil_TraceSetLevel(l, f)
 #define TraceGetLevel() (REPORT_LEVEL)Dutil_TraceGetLevel()
-#define Trace(l, f) (void)Dutil_Trace(__FILE__, __LINE__, l, f, NULL)
-#define Trace1(l, f, s) (void)Dutil_Trace(__FILE__, __LINE__, l, f, s)
-#define Trace2(l, f, s, t) (void)Dutil_Trace(__FILE__, __LINE__, l, f, s, t)
-#define Trace3(l, f, s, t, u) (void)Dutil_Trace(__FILE__, __LINE__, l, f, s, t, u)
-
-#define TraceError(x, f) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_ERROR, x, f, NULL)
-#define TraceError1(x, f, s) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_ERROR, x, f, s)
-#define TraceError2(x, f, s, t) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_ERROR, x, f, s, t)
-#define TraceError3(x, f, s, t, u) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_ERROR, x, f, s, t, u)
-
-#define TraceErrorDebug(x, f) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_DEBUG, x, f, NULL)
-#define TraceErrorDebug1(x, f, s) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_DEBUG, x, f, s)
-#define TraceErrorDebug2(x, f, s, t) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_DEBUG, x, f, s, t)
-#define TraceErrorDebug3(x, f, s, t, u) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_DEBUG, x, f, s, t, u)
+#define Trace(l, f, ...) (void)Dutil_Trace(__FILE__, __LINE__, l, f, __VA_ARGS__)
+#define TraceError(x, f, ...) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_ERROR, x, f, __VA_ARGS__)
+#define TraceErrorDebug(x, f, ...) (void)Dutil_TraceError(__FILE__, __LINE__, REPORT_DEBUG, x, f, __VA_ARGS__)
 
 #else // !DEBUG
 
@@ -85,23 +74,23 @@ void DAPI Dutil_RootFailure(__in_z LPCSTR szFile, __in int iLine, __in HRESULT h
 #define AssertSz(f, sz)
 
 #define TraceSetLevel(l, f)
-#define Trace(l, f)
-#define Trace1(l, f, s)
-#define Trace2(l, f, s, t)
-#define Trace3(l, f, s, t, u)
-
-#define TraceError(x, f)
-#define TraceError1(x, f, s)
-#define TraceError2(x, f, s, t)
-#define TraceError3(x, f, s, t, u)
-
-#define TraceErrorDebug(x, f)
-#define TraceErrorDebug1(x, f, s)
-#define TraceErrorDebug2(x, f, s, t)
-#define TraceErrorDebug3(x, f, s, t, u)
+#define Trace(l, f, ...)
+#define TraceError(x, f, ...)
+#define TraceErrorDebug(x, f, ...)
 
 #endif // DEBUG
 
+#define Trace1 Trace
+#define Trace2 Trace
+#define Trace3 Trace
+
+#define TraceError1 TraceError
+#define TraceError2 TraceError
+#define TraceError3 TraceError
+
+#define TraceErrorDebug1 TraceErrorDebug
+#define TraceErrorDebug2 TraceErrorDebug
+#define TraceErrorDebug3 TraceErrorDebug
 
 // ExitTrace can be overriden
 #ifndef ExitTrace
@@ -123,50 +112,50 @@ void DAPI Dutil_RootFailure(__in_z LPCSTR szFile, __in int iLine, __in HRESULT h
 
 #define ExitFunctionWithLastError(x) { x = HRESULT_FROM_WIN32(::GetLastError()); goto LExit; }
 
-#define ExitOnLastError(x, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; } }
-#define ExitOnLastError1(x, f, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; } }
-#define ExitOnLastError2(x, f, s, t) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; } }
+#define ExitOnLastError(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; } }
+#define ExitOnLastError1 ExitOnLastError
+#define ExitOnLastError2 ExitOnLastError
 
-#define ExitOnLastErrorDebugTrace(x, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s); goto LExit; } }
-#define ExitOnLastErrorDebugTrace1(x, f, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug1(x, f, s); goto LExit; } }
-#define ExitOnLastErrorDebugTrace2(x, f, s, t) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug2(x, f, s, t); goto LExit; } }
+#define ExitOnLastErrorDebugTrace(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s, __VA_ARGS__); goto LExit; } }
+#define ExitOnLastErrorDebugTrace1 ExitOnLastErrorDebugTrace
+#define ExitOnLastErrorDebugTrace2 ExitOnLastErrorDebugTrace
 
-#define ExitWithLastError(x, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; }
-#define ExitWithLastError1(x, f, s) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
-#define ExitWithLastError2(x, f, s, t) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; }
-#define ExitWithLastError3(x, f, s, t, u) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace3(x, f, s, t, u); goto LExit; }
+#define ExitWithLastError(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
+#define ExitWithLastError1 ExitWithLastError
+#define ExitWithLastError2 ExitWithLastError
+#define ExitWithLastError3 ExitWithLastError
 
-#define ExitOnFailure(x, s)   if (FAILED(x)) { ExitTrace(x, s);  goto LExit; }
-#define ExitOnFailure1(x, f, s)   if (FAILED(x)) { ExitTrace1(x, f, s);  goto LExit; }
-#define ExitOnFailure2(x, f, s, t)   if (FAILED(x)) { ExitTrace2(x, f, s, t);  goto LExit; }
-#define ExitOnFailure3(x, f, s, t, u) if (FAILED(x)) { ExitTrace3(x, f, s, t, u);  goto LExit; }
+#define ExitOnFailure(x, s, ...)   if (FAILED(x)) { ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
+#define ExitOnFailure1 ExitOnFailure
+#define ExitOnFailure2 ExitOnFailure
+#define ExitOnFailure3 ExitOnFailure
 
-#define ExitOnRootFailure(x, s)   if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s);  goto LExit; }
-#define ExitOnRootFailure1(x, f, s)   if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s);  goto LExit; }
-#define ExitOnRootFailure2(x, f, s, t)   if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t);  goto LExit; }
-#define ExitOnRootFailure3(x, f, s, t, u) if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace3(x, f, s, t, u);  goto LExit; }
+#define ExitOnRootFailure(x, s, ...)   if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
+#define ExitOnRootFailure1 ExitOnRootFailure
+#define ExitOnRootFailure2 ExitOnRootFailure
+#define ExitOnRootFailure3 ExitOnRootFailure
 
-#define ExitOnFailureDebugTrace(x, s)   if (FAILED(x)) { TraceErrorDebug(x, s);  goto LExit; }
-#define ExitOnFailureDebugTrace1(x, f, s)   if (FAILED(x)) { TraceErrorDebug1(x, f, s);  goto LExit; }
-#define ExitOnFailureDebugTrace2(x, f, s, t)   if (FAILED(x)) { TraceErrorDebug2(x, f, s, t);  goto LExit; }
-#define ExitOnFailureDebugTrace3(x, f, s, t, u) if (FAILED(x)) { TraceErrorDebug3(x, f, s, t, u);  goto LExit; }
+#define ExitOnFailureDebugTrace(x, s, ...)   if (FAILED(x)) { TraceErrorDebug(x, s, __VA_ARGS__);  goto LExit; }
+#define ExitOnFailureDebugTrace1 ExitOnFailureDebugTrace
+#define ExitOnFailureDebugTrace2 ExitOnFailureDebugTrace
+#define ExitOnFailureDebugTrace3 ExitOnFailureDebugTrace
 
-#define ExitOnNull(p, x, e, s)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s);  goto LExit; }
-#define ExitOnNull1(p, x, e, f, s)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s);  goto LExit; }
-#define ExitOnNull2(p, x, e, f, s, t)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t);  goto LExit; }
+#define ExitOnNull(p, x, e, s, ...)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
+#define ExitOnNull1 ExitOnNull
+#define ExitOnNull2 ExitOnNull
 
-#define ExitOnNullWithLastError(p, x, s) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; }
-#define ExitOnNullWithLastError1(p, x, f, s) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
+#define ExitOnNullWithLastError(p, x, s, ...) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
+#define ExitOnNullWithLastError1 ExitOnNullWithLastError
 
-#define ExitOnNullDebugTrace(p, x, e, s)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s);  goto LExit; }
-#define ExitOnNullDebugTrace1(p, x, e, f, s)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug1(x, f, s);  goto LExit; }
+#define ExitOnNullDebugTrace(p, x, e, s, ...)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s, __VA_ARGS__);  goto LExit; }
+#define ExitOnNullDebugTrace1 ExitOnNullDebugTrace
 
-#define ExitOnInvalidHandleWithLastError(p, x, s) if (INVALID_HANDLE_VALUE == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; }
-#define ExitOnInvalidHandleWithLastError1(p, x, f, s) if (INVALID_HANDLE_VALUE == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
+#define ExitOnInvalidHandleWithLastError(p, x, s, ...) if (INVALID_HANDLE_VALUE == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
+#define ExitOnInvalidHandleWithLastError1 ExitOnInvalidHandleWithLastError
 
-#define ExitOnWin32Error(e, x, s) if (ERROR_SUCCESS != e) { x = HRESULT_FROM_WIN32(e); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; }
-#define ExitOnWin32Error1(e, x, f, s) if (ERROR_SUCCESS != e) { x = HRESULT_FROM_WIN32(e); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
-#define ExitOnWin32Error2(e, x, f, s, t) if (ERROR_SUCCESS != e) { x = HRESULT_FROM_WIN32(e); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; }
+#define ExitOnWin32Error(e, x, s, ...) if (ERROR_SUCCESS != e) { x = HRESULT_FROM_WIN32(e); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
+#define ExitOnWin32Error1 ExitOnWin32Error
+#define ExitOnWin32Error2 ExitOnWin32Error
 
 // release macros
 #define ReleaseObject(x) if (x) { x->Release(); }

--- a/src/libs/dutil/inc/dutil.h
+++ b/src/libs/dutil/inc/dutil.h
@@ -6,7 +6,7 @@
 //   The license and further copyright text can be found in the file
 //   LICENSE.TXT at the root directory of the distribution.
 // </copyright>
-// 
+//
 // <summary>
 //    Header for utility layer that provides standard support for asserts, exit macros
 // </summary>
@@ -80,30 +80,9 @@ void DAPI Dutil_RootFailure(__in_z LPCSTR szFile, __in int iLine, __in HRESULT h
 
 #endif // DEBUG
 
-#define Trace1 Trace
-#define Trace2 Trace
-#define Trace3 Trace
-
-#define TraceError1 TraceError
-#define TraceError2 TraceError
-#define TraceError3 TraceError
-
-#define TraceErrorDebug1 TraceErrorDebug
-#define TraceErrorDebug2 TraceErrorDebug
-#define TraceErrorDebug3 TraceErrorDebug
-
 // ExitTrace can be overriden
 #ifndef ExitTrace
 #define ExitTrace TraceError
-#endif
-#ifndef ExitTrace1
-#define ExitTrace1 TraceError1
-#endif
-#ifndef ExitTrace2
-#define ExitTrace2 TraceError2
-#endif
-#ifndef ExitTrace3
-#define ExitTrace3 TraceError3
 #endif
 
 // Exit macros
@@ -113,49 +92,16 @@ void DAPI Dutil_RootFailure(__in_z LPCSTR szFile, __in int iLine, __in HRESULT h
 #define ExitFunctionWithLastError(x) { x = HRESULT_FROM_WIN32(::GetLastError()); goto LExit; }
 
 #define ExitOnLastError(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; } }
-#define ExitOnLastError1 ExitOnLastError
-#define ExitOnLastError2 ExitOnLastError
-
 #define ExitOnLastErrorDebugTrace(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s, __VA_ARGS__); goto LExit; } }
-#define ExitOnLastErrorDebugTrace1 ExitOnLastErrorDebugTrace
-#define ExitOnLastErrorDebugTrace2 ExitOnLastErrorDebugTrace
-
 #define ExitWithLastError(x, s, ...) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
-#define ExitWithLastError1 ExitWithLastError
-#define ExitWithLastError2 ExitWithLastError
-#define ExitWithLastError3 ExitWithLastError
-
 #define ExitOnFailure(x, s, ...)   if (FAILED(x)) { ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
-#define ExitOnFailure1 ExitOnFailure
-#define ExitOnFailure2 ExitOnFailure
-#define ExitOnFailure3 ExitOnFailure
-
 #define ExitOnRootFailure(x, s, ...)   if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
-#define ExitOnRootFailure1 ExitOnRootFailure
-#define ExitOnRootFailure2 ExitOnRootFailure
-#define ExitOnRootFailure3 ExitOnRootFailure
-
 #define ExitOnFailureDebugTrace(x, s, ...)   if (FAILED(x)) { TraceErrorDebug(x, s, __VA_ARGS__);  goto LExit; }
-#define ExitOnFailureDebugTrace1 ExitOnFailureDebugTrace
-#define ExitOnFailureDebugTrace2 ExitOnFailureDebugTrace
-#define ExitOnFailureDebugTrace3 ExitOnFailureDebugTrace
-
 #define ExitOnNull(p, x, e, s, ...)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__);  goto LExit; }
-#define ExitOnNull1 ExitOnNull
-#define ExitOnNull2 ExitOnNull
-
 #define ExitOnNullWithLastError(p, x, s, ...) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
-#define ExitOnNullWithLastError1 ExitOnNullWithLastError
-
 #define ExitOnNullDebugTrace(p, x, e, s, ...)   if (NULL == p) { x = e; Dutil_RootFailure(__FILE__, __LINE__, x); TraceErrorDebug(x, s, __VA_ARGS__);  goto LExit; }
-#define ExitOnNullDebugTrace1 ExitOnNullDebugTrace
-
 #define ExitOnInvalidHandleWithLastError(p, x, s, ...) if (INVALID_HANDLE_VALUE == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
-#define ExitOnInvalidHandleWithLastError1 ExitOnInvalidHandleWithLastError
-
 #define ExitOnWin32Error(e, x, s, ...) if (ERROR_SUCCESS != e) { x = HRESULT_FROM_WIN32(e); if (!FAILED(x)) { x = E_FAIL; } Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; }
-#define ExitOnWin32Error1 ExitOnWin32Error
-#define ExitOnWin32Error2 ExitOnWin32Error
 
 // release macros
 #define ReleaseObject(x) if (x) { x->Release(); }

--- a/src/libs/dutil/inc/gdiputil.h
+++ b/src/libs/dutil/inc/gdiputil.h
@@ -13,9 +13,7 @@
 
 #pragma once
 
-#define ExitOnGdipFailure(g, x, s) { x = GdipHresultFromStatus(g); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s); goto LExit; } }
-#define ExitOnGdipFailure1(g, x, f, s) { x = GdipHresultFromStatus(g); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; } }
-#define ExitOnGdipFailure2(g, x, f, s, t) { x = GdipHresultFromStatus(g); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; } }
+#define ExitOnGdipFailure(g, x, s, ...) { x = GdipHresultFromStatus(g); if (FAILED(x)) { Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, s, __VA_ARGS__); goto LExit; } }
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/libs/dutil/inc/logutil.h
+++ b/src/libs/dutil/inc/logutil.h
@@ -17,14 +17,8 @@ extern "C" {
 #endif
 
 #define LogExitOnFailure(x, i, f, ...) if (FAILED(x)) { LogErrorId(x, i, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
-#define LogExitOnFailure1 LogExitOnFailure
-#define LogExitOnFailure2 LogExitOnFailure
-#define LogExitOnFailure3 LogExitOnFailure
 
 #define LogExitOnRootFailure(x, i, f, ...) if (FAILED(x)) { LogErrorId(x, i, __VA_ARGS__); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
-#define LogExitOnRootFailure1 LogExitOnRootFailure
-#define LogExitOnRootFailure2 LogExitOnRootFailure
-#define LogExitOnRootFailure3 LogExitOnRootFailure
 
 typedef HRESULT (DAPI *PFN_LOGSTRINGWORKRAW)(
     __in_z LPCSTR szString,

--- a/src/libs/dutil/inc/logutil.h
+++ b/src/libs/dutil/inc/logutil.h
@@ -16,15 +16,15 @@
 extern "C" {
 #endif
 
-#define LogExitOnFailure(x, i, f) if (FAILED(x)) { LogErrorId(x, i, NULL, NULL, NULL); ExitTrace(x, f); goto LExit; }
-#define LogExitOnFailure1(x, i, f, s) if (FAILED(x)) { LogErrorId(x, i, s, NULL, NULL); ExitTrace1(x, f, s); goto LExit; }
-#define LogExitOnFailure2(x, i, f, s, t) if (FAILED(x)) { LogErrorId(x, i, s, t, NULL); ExitTrace2(x, f, s, t); goto LExit; }
-#define LogExitOnFailure3(x, i, f, s, t, u) if (FAILED(x)) { LogErrorId(x, i, s, t, u); ExitTrace3(x, f, s, t, u); goto LExit; }
+#define LogExitOnFailure(x, i, f, ...) if (FAILED(x)) { LogErrorId(x, i, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define LogExitOnFailure1 LogExitOnFailure
+#define LogExitOnFailure2 LogExitOnFailure
+#define LogExitOnFailure3 LogExitOnFailure
 
-#define LogExitOnRootFailure(x, i, f) if (FAILED(x)) { LogErrorId(x, i, NULL, NULL, NULL); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f); goto LExit; }
-#define LogExitOnRootFailure1(x, i, f, s) if (FAILED(x)) { LogErrorId(x, i, s, NULL, NULL); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace1(x, f, s); goto LExit; }
-#define LogExitOnRootFailure2(x, i, f, s, t) if (FAILED(x)) { LogErrorId(x, i, s, t, NULL); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace2(x, f, s, t); goto LExit; }
-#define LogExitOnRootFailure3(x, i, f, s, t, u) if (FAILED(x)) { LogErrorId(x, i, s, t, u); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace3(x, f, s, t, u); goto LExit; }
+#define LogExitOnRootFailure(x, i, f, ...) if (FAILED(x)) { LogErrorId(x, i, __VA_ARGS__); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
+#define LogExitOnRootFailure1 LogExitOnRootFailure
+#define LogExitOnRootFailure2 LogExitOnRootFailure
+#define LogExitOnRootFailure3 LogExitOnRootFailure
 
 typedef HRESULT (DAPI *PFN_LOGSTRINGWORKRAW)(
     __in_z LPCSTR szString,
@@ -184,9 +184,9 @@ HRESULT DAPI LogErrorIdModule(
 inline HRESULT LogErrorId(
     __in HRESULT hrError,
     __in DWORD dwLogId,
-    __in_z_opt LPCWSTR wzString1,
-    __in_z_opt LPCWSTR wzString2,
-    __in_z_opt LPCWSTR wzString3
+    __in_z_opt LPCWSTR wzString1 = NULL,
+    __in_z_opt LPCWSTR wzString2 = NULL,
+    __in_z_opt LPCWSTR wzString3 = NULL
     )
 {
     return LogErrorIdModule(hrError, dwLogId, NULL, wzString1, wzString2, wzString3);

--- a/src/libs/dutil/iniutil.cpp
+++ b/src/libs/dutil/iniutil.cpp
@@ -105,7 +105,7 @@ extern "C" HRESULT DAPI IniSetOpenTag(
     if (wzOpenTagPrefix)
     {
         hr = StrAllocString(&pi->sczOpenTagPrefix, wzOpenTagPrefix, 0);
-        ExitOnFailure1(hr, "Failed to copy open tag prefix to ini struct: %ls", wzOpenTagPrefix);
+        ExitOnFailure(hr, "Failed to copy open tag prefix to ini struct: %ls", wzOpenTagPrefix);
     }
     else
     {
@@ -115,7 +115,7 @@ extern "C" HRESULT DAPI IniSetOpenTag(
     if (wzOpenTagPostfix)
     {
         hr = StrAllocString(&pi->sczOpenTagPostfix, wzOpenTagPostfix, 0);
-        ExitOnFailure1(hr, "Failed to copy open tag postfix to ini struct: %ls", wzOpenTagPostfix);
+        ExitOnFailure(hr, "Failed to copy open tag postfix to ini struct: %ls", wzOpenTagPostfix);
     }
     else
     {
@@ -139,7 +139,7 @@ extern "C" HRESULT DAPI IniSetValueStyle(
     if (wzValuePrefix)
     {
         hr = StrAllocString(&pi->sczValuePrefix, wzValuePrefix, 0);
-        ExitOnFailure1(hr, "Failed to copy value prefix to ini struct: %ls", wzValuePrefix);
+        ExitOnFailure(hr, "Failed to copy value prefix to ini struct: %ls", wzValuePrefix);
     }
     else
     {
@@ -149,7 +149,7 @@ extern "C" HRESULT DAPI IniSetValueStyle(
     if (wzValueSeparator)
     {
         hr = StrAllocString(&pi->sczValueSeparator, wzValueSeparator, 0);
-        ExitOnFailure1(hr, "Failed to copy value separator to ini struct: %ls", wzValueSeparator);
+        ExitOnFailure(hr, "Failed to copy value separator to ini struct: %ls", wzValueSeparator);
     }
     else
     {
@@ -194,7 +194,7 @@ extern "C" HRESULT DAPI IniSetCommentStyle(
     if (wzLinePrefix)
     {
         hr = StrAllocString(&pi->sczCommentLinePrefix, wzLinePrefix, 0);
-        ExitOnFailure1(hr, "Failed to copy comment line prefix to ini struct: %ls", wzLinePrefix);
+        ExitOnFailure(hr, "Failed to copy comment line prefix to ini struct: %ls", wzLinePrefix);
     }
     else
     {
@@ -235,10 +235,10 @@ extern "C" HRESULT DAPI IniParse(
     BOOL fValuePrefix = (NULL != pi->sczValuePrefix);
 
     hr = StrAllocString(&pi->sczPath, wzPath, 0);
-    ExitOnFailure1(hr, "Failed to copy path to ini struct: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to copy path to ini struct: %ls", wzPath);
 
     hr = FileToString(pi->sczPath, &sczContents, &pi->feEncoding);
-    ExitOnFailure1(hr, "Failed to convert file to string: %ls", pi->sczPath);
+    ExitOnFailure(hr, "Failed to convert file to string: %ls", pi->sczPath);
 
     if (pfeEncodingFound)
     {
@@ -333,7 +333,7 @@ extern "C" HRESULT DAPI IniParse(
         {
             // There is an section starting here, let's keep track of it and move on
             hr = StrAllocString(&sczCurrentSection, wzOpenTagPrefix + lstrlenW(pi->sczOpenTagPrefix), wzOpenTagPostfix - (wzOpenTagPrefix + lstrlenW(pi->sczOpenTagPrefix)));
-            ExitOnFailure2(hr, "Failed to record section name for line: %ls of INI file: %ls", pi->rgsczLines[i], pi->sczPath);
+            ExitOnFailure(hr, "Failed to record section name for line: %ls of INI file: %ls", pi->rgsczLines[i], pi->sczPath);
 
             // Sections will be calculated dynamically after any set operations, so don't include this in the list of lines to remember for output
             ReleaseNullStr(pi->rgsczLines[i]);
@@ -443,7 +443,7 @@ extern "C" HRESULT DAPI IniGetValue(
     if (NULL == pValue)
     {
         hr = E_NOTFOUND;
-        ExitOnFailure1(hr, "Failed to check for INI value: %ls", wzValueName);
+        ExitOnFailure(hr, "Failed to check for INI value: %ls", wzValueName);
     }
 
     if (NULL == pValue->wzValue)
@@ -452,7 +452,7 @@ extern "C" HRESULT DAPI IniGetValue(
     }
 
     hr = StrAllocString(psczValue, pValue->wzValue, 0);
-    ExitOnFailure1(hr, "Failed to make copy of value while looking up INI value named: %ls", wzValueName);
+    ExitOnFailure(hr, "Failed to make copy of value while looking up INI value named: %ls", wzValueName);
 
 LExit:
     return hr;
@@ -503,7 +503,7 @@ extern "C" HRESULT DAPI IniSetValue(
             {
                 pi->fModified = TRUE;
                 hr = StrAllocString(const_cast<LPWSTR *>(&pValue->wzValue), wzValue, 0);
-                ExitOnFailure1(hr, "Failed to update value INI value named: %ls", wzValueName);
+                ExitOnFailure(hr, "Failed to update value INI value named: %ls", wzValueName);
             }
 
             ExitFunction1(hr = S_OK);
@@ -513,7 +513,7 @@ extern "C" HRESULT DAPI IniSetValue(
             if (wzValueName)
             {
                 hr = GetSectionPrefixFromName(wzValueName, &sczSectionPrefix);
-                ExitOnFailure1(hr, "Failed to get section prefix from value name: %ls", wzValueName);
+                ExitOnFailure(hr, "Failed to get section prefix from value name: %ls", wzValueName);
             }
 
             // If we have a section prefix, figure out the index to insert it (at the end of the section it belongs in)
@@ -649,7 +649,7 @@ extern "C" HRESULT DAPI IniWriteFile(
 
         // First see if we need to write a section line
         hr = GetSectionPrefixFromName(pi->rgivValues[i].wzName, &sczNewSectionPrefix);
-        ExitOnFailure1(hr, "Failed to get section prefix from name: %ls", pi->rgivValues[i].wzName);
+        ExitOnFailure(hr, "Failed to get section prefix from name: %ls", pi->rgivValues[i].wzName);
 
         // If the new section prefix is different, write a section out for it
         if (fSections && sczNewSectionPrefix && (NULL == sczCurrentSectionPrefix || CSTR_EQUAL != ::CompareStringW(LOCALE_INVARIANT, 0, sczNewSectionPrefix, -1, sczCurrentSectionPrefix, -1)))
@@ -722,7 +722,7 @@ extern "C" HRESULT DAPI IniWriteFile(
     }
 
     hr = FileFromString(wzPath, 0, sczContents, feEncoding);
-    ExitOnFailure1(hr, "Failed to write INI contents out to file: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to write INI contents out to file: %ls", wzPath);
 
 LExit:
     ReleaseStr(sczContents);

--- a/src/libs/dutil/jsonutil.cpp
+++ b/src/libs/dutil/jsonutil.cpp
@@ -438,7 +438,7 @@ static HRESULT DoEnd(
             (JSON_TOKEN_OBJECT_END == tokenEnd && JSON_TOKEN_OBJECT_START != token && JSON_TOKEN_OBJECT_VALUE != token))
         {
             hr = E_UNEXPECTED;
-            ExitOnRootFailure1(hr, "Failure to pop token because the stack did not match the expected token: %d", tokenEnd);
+            ExitOnRootFailure(hr, "Failure to pop token because the stack did not match the expected token: %d", tokenEnd);
         }
     }
 

--- a/src/libs/dutil/logutil.cpp
+++ b/src/libs/dutil/logutil.cpp
@@ -132,12 +132,12 @@ extern "C" HRESULT DAPI LogOpen(
         ExitOnFailure(hr, "Failed to get log directory.");
 
         hr = DirEnsureExists(sczLogDirectory, NULL);
-        ExitOnFailure1(hr, "Failed to ensure log file directory exists: %ls", sczLogDirectory);
+        ExitOnFailure(hr, "Failed to ensure log file directory exists: %ls", sczLogDirectory);
 
         LogUtil_hLog = ::CreateFileW(LogUtil_sczLogPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, (fAppend) ? OPEN_ALWAYS : CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (INVALID_HANDLE_VALUE == LogUtil_hLog)
         {
-            ExitOnLastError1(hr, "failed to create log file: %ls", LogUtil_sczLogPath);
+            ExitOnLastError(hr, "failed to create log file: %ls", LogUtil_sczLogPath);
         }
 
         if (fAppend)
@@ -228,15 +228,15 @@ HRESULT DAPI LogRename(
     ReleaseFileHandle(LogUtil_hLog);
 
     hr = FileEnsureMove(LogUtil_sczLogPath, wzNewPath, TRUE, TRUE);
-    ExitOnFailure1(hr, "Failed to move logfile to new location: %ls", wzNewPath);
+    ExitOnFailure(hr, "Failed to move logfile to new location: %ls", wzNewPath);
 
     hr = StrAllocString(&LogUtil_sczLogPath, wzNewPath, 0);
-    ExitOnFailure1(hr, "Failed to store new logfile path: %ls", wzNewPath);
+    ExitOnFailure(hr, "Failed to store new logfile path: %ls", wzNewPath);
 
     LogUtil_hLog = ::CreateFileW(LogUtil_sczLogPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == LogUtil_hLog)
     {
-        ExitOnLastError1(hr, "failed to create log file: %ls", LogUtil_sczLogPath);
+        ExitOnLastError(hr, "failed to create log file: %ls", LogUtil_sczLogPath);
     }
 
     // Enable "append" mode by moving file pointer to the end
@@ -615,7 +615,7 @@ extern "C" HRESULT DAPI LogErrorStringArgs(
     // that the caller's "%s" is interpreted differently
     // (so callers should use %hs for LPSTR and %ls for LPWSTR)
     hr = StrAllocFormattedArgs(&sczMessage, sczFormat, args);
-    ExitOnFailure1(hr, "Failed to format error message: \"%ls\"", sczFormat);
+    ExitOnFailure(hr, "Failed to format error message: \"%ls\"", sczFormat);
 
     hr = LogLine(REPORT_ERROR, "Error 0x%x: %ls", hrError, sczMessage);
 
@@ -637,9 +637,9 @@ extern "C" HRESULT DAPI LogErrorIdModule(
     __in HRESULT hrError,
     __in DWORD dwLogId,
     __in_opt HMODULE hModule,
-    __in_z_opt LPCWSTR wzString1,
-    __in_z_opt LPCWSTR wzString2,
-    __in_z_opt LPCWSTR wzString3
+    __in_z_opt LPCWSTR wzString1 = NULL,
+    __in_z_opt LPCWSTR wzString2 = NULL,
+    __in_z_opt LPCWSTR wzString3 = NULL
     )
 {
     HRESULT hr = S_OK;
@@ -647,7 +647,7 @@ extern "C" HRESULT DAPI LogErrorIdModule(
     WORD cStrings = 1; // guaranteed wzError is in the list
 
     hr = ::StringCchPrintfW(wzError, countof(wzError), L"0x%08x", hrError);
-    ExitOnFailure1(hr, "failed to format error code: \"0%08x\"", hrError);
+    ExitOnFailure(hr, "failed to format error code: \"0%08x\"", hrError);
 
     cStrings += wzString1 ? 1 : 0;
     cStrings += wzString2 ? 1 : 0;
@@ -792,7 +792,7 @@ extern "C" HRESULT LogStringWorkRaw(
     {
         if (!::WriteFile(LogUtil_hLog, reinterpret_cast<const BYTE*>(szLogData) + cbTotal, cbLogData - cbTotal, &cbWrote, NULL))
         {
-            ExitOnLastError2(hr, "Failed to write output to log: %ls - %ls", LogUtil_sczLogPath, szLogData);
+            ExitOnLastError(hr, "Failed to write output to log: %ls - %ls", LogUtil_sczLogPath, szLogData);
         }
 
         cbTotal += cbWrote;
@@ -827,7 +827,7 @@ static HRESULT LogIdWork(
 
     if (0 == cch)
     {
-        ExitOnLastError1(hr, "failed to log id: %d", dwLogId);
+        ExitOnLastError(hr, "failed to log id: %d", dwLogId);
     }
 
     if (2 <= cch && L'\r' == pwz[cch-2] && L'\n' == pwz[cch-1])
@@ -865,10 +865,10 @@ static HRESULT LogStringWorkArgs(
 
     // format the string as a unicode string
     hr = StrAllocFormattedArgs(&sczMessage, sczFormat, args);
-    ExitOnFailure1(hr, "Failed to format message: \"%ls\"", sczFormat);
+    ExitOnFailure(hr, "Failed to format message: \"%ls\"", sczFormat);
 
     hr = LogStringWork(rl, 0, sczMessage, fLOGUTIL_NEWLINE);
-    ExitOnFailure1(hr, "Failed to write formatted string to log:%ls", sczMessage);
+    ExitOnFailure(hr, "Failed to write formatted string to log:%ls", sczMessage);
 
 LExit:
     ReleaseStr(sczFormat);
@@ -932,12 +932,12 @@ static HRESULT LogStringWork(
     if (s_vpfLogStringWorkRaw)
     {
         hr = s_vpfLogStringWorkRaw(sczMultiByte, s_vpvLogStringWorkRawContext);
-        ExitOnFailure1(hr, "Failed to write string to log using redirected function: %ls", sczString);
+        ExitOnFailure(hr, "Failed to write string to log using redirected function: %ls", sczString);
     }
     else
     {
         hr = LogStringWorkRaw(sczMultiByte);
-        ExitOnFailure1(hr, "Failed to write string to log using default function: %ls", sczString);
+        ExitOnFailure(hr, "Failed to write string to log using default function: %ls", sczString);
     }
 
 LExit:

--- a/src/libs/dutil/metautil.cpp
+++ b/src/libs/dutil/metautil.cpp
@@ -122,7 +122,7 @@ extern "C" HRESULT DAPI MetaFindWebBase(
             {
                 // if the passed in buffer wasn't big enough
                 hr = ::StringCchCopyW(wzWebBase, cchWebBase, wzKey);
-                ExitOnFailure1(hr, "failed to copy in web base: %ls", wzKey);
+                ExitOnFailure(hr, "failed to copy in web base: %ls", wzKey);
 
                 fFound = TRUE;
                 break;

--- a/src/libs/dutil/pathutil.cpp
+++ b/src/libs/dutil/pathutil.cpp
@@ -239,7 +239,7 @@ DAPI_(HRESULT) PathExpand(
         cch = ::ExpandEnvironmentStringsW(wzRelativePath, sczExpandedPath, cchExpandedPath);
         if (0 == cch)
         {
-            ExitWithLastError1(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
+            ExitWithLastError(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
         }
         else if (cchExpandedPath < cch)
         {
@@ -250,7 +250,7 @@ DAPI_(HRESULT) PathExpand(
             cch = ::ExpandEnvironmentStringsW(wzRelativePath, sczExpandedPath, cchExpandedPath);
             if (0 == cch)
             {
-                ExitWithLastError1(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
+                ExitWithLastError(hr, "Failed to expand environment variables in string: %ls", wzRelativePath);
             }
             else if (cchExpandedPath < cch)
             {
@@ -288,7 +288,7 @@ DAPI_(HRESULT) PathExpand(
         cch = ::GetFullPathNameW(wzPath, cchFullPath, sczFullPath, &wzFileName);
         if (0 == cch)
         {
-            ExitWithLastError1(hr, "Failed to get full path for string: %ls", wzPath);
+            ExitWithLastError(hr, "Failed to get full path for string: %ls", wzPath);
         }
         else if (cchFullPath < cch)
         {
@@ -299,7 +299,7 @@ DAPI_(HRESULT) PathExpand(
             cch = ::GetFullPathNameW(wzPath, cchFullPath, sczFullPath, &wzFileName);
             if (0 == cch)
             {
-                ExitWithLastError1(hr, "Failed to get full path for string: %ls", wzPath);
+                ExitWithLastError(hr, "Failed to get full path for string: %ls", wzPath);
             }
             else if (cchFullPath < cch)
             {
@@ -366,7 +366,7 @@ DAPI_(HRESULT) PathPrefix(
     else
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Invalid path provided to prefix: %ls.", wzFullPath);
+        ExitOnFailure(hr, "Invalid path provided to prefix: %ls.", wzFullPath);
     }
 
 LExit:
@@ -539,7 +539,7 @@ DAPI_(HRESULT) PathCreateTempFile(
                 {
                     hr = S_OK;
                 }
-                ExitOnFailure1(hr, "Failed to create file: %ls", sczTempFile);
+                ExitOnFailure(hr, "Failed to create file: %ls", sczTempFile);
             }
         }
     }
@@ -559,7 +559,7 @@ DAPI_(HRESULT) PathCreateTempFile(
         hTempFile = ::CreateFileW(sczTempFile, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, dwFileAttributes, NULL);
         if (INVALID_HANDLE_VALUE == hTempFile)
         {
-            ExitWithLastError1(hr, "Failed to open new temp file: %ls", sczTempFile);
+            ExitWithLastError(hr, "Failed to open new temp file: %ls", sczTempFile);
         }
     }
 
@@ -629,7 +629,7 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
     if (S_OK == hr)
     {
         hr = DirEnsureExists(sczPrefixFolder, NULL);
-        ExitOnFailure1(hr, "Failed to ensure temp file path exists: %ls", sczPrefixFolder);
+        ExitOnFailure(hr, "Failed to ensure temp file path exists: %ls", sczPrefixFolder);
     }
 
     if (!wzPostfix)
@@ -661,7 +661,7 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
             }
 
             hr = HRESULT_FROM_WIN32(er);
-            ExitOnFailureDebugTrace1(hr, "Failed to create temp file: %ls", sczTempPath);
+            ExitOnFailureDebugTrace(hr, "Failed to create temp file: %ls", sczTempPath);
         }
     } while (fRetry);
 
@@ -710,7 +710,7 @@ DAPI_(HRESULT) PathCreateTempDirectory(
         ExitOnFailure(hr, "Failed to copy temp path.");
 
         hr = PathBackslashTerminate(&sczTempPath);
-        ExitOnFailure1(hr, "Failed to ensure path ends in backslash: %ls", wzDirectory);
+        ExitOnFailure(hr, "Failed to ensure path ends in backslash: %ls", wzDirectory);
     }
     else
     {
@@ -928,7 +928,7 @@ DAPI_(HRESULT) PathCompress(
     hPath = ::CreateFileW(wzPath, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (INVALID_HANDLE_VALUE == hPath)
     {
-        ExitWithLastError1(hr, "Failed to open path %ls for compression.", wzPath);
+        ExitWithLastError(hr, "Failed to open path %ls for compression.", wzPath);
     }
 
     DWORD dwBytesReturned = 0;
@@ -939,7 +939,7 @@ DAPI_(HRESULT) PathCompress(
         DWORD er = ::GetLastError();
         if (ERROR_INVALID_FUNCTION != er)
         {
-            ExitOnWin32Error1(er, hr, "Failed to set compression state for path %ls.", wzPath);
+            ExitOnWin32Error(er, hr, "Failed to set compression state for path %ls.", wzPath);
         }
     }
 
@@ -981,7 +981,7 @@ DAPI_(HRESULT) PathGetHierarchyArray(
     Assert(cArraySpacesNeeded >= 1);
 
     hr = MemEnsureArraySize(reinterpret_cast<void **>(prgsczPathArray), cArraySpacesNeeded, sizeof(LPWSTR), 0);
-    ExitOnFailure1(hr, "Failed to allocate array of size %u for parent directories", cArraySpacesNeeded);
+    ExitOnFailure(hr, "Failed to allocate array of size %u for parent directories", cArraySpacesNeeded);
     *pcPathArray = cArraySpacesNeeded;
 
     hr = StrAllocString(&sczPathCopy, wzPath, 0);

--- a/src/libs/dutil/polcutil.cpp
+++ b/src/libs/dutil/polcutil.cpp
@@ -36,14 +36,14 @@ extern "C" HRESULT DAPI PolcReadNumber(
     {
         ExitFunction1(hr = S_FALSE);
     }
-    ExitOnFailure1(hr, "Failed to open policy key: %ls", wzPolicyPath);
+    ExitOnFailure(hr, "Failed to open policy key: %ls", wzPolicyPath);
 
     hr = RegReadNumber(hk, wzPolicyName, pdw);
     if (E_FILENOTFOUND == hr || E_PATHNOTFOUND == hr)
     {
         ExitFunction1(hr = S_FALSE);
     }
-    ExitOnFailure2(hr, "Failed to open policy key: %ls, name: %ls", wzPolicyPath, wzPolicyName);
+    ExitOnFailure(hr, "Failed to open policy key: %ls, name: %ls", wzPolicyPath, wzPolicyName);
 
 LExit:
     ReleaseRegKey(hk);
@@ -71,14 +71,14 @@ extern "C" HRESULT DAPI PolcReadString(
     {
         ExitFunction1(hr = S_FALSE);
     }
-    ExitOnFailure1(hr, "Failed to open policy key: %ls", wzPolicyPath);
+    ExitOnFailure(hr, "Failed to open policy key: %ls", wzPolicyPath);
 
     hr = RegReadString(hk, wzPolicyName, pscz);
     if (E_FILENOTFOUND == hr || E_PATHNOTFOUND == hr)
     {
         ExitFunction1(hr = S_FALSE);
     }
-    ExitOnFailure2(hr, "Failed to open policy key: %ls, name: %ls", wzPolicyPath, wzPolicyName);
+    ExitOnFailure(hr, "Failed to open policy key: %ls, name: %ls", wzPolicyPath, wzPolicyName);
 
 LExit:
     ReleaseRegKey(hk);

--- a/src/libs/dutil/proc3utl.cpp
+++ b/src/libs/dutil/proc3utl.cpp
@@ -49,7 +49,7 @@ extern "C" HRESULT DAPI ProcExecuteAsInteractiveUser(
     si.cb = sizeof(si);
     if (!::CreateProcessAsUserW(hToken, wzExecutablePath, sczFullCommandLine, NULL, NULL, FALSE, CREATE_UNICODE_ENVIRONMENT, pEnvironment, NULL, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to create UI process: %ls", sczFullCommandLine);
+        ExitWithLastError(hr, "Failed to create UI process: %ls", sczFullCommandLine);
     }
 
     *phProcess = pi.hProcess;

--- a/src/libs/dutil/procutil.cpp
+++ b/src/libs/dutil/procutil.cpp
@@ -166,7 +166,7 @@ extern "C" HRESULT DAPI ProcExec(
     si.wShowWindow = static_cast<WORD>(nCmdShow);
     if (!::CreateProcessW(wzExecutablePath, sczFullCommandLine, NULL, NULL, FALSE, 0, 0, NULL, &si, &pi))
     {
-        ExitWithLastError1(hr, "Failed to create process: %ls", sczFullCommandLine);
+        ExitWithLastError(hr, "Failed to create process: %ls", sczFullCommandLine);
     }
 
     *phProcess = pi.hProcess;

--- a/src/libs/dutil/regutil.cpp
+++ b/src/libs/dutil/regutil.cpp
@@ -207,7 +207,7 @@ extern "C" HRESULT DAPI RegDelete(
         {
             ExitFunction1(hr = S_OK);
         }
-        ExitOnFailure1(hr, "Failed to open this key for enumerating subkeys", wzSubKey);
+        ExitOnFailure(hr, "Failed to open this key for enumerating subkeys", wzSubKey);
 
         // Yes, keep enumerating the 0th item, because we're deleting it every time
         while (E_NOMOREITEMS != (hr = RegKeyEnum(hkKey, 0, &pszEnumeratedSubKey)))
@@ -215,10 +215,10 @@ extern "C" HRESULT DAPI RegDelete(
             ExitOnFailure(hr, "Failed to enumerate key 0");
             
             hr = PathConcat(wzSubKey, pszEnumeratedSubKey, &pszRecursiveSubKey);
-            ExitOnFailure2(hr, "Failed to concatenate paths while recursively deleting subkeys. Path1: %ls, Path2: %ls", wzSubKey, pszEnumeratedSubKey);
+            ExitOnFailure(hr, "Failed to concatenate paths while recursively deleting subkeys. Path1: %ls, Path2: %ls", wzSubKey, pszEnumeratedSubKey);
 
             hr = RegDelete(hkRoot, pszRecursiveSubKey, kbKeyBitness, fDeleteTree);
-            ExitOnFailure1(hr, "Failed to recursively delete subkey: %ls", pszRecursiveSubKey);
+            ExitOnFailure(hr, "Failed to recursively delete subkey: %ls", pszRecursiveSubKey);
         }
 
         hr = S_OK;
@@ -429,7 +429,7 @@ HRESULT DAPI RegReadBinary(
     else
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Error reading binary registry value due to unexpected data type: %u", dwType);
+        ExitOnRootFailure(hr, "Error reading binary registry value due to unexpected data type: %u", dwType);
     }
 
 LExit:
@@ -497,13 +497,13 @@ extern "C" HRESULT DAPI RegReadString(
             ExitOnFailure(hr, "Failed to copy registry value to expand.");
 
             hr = PathExpand(psczValue, sczExpand, PATH_EXPAND_ENVIRONMENT);
-            ExitOnFailure1(hr, "Failed to expand registry value: %ls", *psczValue);
+            ExitOnFailure(hr, "Failed to expand registry value: %ls", *psczValue);
         }
     }
     else
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Error reading string registry value due to unexpected data type: %u", dwType);
+        ExitOnRootFailure(hr, "Error reading string registry value due to unexpected data type: %u", dwType);
     }
 
 LExit:
@@ -551,13 +551,13 @@ HRESULT DAPI RegReadStringArray(
     if (cb / sizeof(WCHAR) != cch)
     {
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "The size of registry value %ls unexpected changed between 2 reads", wzName);
+        ExitOnFailure(hr, "The size of registry value %ls unexpected changed between 2 reads", wzName);
     }
 
     if (REG_MULTI_SZ != dwType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Tried to read string array, but registry value %ls is of an incorrect type", wzName);
+        ExitOnRootFailure(hr, "Tried to read string array, but registry value %ls is of an incorrect type", wzName);
     }
 
     // Value exists, but is empty, so no strings to return.
@@ -572,7 +572,7 @@ HRESULT DAPI RegReadStringArray(
     if (L'\0' != sczValue[cch-1] || L'\0' != sczValue[cch-2])
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Tried to read string array, but registry value %ls is invalid (isn't double-null-terminated)", wzName);
+        ExitOnFailure(hr, "Tried to read string array, but registry value %ls is invalid (isn't double-null-terminated)", wzName);
     }
 
     cch = cb / sizeof(WCHAR);
@@ -646,7 +646,7 @@ extern "C" HRESULT DAPI RegReadVersion(
     else // unexpected data type
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
+        ExitOnRootFailure(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
     }
 
 LExit:
@@ -681,7 +681,7 @@ extern "C" HRESULT DAPI RegReadNumber(
     if (REG_DWORD != dwType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
+        ExitOnRootFailure(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
     }
 
 LExit:
@@ -714,7 +714,7 @@ extern "C" HRESULT DAPI RegReadQword(
     if (REG_QWORD != dwType)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATATYPE);
-        ExitOnRootFailure1(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
+        ExitOnRootFailure(hr, "Error reading version registry value due to unexpected data type: %u", dwType);
     }
 
 LExit:
@@ -737,7 +737,7 @@ HRESULT DAPI RegWriteBinary(
     DWORD er = ERROR_SUCCESS;
 
     er = vpfnRegSetValueExW(hk, wzName, 0, REG_BINARY, pbBuffer, cbBuffer);
-    ExitOnWin32Error1(er, hr, "Failed to write binary registry value with name: %ls", wzName);
+    ExitOnWin32Error(er, hr, "Failed to write binary registry value with name: %ls", wzName);
 
 LExit:
     return hr;
@@ -762,10 +762,10 @@ extern "C" HRESULT DAPI RegWriteString(
     if (wzValue)
     {
         hr = ::StringCbLengthW(wzValue, DWORD_MAX, reinterpret_cast<size_t*>(&cbValue));
-        ExitOnFailure1(hr, "Failed to determine length of registry value: %ls", wzName);
+        ExitOnFailure(hr, "Failed to determine length of registry value: %ls", wzName);
 
         er = vpfnRegSetValueExW(hk, wzName, 0, REG_SZ, reinterpret_cast<const BYTE *>(wzValue), cbValue);
-        ExitOnWin32Error1(er, hr, "Failed to set registry value: %ls", wzName);
+        ExitOnWin32Error(er, hr, "Failed to set registry value: %ls", wzName);
     }
     else
     {
@@ -774,7 +774,7 @@ extern "C" HRESULT DAPI RegWriteString(
         {
             er = ERROR_SUCCESS;
         }
-        ExitOnWin32Error1(er, hr, "Failed to delete registry value: %ls", wzName);
+        ExitOnWin32Error(er, hr, "Failed to delete registry value: %ls", wzName);
     }
 
 LExit:
@@ -800,7 +800,7 @@ extern "C" HRESULT DAPI RegWriteStringFormatted(
     va_start(args, szFormat);
     hr = StrAllocFormattedArgs(&sczValue, szFormat, args);
     va_end(args);
-    ExitOnFailure1(hr, "Failed to allocate %ls value.", wzName);
+    ExitOnFailure(hr, "Failed to allocate %ls value.", wzName);
 
     hr = RegWriteString(hk, wzName, sczValue);
 
@@ -855,7 +855,7 @@ HRESULT DAPI RegWriteStringArray(
         for (DWORD i = 0; i < cValues; ++i)
         {
             hr = ::StringCchCopyW(wzCopyDestination, dwTotalStringSize, rgwzValues[i]);
-            ExitOnFailure1(hr, "failed to copy string: %ls", rgwzValues[i]);
+            ExitOnFailure(hr, "failed to copy string: %ls", rgwzValues[i]);
             
             dwTemp -= lstrlenW(rgwzValues[i]) + 1;
             wzCopyDestination += lstrlenW(rgwzValues[i]) + 1;
@@ -868,7 +868,7 @@ HRESULT DAPI RegWriteStringArray(
     ExitOnFailure(hr, "Failed to get total string size in bytes");
 
     er = vpfnRegSetValueExW(hk, wzName, 0, REG_MULTI_SZ, reinterpret_cast<const BYTE *>(wzWriteValue), cbTotalStringSize);
-    ExitOnWin32Error1(er, hr, "Failed to set registry value to array of strings (first string of which is): %ls", wzWriteValue);
+    ExitOnWin32Error(er, hr, "Failed to set registry value to array of strings (first string of which is): %ls", wzWriteValue);
 
 LExit:
     ReleaseStr(sczWriteValue);
@@ -890,7 +890,7 @@ extern "C" HRESULT DAPI RegWriteNumber(
     DWORD er = ERROR_SUCCESS;
 
     er = vpfnRegSetValueExW(hk, wzName, 0, REG_DWORD, reinterpret_cast<const BYTE *>(&dwValue), sizeof(dwValue));
-    ExitOnWin32Error1(er, hr, "Failed to set %ls value.", wzName);
+    ExitOnWin32Error(er, hr, "Failed to set %ls value.", wzName);
 
 LExit:
     return hr;
@@ -910,7 +910,7 @@ extern "C" HRESULT DAPI RegWriteQword(
     DWORD er = ERROR_SUCCESS;
 
     er = vpfnRegSetValueExW(hk, wzName, 0, REG_QWORD, reinterpret_cast<const BYTE *>(&qwValue), sizeof(qwValue));
-    ExitOnWin32Error1(er, hr, "Failed to set %ls value.", wzName);
+    ExitOnWin32Error(er, hr, "Failed to set %ls value.", wzName);
 
 LExit:
     return hr;

--- a/src/libs/dutil/resrutil.cpp
+++ b/src/libs/dutil/resrutil.cpp
@@ -44,7 +44,7 @@ extern "C" HRESULT DAPI ResGetStringLangId(
     if (wzPath && *wzPath)
     {
         hModule = LoadLibraryExW(wzPath, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_AS_DATAFILE);
-        ExitOnNullWithLastError1(hModule, hr, "Failed to open resource file: %ls", wzPath);
+        ExitOnNullWithLastError(hModule, hr, "Failed to open resource file: %ls", wzPath);
     }
 
 #pragma prefast(push)
@@ -87,12 +87,12 @@ extern "C" HRESULT DAPI ResReadString(
     do
     {
         hr = StrAlloc(ppwzString, cch);
-        ExitOnFailureDebugTrace1(hr, "Failed to allocate string for resource id: %d", uID);
+        ExitOnFailureDebugTrace(hr, "Failed to allocate string for resource id: %d", uID);
 
         cchReturned = ::LoadStringW(hinst, uID, *ppwzString, cch);
         if (0 == cchReturned)
         {
-            ExitWithLastError1(hr, "Failed to load string resource id: %d", uID);
+            ExitWithLastError(hr, "Failed to load string resource id: %d", uID);
         }
 
         // if the returned string count is one character too small, it's likely we have
@@ -103,7 +103,7 @@ extern "C" HRESULT DAPI ResReadString(
             hr = S_FALSE;
         }
     } while (S_FALSE == hr);
-    ExitOnFailure1(hr, "Failed to load string resource id: %d", uID);
+    ExitOnFailure(hr, "Failed to load string resource id: %d", uID);
 
 LExit:
     return hr;
@@ -130,7 +130,7 @@ extern "C" HRESULT DAPI ResReadStringAnsi(
     do
     {
         hr = StrAnsiAlloc(ppszString, cch);
-        ExitOnFailureDebugTrace1(hr, "Failed to allocate string for resource id: %d", uID);
+        ExitOnFailureDebugTrace(hr, "Failed to allocate string for resource id: %d", uID);
 
 #pragma prefast(push)
 #pragma prefast(disable:25068)
@@ -138,7 +138,7 @@ extern "C" HRESULT DAPI ResReadStringAnsi(
 #pragma prefast(pop)
         if (0 == cchReturned)
         {
-            ExitWithLastError1(hr, "Failed to load string resource id: %d", uID);
+            ExitWithLastError(hr, "Failed to load string resource id: %d", uID);
         }
 
         // if the returned string count is one character too small, it's likely we have
@@ -149,7 +149,7 @@ extern "C" HRESULT DAPI ResReadStringAnsi(
             hr = S_FALSE;
         }
     } while (S_FALSE == hr);
-    ExitOnFailure1(hr, "failed to load string resource id: %d", uID);
+    ExitOnFailure(hr, "failed to load string resource id: %d", uID);
 
 LExit:
     return hr;
@@ -218,18 +218,18 @@ extern "C" HRESULT DAPI ResExportDataToFile(
     BOOL bCreatedFile = FALSE;
 
     hr = ResReadData(NULL, szDataName, &pData, &cbData);
-    ExitOnFailure1(hr, "Failed to GetData from %s.", szDataName);
+    ExitOnFailure(hr, "Failed to GetData from %s.", szDataName);
 
     hFile = ::CreateFileW(wzTargetFile, GENERIC_WRITE, 0, NULL, dwCreationDisposition, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to CreateFileW for %ls.", wzTargetFile);
+        ExitWithLastError(hr, "Failed to CreateFileW for %ls.", wzTargetFile);
     }
     bCreatedFile = TRUE;
 
     if (!::WriteFile(hFile, pData, cbData, &cbWritten, NULL))
     {
-        ExitWithLastError1(hr, "Failed to ::WriteFile for %ls.", wzTargetFile);
+        ExitWithLastError(hr, "Failed to ::WriteFile for %ls.", wzTargetFile);
     }
 
 LExit:

--- a/src/libs/dutil/reswutil.cpp
+++ b/src/libs/dutil/reswutil.cpp
@@ -77,7 +77,7 @@ extern "C" HRESULT DAPI ResWriteString(
     DWORD dwStringId = (dwDataId % RES_STRINGS_PER_BLOCK);
 
     hModule = LoadLibraryExW(wzResourceFile, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_AS_DATAFILE);
-    ExitOnNullWithLastError1(hModule, hr, "Failed to load library: %ls", wzResourceFile);
+    ExitOnNullWithLastError(hModule, hr, "Failed to load library: %ls", wzResourceFile);
 
     hr = StringBlockInitialize(hModule, dwBlockId, wLangId, &StrBlock);
     ExitOnFailure(hr, "Failed to get string block to update.");
@@ -188,23 +188,23 @@ extern "C" HRESULT DAPI ResImportDataFromFile(
     hFile = ::CreateFileW(wzSourceFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE == hFile)
     {
-        ExitWithLastError1(hr, "Failed to CreateFileW for %ls.", wzSourceFile);
+        ExitWithLastError(hr, "Failed to CreateFileW for %ls.", wzSourceFile);
     }
 
     cbFile = ::GetFileSize(hFile, NULL);
     if (!cbFile)
     {
-        ExitWithLastError1(hr, "Failed to GetFileSize for %ls.", wzSourceFile);
+        ExitWithLastError(hr, "Failed to GetFileSize for %ls.", wzSourceFile);
     }
 
     hMap = ::CreateFileMapping(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
-    ExitOnNullWithLastError1(hMap, hr, "Failed to CreateFileMapping for %ls.", wzSourceFile);
+    ExitOnNullWithLastError(hMap, hr, "Failed to CreateFileMapping for %ls.", wzSourceFile);
 
     pv = ::MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, cbFile);
-    ExitOnNullWithLastError1(pv, hr, "Failed to MapViewOfFile for %ls.", wzSourceFile);
+    ExitOnNullWithLastError(pv, hr, "Failed to MapViewOfFile for %ls.", wzSourceFile);
 
     hr = ResWriteData(wzTargetFile, szDataName, pv, cbFile);
-    ExitOnFailure2(hr, "Failed to ResSetData %s on file %ls.", szDataName, wzTargetFile);
+    ExitOnFailure(hr, "Failed to ResSetData %s on file %ls.", szDataName, wzTargetFile);
 
 LExit:
     if (pv)

--- a/src/libs/dutil/rexutil.cpp
+++ b/src/libs/dutil/rexutil.cpp
@@ -151,7 +151,7 @@ extern "C" HRESULT RexExtract(
     //
     //if (!::WideCharToMultiByte(CP_ACP, 0, wzResource, -1, vszResource, countof(vszResource), NULL, NULL))
     //{
-    //    ExitOnLastError1(hr, "failed to convert cabinet resource name to ASCII: %ls", wzResource);
+    //    ExitOnLastError(hr, "failed to convert cabinet resource name to ASCII: %ls", wzResource);
     //}
 
     hr = ::StringCchCopyA(vszResource, countof(vszResource), szResource);
@@ -236,7 +236,7 @@ static __callback INT_PTR FAR DIAMONDAPI RexOpen(__in_z char FAR *pszFile, int o
         hFile = ::CreateFileA(pszFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         if (INVALID_HANDLE_VALUE == hFile)
         {
-            ExitWithLastError1(hr, "failed to open file: %s", pszFile);
+            ExitWithLastError(hr, "failed to open file: %s", pszFile);
         }
 
         vrgffFileTable[i].fUsed = TRUE;
@@ -344,7 +344,7 @@ static __callback long FAR DIAMONDAPI RexSeek(INT_PTR hf, long dist, int seektyp
     default :
         dwMoveMethod = 0;
         hr = E_UNEXPECTED;
-        ExitOnFailure1(hr, "unexpected seektype in FDISeek(): %d", seektype);
+        ExitOnFailure(hr, "unexpected seektype in FDISeek(): %d", seektype);
     }
 
     if (MEMORY_FILE == vrgffFileTable[hf].fftType)
@@ -373,7 +373,7 @@ static __callback long FAR DIAMONDAPI RexSeek(INT_PTR hf, long dist, int seektyp
         lMove = ::SetFilePointer(vrgffFileTable[hf].hFile, dist, NULL, dwMoveMethod);
         if (0xFFFFFFFF == lMove)
         {
-            ExitWithLastError1(hr, "failed to move file pointer %d bytes", dist);
+            ExitWithLastError(hr, "failed to move file pointer %d bytes", dist);
         }
     }
 
@@ -451,7 +451,7 @@ static __callback INT_PTR DIAMONDAPI RexCallback(FDINOTIFICATIONTYPE iNotificati
         sz = static_cast<LPCSTR>(pFDINotify->psz1);
         if (!::MultiByteToWideChar(CP_ACP, 0, sz, -1, wz, countof(wz)))
         {
-            ExitWithLastError1(hr, "failed to convert cabinet file id to unicode: %s", sz);
+            ExitWithLastError(hr, "failed to convert cabinet file id to unicode: %s", sz);
         }
 
         if (prcs->pfnProgress)
@@ -468,25 +468,25 @@ static __callback INT_PTR DIAMONDAPI RexCallback(FDINOTIFICATIONTYPE iNotificati
             // get the created date for the resource in the cabinet
             if (!::DosDateTimeToFileTime(pFDINotify->date, pFDINotify->time, &ft))
             {
-                ExitWithLastError1(hr, "failed to get time for resource: %ls", wz);
+                ExitWithLastError(hr, "failed to get time for resource: %ls", wz);
             }
 
             WCHAR wzPath[MAX_PATH];
 
             hr = ::StringCchCopyW(wzPath, countof(wzPath), prcs->pwzExtractDir);
-            ExitOnFailure2(hr, "failed to copy extract directory: %ls for file: %ls", prcs->pwzExtractDir, wz);
+            ExitOnFailure(hr, "failed to copy extract directory: %ls for file: %ls", prcs->pwzExtractDir, wz);
 
             if (L'*' == *prcs->pwzExtract)
             {
                 hr = ::StringCchCatW(wzPath, countof(wzPath), wz);
-                ExitOnFailure2(hr, "failed to concat onto path: %ls file: %ls", wzPath, wz);
+                ExitOnFailure(hr, "failed to concat onto path: %ls file: %ls", wzPath, wz);
             }
             else
             {
                 Assert(*prcs->pwzExtractName);
 
                 hr = ::StringCchCatW(wzPath, countof(wzPath), prcs->pwzExtractName);
-                ExitOnFailure2(hr, "failed to concat onto path: %ls file: %ls", wzPath, prcs->pwzExtractName);
+                ExitOnFailure(hr, "failed to concat onto path: %ls file: %ls", wzPath, prcs->pwzExtractName);
             }
 
             // Quickly chop off the file name part of the path to ensure the path exists
@@ -497,7 +497,7 @@ static __callback INT_PTR DIAMONDAPI RexCallback(FDINOTIFICATIONTYPE iNotificati
             *wzFile = L'\0';
 
             hr = DirEnsureExists(wzPath, NULL);
-            ExitOnFailure1(hr, "failed to ensure directory: %ls", wzPath);
+            ExitOnFailure(hr, "failed to ensure directory: %ls", wzPath);
 
             hr = S_OK;
 
@@ -523,7 +523,7 @@ static __callback INT_PTR DIAMONDAPI RexCallback(FDINOTIFICATIONTYPE iNotificati
             hFile = ::CreateFileW(wzPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
             if (INVALID_HANDLE_VALUE == hFile)
             {
-                ExitWithLastError1(hr, "failed to open file: %ls", wzPath);
+                ExitWithLastError(hr, "failed to open file: %ls", wzPath);
             }
 
             vrgffFileTable[i].fUsed = TRUE;
@@ -556,7 +556,7 @@ static __callback INT_PTR DIAMONDAPI RexCallback(FDINOTIFICATIONTYPE iNotificati
         sz = static_cast<LPCSTR>(pFDINotify->psz1);
         if (!::MultiByteToWideChar(CP_ACP, 0, sz, -1, wz, countof(wz)))
         {
-            ExitWithLastError1(hr, "failed to convert cabinet file id to unicode: %s", sz);
+            ExitWithLastError(hr, "failed to convert cabinet file id to unicode: %s", sz);
         }
 
         RexClose(pFDINotify->hf);

--- a/src/libs/dutil/rmutil.cpp
+++ b/src/libs/dutil/rmutil.cpp
@@ -97,7 +97,7 @@ extern "C" HRESULT DAPI RmuJoinSession(
     ExitOnFailure(hr, "Failed to initialize Restart Manager.");
 
     er = vpfnRmJoinSession(&pSession->dwSessionHandle, wzSessionKey);
-    ExitOnWin32Error1(er, hr, "Failed to join Restart Manager session %ls.", wzSessionKey);
+    ExitOnWin32Error(er, hr, "Failed to join Restart Manager session %ls.", wzSessionKey);
 
     ::InitializeCriticalSection(&pSession->cs);
     pSession->fInitialized = TRUE;
@@ -159,11 +159,11 @@ extern "C" HRESULT DAPI RmuAddProcessById(
     BOOL fLocked = FALSE;
 
     hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
-    ExitOnNullWithLastError1(hProcess, hr, "Failed to open the process ID %d.", dwProcessId);
+    ExitOnNullWithLastError(hProcess, hr, "Failed to open the process ID %d.", dwProcessId);
 
     if (!::GetProcessTimes(hProcess, &CreationTime, &ExitTime, &KernelTime, &UserTime))
     {
-        ExitWithLastError1(hr, "Failed to get the process times for process ID %d.", dwProcessId);
+        ExitWithLastError(hr, "Failed to get the process times for process ID %d.", dwProcessId);
     }
 
     ::EnterCriticalSection(&pSession->cs);
@@ -204,12 +204,12 @@ extern "C" HRESULT DAPI RmuAddProcessesByName(
     DWORD cProcessIds = 0;
 
     hr = ProcFindAllIdsFromExeName(wzProcessName, &pdwProcessIds, &cProcessIds);
-    ExitOnFailure1(hr, "Failed to enumerate all the processes by name %ls.", wzProcessName);
+    ExitOnFailure(hr, "Failed to enumerate all the processes by name %ls.", wzProcessName);
 
     for (DWORD i = 0; i < cProcessIds; ++i)
     {
         hr = RmuAddProcessById(pSession, pdwProcessIds[i]);
-        ExitOnFailure2(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
+        ExitOnFailure(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
     }
 
 LExit:

--- a/src/libs/dutil/rssutil.cpp
+++ b/src/libs/dutil/rssutil.cpp
@@ -313,7 +313,7 @@ static HRESULT ParseRssChannel(
         else
         {
             hr = ParseRssUnknownElement(pNode, &pNewChannel->pUnknownElements);
-            ExitOnFailure1(hr, "Failed to parse unknown RSS channel element: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Failed to parse unknown RSS channel element: %ls", bstrNodeName);
         }
 
         ReleaseNullBSTR(bstrNodeValue);
@@ -433,7 +433,7 @@ static HRESULT ParseRssItem(
         else
         {
             hr = ParseRssUnknownElement(pNode, &pItem->pUnknownElements);
-            ExitOnFailure1(hr, "Failed to parse unknown RSS item element: %ls", bstrNodeName);
+            ExitOnFailure(hr, "Failed to parse unknown RSS item element: %ls", bstrNodeName);
         }
 
         ReleaseNullBSTR(bstrNodeValue);

--- a/src/libs/dutil/sceutil.cpp
+++ b/src/libs/dutil/sceutil.cpp
@@ -249,10 +249,10 @@ extern "C" HRESULT DAPI SceCreateDatabase(
     ExitOnFailure(hr, "Failed to get IDBDataSourceAdmin interface");
 
     hr = PathGetDirectory(sczFile, &sczDirectory);
-    ExitOnFailure1(hr, "Failed to get directory portion of path: %ls", sczFile);
+    ExitOnFailure(hr, "Failed to get directory portion of path: %ls", sczFile);
 
     hr = DirEnsureExists(sczDirectory, NULL);
-    ExitOnFailure1(hr, "Failed to ensure directory exists: %ls", sczDirectory);
+    ExitOnFailure(hr, "Failed to ensure directory exists: %ls", sczDirectory);
 
     rgdbpDataSourceProp[0].dwPropertyID = DBPROP_INIT_DATASOURCE;
     rgdbpDataSourceProp[0].dwOptions = DBPROPOPTIONS_REQUIRED;
@@ -392,7 +392,7 @@ extern "C" HRESULT DAPI SceOpenDatabase(
     ExitOnFailure(hr, "Failed to set initial properties to open database");
 
     hr = pNewSceDatabaseInternal->pIDBInitialize->Initialize();
-    ExitOnFailure1(hr, "Failed to open database: %ls", sczFile);
+    ExitOnFailure(hr, "Failed to open database: %ls", sczFile);
 
     hr = pNewSceDatabaseInternal->pIDBInitialize->QueryInterface(IID_IDBCreateSession, reinterpret_cast<void **>(&pNewSceDatabaseInternal->pIDBCreateSession));
     ExitOnFailure(hr, "Failed to get IDBCreateSession interface");
@@ -415,12 +415,12 @@ extern "C" HRESULT DAPI SceOpenDatabase(
     if (CSTR_EQUAL != ::CompareStringW(LOCALE_INVARIANT, 0, sczSchemaType, -1, wzExpectedSchemaType, -1))
     {
         hr = HRESULT_FROM_WIN32(ERROR_BAD_FILE_TYPE);
-        ExitOnRootFailure2(hr, "Tried to open wrong database type - expected type %ls, found type %ls", wzExpectedSchemaType, sczSchemaType);
+        ExitOnRootFailure(hr, "Tried to open wrong database type - expected type %ls, found type %ls", wzExpectedSchemaType, sczSchemaType);
     }
     else if (dwVersionFound != dwExpectedVersion)
     {
         hr = HRESULT_FROM_WIN32(ERROR_PRODUCT_VERSION);
-        ExitOnRootFailure2(hr, "Tried to open wrong database schema version - expected version %u, found version %u", dwExpectedVersion, dwVersionFound);
+        ExitOnRootFailure(hr, "Tried to open wrong database schema version - expected version %u, found version %u", dwExpectedVersion, dwVersionFound);
     }
 
     *ppDatabase = pNewSceDatabase;
@@ -449,19 +449,19 @@ extern "C" HRESULT DAPI SceEnsureDatabase(
     if (FileExistsEx(sczFile, NULL))
     {
         hr = SceOpenDatabase(sczFile, wzSqlCeDllPath, wzSchemaType, dwExpectedVersion, &pDatabase, FALSE);
-        ExitOnFailure1(hr, "Failed to open database while ensuring database exists: %ls", sczFile);
+        ExitOnFailure(hr, "Failed to open database while ensuring database exists: %ls", sczFile);
     }
     else
     {
         hr = SceCreateDatabase(sczFile, wzSqlCeDllPath, &pDatabase);
-        ExitOnFailure1(hr, "Failed to create database while ensuring database exists: %ls", sczFile);
+        ExitOnFailure(hr, "Failed to create database while ensuring database exists: %ls", sczFile);
 
         hr = SetDatabaseSchemaInfo(pDatabase, wzSchemaType, dwExpectedVersion);
         ExitOnFailure(hr, "Failed to set schema version of database");
     }
 
     hr = EnsureSchema(pDatabase, pdsSchema);
-    ExitOnFailure1(hr, "Failed to ensure schema is correct in database: %ls", sczFile);
+    ExitOnFailure(hr, "Failed to ensure schema is correct in database: %ls", sczFile);
 
     // Keep a pointer to the schema in the SCE_DATABASE object for future reference
     pDatabase->pdsSchema = pdsSchema;
@@ -667,7 +667,7 @@ extern "C" HRESULT DAPI SceDeleteRow(
     ExitOnFailure(hr, "Failed to get IRowsetChange interface");
 
     hr = pIRowsetChange->DeleteRows(DB_NULL_HCHAPTER, 1, &pRow->hRow, &rowStatus);
-    ExitOnFailure1(hr, "Failed to delete row with status: %u", rowStatus);
+    ExitOnFailure(hr, "Failed to delete row with status: %u", rowStatus);
 
     ReleaseNullSceRow(*pRowHandle);
 
@@ -784,7 +784,7 @@ extern "C" HRESULT DAPI SceSetColumnBinary(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set binary, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set binary, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -810,7 +810,7 @@ extern "C" HRESULT DAPI SceSetColumnDword(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set dword, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set dword, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -836,7 +836,7 @@ extern "C" HRESULT DAPI SceSetColumnQword(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set qword, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set qword, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -863,7 +863,7 @@ extern "C" HRESULT DAPI SceSetColumnBool(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set bool, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set bool, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -890,7 +890,7 @@ extern "C" HRESULT DAPI SceSetColumnString(
     SIZE_T cbSize = (NULL == wzValue) ? 0 : ((lstrlenW(wzValue) + 1) * sizeof(WCHAR));
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set string, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set string, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -899,7 +899,7 @@ extern "C" HRESULT DAPI SceSetColumnString(
     }
 
     hr = SetColumnValue(pRow->pTableSchema, dwColumnIndex, reinterpret_cast<const BYTE *>(wzValue), cbSize, &pRow->rgBinding[pRow->dwBindingIndex++], &pRow->cbOffset, &pRow->pbData);
-    ExitOnFailure1(hr, "Failed to set column value as string: %ls", wzValue);
+    ExitOnFailure(hr, "Failed to set column value as string: %ls", wzValue);
 
 LExit:
     return hr;
@@ -915,7 +915,7 @@ extern "C" HRESULT DAPI SceSetColumnNull(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set empty, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set empty, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -943,7 +943,7 @@ extern "C" HRESULT DAPI SceSetColumnSystemTime(
     SCE_ROW *pRow = reinterpret_cast<SCE_ROW *>(rowHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), pRow->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to set systemtime, columns: %u", pRow->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to set systemtime, columns: %u", pRow->pTableSchema->cColumns);
 
     if (NULL == pRow->rgBinding)
     {
@@ -1163,7 +1163,7 @@ extern "C" HRESULT DAPI SceBeginQuery(
     psq->pDatabaseInternal = reinterpret_cast<SCE_DATABASE_INTERNAL *>(pDatabase->sdbHandle);
 
     hr = ::SizeTMult(sizeof(DBBINDING), psq->pTableSchema->cColumns, &cbAllocSize);
-    ExitOnFailure1(hr, "Overflow while calculating allocation size for DBBINDING to begin query, columns: %u", psq->pTableSchema->cColumns);
+    ExitOnFailure(hr, "Overflow while calculating allocation size for DBBINDING to begin query, columns: %u", psq->pTableSchema->cColumns);
 
     psq->rgBinding = static_cast<DBBINDING *>(MemAlloc(cbAllocSize, TRUE));
     ExitOnNull(psq, hr, E_OUTOFMEMORY, "Failed to allocate DBBINDINGs for new sce query");
@@ -1187,7 +1187,7 @@ HRESULT DAPI SceSetQueryColumnBinary(
     SCE_QUERY *pQuery = reinterpret_cast<SCE_QUERY *>(sqhHandle);
 
     hr = SetColumnValue(pQuery->pTableSchema, pQuery->pIndexSchema->rgColumns[pQuery->dwBindingIndex], pbBuffer, cbBuffer, &pQuery->rgBinding[pQuery->dwBindingIndex], &pQuery->cbOffset, &pQuery->pbData);
-    ExitOnFailure1(hr, "Failed to set query column value as binary of size: %u", cbBuffer);
+    ExitOnFailure(hr, "Failed to set query column value as binary of size: %u", cbBuffer);
 
     ++(pQuery->dwBindingIndex);
 
@@ -1456,14 +1456,14 @@ static HRESULT CreateSqlCe(
     else
     {
         *phSqlCeDll = ::LoadLibraryW(wzSqlCeDllPath);
-        ExitOnNullWithLastError1(*phSqlCeDll, hr, "Failed to open Sql CE DLL: %ls", wzSqlCeDllPath);
+        ExitOnNullWithLastError(*phSqlCeDll, hr, "Failed to open Sql CE DLL: %ls", wzSqlCeDllPath);
 
         HRESULT (WINAPI *pfnGetFactory)(REFCLSID, REFIID, void**);
         pfnGetFactory = (HRESULT (WINAPI *)(REFCLSID, REFIID, void**))GetProcAddress(*phSqlCeDll, "DllGetClassObject");
 
         IClassFactory* pFactory = NULL;
         hr = pfnGetFactory(CLSID_SQLSERVERCE, IID_IClassFactory, (void**)&pFactory);
-        ExitOnFailure1(hr, "Failed to get factory for IID_IDBInitialize from DLL: %ls", wzSqlCeDllPath);
+        ExitOnFailure(hr, "Failed to get factory for IID_IDBInitialize from DLL: %ls", wzSqlCeDllPath);
         ExitOnNull(pFactory, hr, E_UNEXPECTED, "GetFactory returned success, but pFactory was NULL");
 
         hr = pFactory->CreateInstance(NULL, IID_IDBInitialize, (void**)ppIDBInitialize);
@@ -1711,13 +1711,13 @@ static HRESULT EnsureSchema(
             }
 
             hr = pTableDefinition->CreateTable(NULL, &tableID, pdsSchema->rgTables[dwTable].cColumns, rgColumnDescriptions, IID_IUnknown, _countof(rgdbpRowSetPropSet), rgdbpRowSetPropSet, NULL, NULL);
-            ExitOnFailure1(hr, "Failed to create table: %ls", pdsSchema->rgTables[dwTable].wzName);
+            ExitOnFailure(hr, "Failed to create table: %ls", pdsSchema->rgTables[dwTable].wzName);
 
 #pragma prefast(push)
 #pragma prefast(disable:26010)
             hr = EnsureLocalColumnConstraints(pTableDefinition, &tableID, pdsSchema->rgTables + dwTable);
 #pragma prefast(pop)
-            ExitOnFailure1(hr, "Failed to ensure local column constraints for table: %ls", pdsSchema->rgTables[dwTable].wzName);
+            ExitOnFailure(hr, "Failed to ensure local column constraints for table: %ls", pdsSchema->rgTables[dwTable].wzName);
 
             for (DWORD i = 0; i < pdsSchema->rgTables[dwTable].cColumns; ++i)
             {
@@ -1735,7 +1735,7 @@ static HRESULT EnsureSchema(
             // Close any rowset we opened
             ReleaseNullObject(pdsSchema->rgTables[dwTable].pIRowset);
 
-            ExitOnFailure1(hr, "Failed to open table %ls while ensuring schema", tableID.uName.pwszName);
+            ExitOnFailure(hr, "Failed to open table %ls while ensuring schema", tableID.uName.pwszName);
         }
 
         if (0 < pdsSchema->rgTables[dwTable].cIndexes)
@@ -1757,7 +1757,7 @@ static HRESULT EnsureSchema(
                 hr = S_OK;
 
                 hr = ::SizeTMult(sizeof(DBINDEXCOLUMNDESC), pdsSchema->rgTables[dwTable].rgIndexes[dwIndex].cColumns, &cbAllocSize);
-                ExitOnFailure1(hr, "Overflow while calculating allocation size for DBINDEXCOLUMNDESC, columns: %u", pdsSchema->rgTables[dwTable].rgIndexes[dwIndex].cColumns);
+                ExitOnFailure(hr, "Overflow while calculating allocation size for DBINDEXCOLUMNDESC, columns: %u", pdsSchema->rgTables[dwTable].rgIndexes[dwIndex].cColumns);
 
                 rgIndexColumnDescriptions = reinterpret_cast<DBINDEXCOLUMNDESC *>(MemAlloc(cbAllocSize, TRUE));
                 ExitOnNull(rgIndexColumnDescriptions, hr, E_OUTOFMEMORY, "Failed to allocate structure to hold index column descriptions");
@@ -1777,7 +1777,7 @@ static HRESULT EnsureSchema(
                     // If the index already exists, no worries
                     hr = S_OK;
                 }
-                ExitOnFailure2(hr, "Failed to create index named %ls into table named %ls", pdsSchema->rgTables[dwTable].rgIndexes[dwIndex].wzName, pdsSchema->rgTables[dwTable].wzName);
+                ExitOnFailure(hr, "Failed to create index named %ls into table named %ls", pdsSchema->rgTables[dwTable].rgIndexes[dwIndex].wzName, pdsSchema->rgTables[dwTable].wzName);
 
                 for (DWORD i = 0; i < cIndexColumnDescriptions; ++i)
                 {
@@ -1800,7 +1800,7 @@ static HRESULT EnsureSchema(
 
             // Setup any constraints for the table's columns
             hr = EnsureForeignColumnConstraints(pTableDefinition, &tableID, pdsSchema->rgTables + dwTable, pdsSchema);
-            ExitOnFailure1(hr, "Failed to ensure foreign column constraints for table: %ls", pdsSchema->rgTables[dwTable].wzName);
+            ExitOnFailure(hr, "Failed to ensure foreign column constraints for table: %ls", pdsSchema->rgTables[dwTable].wzName);
         }
     }
 
@@ -1861,10 +1861,10 @@ static HRESULT OpenSchema(
 
         // And finally, open the table's standard interfaces
         hr = pDatabaseInternal->pIOpenRowset->OpenRowset(NULL, &tableID, NULL, IID_IRowset, _countof(rgdbpRowSetPropSet), rgdbpRowSetPropSet, reinterpret_cast<IUnknown **>(&pdsSchema->rgTables[dwTable].pIRowset));
-        ExitOnFailure2(hr, "Failed to open table %u named %ls after ensuring all indexes and constraints are created", dwTable, pdsSchema->rgTables[dwTable].wzName);
+        ExitOnFailure(hr, "Failed to open table %u named %ls after ensuring all indexes and constraints are created", dwTable, pdsSchema->rgTables[dwTable].wzName);
 
         hr = pdsSchema->rgTables[dwTable].pIRowset->QueryInterface(IID_IRowsetChange, reinterpret_cast<void **>(&pdsSchema->rgTables[dwTable].pIRowsetChange));
-        ExitOnFailure1(hr, "Failed to get IRowsetChange object for table: %ls", pdsSchema->rgTables[dwTable].wzName);
+        ExitOnFailure(hr, "Failed to get IRowsetChange object for table: %ls", pdsSchema->rgTables[dwTable].wzName);
     }
 
 LExit:
@@ -1896,7 +1896,7 @@ static HRESULT SetColumnValue(
     pBinding->obValue = cbNewOffset;
 
     hr = ::SizeTAdd(cbNewOffset, cbSize, &cbNewOffset);
-    ExitOnFailure1(hr, "Failed to add %u to alloc size while setting column value", cbSize);
+    ExitOnFailure(hr, "Failed to add %u to alloc size while setting column value", cbSize);
 
     pBinding->obStatus = cbNewOffset;
     pBinding->eParamIO = DBPARAMIO_INPUT;
@@ -1986,12 +1986,12 @@ static HRESULT GetColumnValue(
         if (DBTYPE_WSTR == dbBinding.wType)
         {
             hr = StrAlloc(reinterpret_cast<LPWSTR *>(&pvRawData), dwDataSize / sizeof(WCHAR));
-            ExitOnFailure1(hr, "Failed to allocate space for string data while reading column %u", dwColumnIndex);
+            ExitOnFailure(hr, "Failed to allocate space for string data while reading column %u", dwColumnIndex);
         }
         else
         {
             pvRawData = MemAlloc(dwDataSize, TRUE);
-            ExitOnNull1(pvRawData, hr, E_OUTOFMEMORY, "Failed to allocate space for data while reading column %u", dwColumnIndex);
+            ExitOnNull(pvRawData, hr, E_OUTOFMEMORY, "Failed to allocate space for data while reading column %u", dwColumnIndex);
         }
 
         hr = pRow->pIRowset->GetData(pRow->hRow, hAccessorValue, pvRawData);
@@ -2141,7 +2141,7 @@ static HRESULT EnsureLocalColumnConstraints(
             {
                 hr = S_OK;
             }
-            ExitOnFailure2(hr, "Failed to add primary key constraint for column %ls, table %ls", pCurrentColumn->wzName, pTableSchema->wzName);
+            ExitOnFailure(hr, "Failed to add primary key constraint for column %ls, table %ls", pCurrentColumn->wzName, pTableSchema->wzName);
         }
     }
 
@@ -2211,7 +2211,7 @@ static HRESULT EnsureForeignColumnConstraints(
             {
                 hr = S_OK;
             }
-            ExitOnFailure2(hr, "Failed to add constraint named: %ls to table: %ls", pCurrentColumn->wzRelationName, pTableSchema->wzName);
+            ExitOnFailure(hr, "Failed to add constraint named: %ls to table: %ls", pCurrentColumn->wzRelationName, pTableSchema->wzName);
         }
     }
 
@@ -2317,10 +2317,10 @@ static HRESULT SetDatabaseSchemaInfo(
     }
 
     hr = SceSetColumnString(sceRow, 0, wzSchemaType);
-    ExitOnFailure1(hr, "Failed to set internal schematype to: %ls", wzSchemaType);
+    ExitOnFailure(hr, "Failed to set internal schematype to: %ls", wzSchemaType);
 
     hr = SceSetColumnDword(sceRow, 1, dwVersion);
-    ExitOnFailure1(hr, "Failed to set internal version to: %u", dwVersion);
+    ExitOnFailure(hr, "Failed to set internal version to: %u", dwVersion);
 
     hr = SceFinishUpdate(sceRow);
     ExitOnFailure(hr, "Failed to insert first row in internal version schema table");
@@ -2402,7 +2402,7 @@ static void ReleaseDatabaseInternal(
         hr = FileEnsureDelete(pDatabaseInternal->sczTempDbFile);
         if (FAILED(hr))
         {
-            TraceError1(hr, "Failed to delete temporary database file (copied here because the database was opened as read-only): %ls", pDatabaseInternal->sczTempDbFile);
+            TraceError(hr, "Failed to delete temporary database file (copied here because the database was opened as read-only): %ls", pDatabaseInternal->sczTempDbFile);
         }
         ReleaseStr(pDatabaseInternal->sczTempDbFile);
     }

--- a/src/libs/dutil/shelutil.cpp
+++ b/src/libs/dutil/shelutil.cpp
@@ -66,7 +66,7 @@ extern "C" HRESULT DAPI ShelExec(
 
     if (!vpfnShellExecuteExW(&shExecInfo))
     {
-        ExitWithLastError1(hr, "ShellExecEx failed with return code: %d", Dutil_er);
+        ExitWithLastError(hr, "ShellExecEx failed with return code: %d", Dutil_er);
     }
 
     if (phProcess)
@@ -141,7 +141,7 @@ extern "C" HRESULT DAPI ShelExecUnelevated(
     {
         hr = HRESULT_FROM_WIN32(ERROR_CANCELLED);
     }
-    ExitOnRootFailure1(hr, "Failed to launch unelevate executable: %ls", bstrTargetPath);
+    ExitOnRootFailure(hr, "Failed to launch unelevate executable: %ls", bstrTargetPath);
 
 LExit:
     ReleaseObject(psd);
@@ -168,13 +168,13 @@ extern "C" HRESULT DAPI ShelGetFolder(
     WCHAR wzPath[MAX_PATH];
 
     hr = ::SHGetFolderPathW(NULL, csidlFolder | CSIDL_FLAG_CREATE, NULL, SHGFP_TYPE_CURRENT, wzPath);
-    ExitOnFailure1(hr, "Failed to get folder path for CSIDL: %d", csidlFolder);
+    ExitOnFailure(hr, "Failed to get folder path for CSIDL: %d", csidlFolder);
 
     hr = StrAllocString(psczFolderPath, wzPath, 0);
-    ExitOnFailure1(hr, "Failed to copy shell folder path: %ls", wzPath);
+    ExitOnFailure(hr, "Failed to copy shell folder path: %ls", wzPath);
 
     hr = PathBackslashTerminate(psczFolderPath);
-    ExitOnFailure1(hr, "Failed to backslash terminate shell folder path: %ls", *psczFolderPath);
+    ExitOnFailure(hr, "Failed to backslash terminate shell folder path: %ls", *psczFolderPath);
 
 LExit:
     return hr;
@@ -226,10 +226,10 @@ extern "C" HRESULT DAPI ShelGetKnownFolder(
     ExitOnFailure(hr, "Failed to get known folder path.");
 
     hr = StrAllocString(psczFolderPath, pwzPath, 0);
-    ExitOnFailure1(hr, "Failed to copy shell folder path: %ls", pwzPath);
+    ExitOnFailure(hr, "Failed to copy shell folder path: %ls", pwzPath);
 
     hr = PathBackslashTerminate(psczFolderPath);
-    ExitOnFailure1(hr, "Failed to backslash terminate shell folder path: %ls", *psczFolderPath);
+    ExitOnFailure(hr, "Failed to backslash terminate shell folder path: %ls", *psczFolderPath);
 
 LExit:
     if (pwzPath)

--- a/src/libs/dutil/sqlutil.cpp
+++ b/src/libs/dutil/sqlutil.cpp
@@ -141,7 +141,7 @@ extern "C" HRESULT DAPI SqlConnectDatabase(
 
     //initialize connection to datasource
     hr = pidbInitialize->Initialize();
-    ExitOnFailure1(hr, "failed to initialize connection to database: %ls", wzDatabase);
+    ExitOnFailure(hr, "failed to initialize connection to database: %ls", wzDatabase);
 
     hr = pidbInitialize->QueryInterface(IID_IDBCreateSession, (LPVOID*)ppidbSession);
 
@@ -242,7 +242,7 @@ extern "C" HRESULT DAPI SqlDatabaseExists(
     IDBCreateSession* pidbSession = NULL;
 
     hr = SqlConnectDatabase(wzServer, wzInstance, L"master", fIntegratedAuth, wzUser, wzPassword, &pidbSession);
-    ExitOnFailure1(hr, "failed to connect to 'master' database on server %ls", wzServer);
+    ExitOnFailure(hr, "failed to connect to 'master' database on server %ls", wzServer);
 
     hr = SqlSessionDatabaseExists(pidbSession, wzDatabase, pbstrErrorDescription);
 
@@ -335,10 +335,10 @@ extern "C" HRESULT DAPI SqlDatabaseEnsureExists(
     // connect to the master database to create the new database
     //
     hr = SqlConnectDatabase(wzServer, wzInstance, L"master", fIntegratedAuth, wzUser, wzPassword, &pidbSession);
-    ExitOnFailure1(hr, "failed to connect to 'master' database on server %ls", wzServer);
+    ExitOnFailure(hr, "failed to connect to 'master' database on server %ls", wzServer);
 
     hr = SqlSessionDatabaseEnsureExists(pidbSession, wzDatabase, psfDatabase, psfLog, pbstrErrorDescription);
-    ExitOnFailure1(hr, "failed to create database: %ls", wzDatabase);
+    ExitOnFailure(hr, "failed to create database: %ls", wzDatabase);
 
     Assert(S_OK == hr);
 LExit:
@@ -366,12 +366,12 @@ extern "C" HRESULT DAPI SqlSessionDatabaseEnsureExists(
     HRESULT hr = S_OK;
 
     hr = SqlSessionDatabaseExists(pidbSession, wzDatabase, pbstrErrorDescription);
-    ExitOnFailure1(hr, "failed to determine if exists, database: %ls", wzDatabase);
+    ExitOnFailure(hr, "failed to determine if exists, database: %ls", wzDatabase);
 
     if (S_FALSE == hr)
     {
         hr = SqlSessionCreateDatabase(pidbSession, wzDatabase, psfDatabase, psfLog, pbstrErrorDescription);
-        ExitOnFailure1(hr, "failed to create database: %1", wzDatabase);
+        ExitOnFailure(hr, "failed to create database: %1", wzDatabase);
     }
     // else database already exists, return S_FALSE
 
@@ -409,10 +409,10 @@ extern "C" HRESULT DAPI SqlCreateDatabase(
     // connect to the master database to create the new database
     //
     hr = SqlConnectDatabase(wzServer, wzInstance, L"master", fIntegratedAuth, wzUser, wzPassword, &pidbSession);
-    ExitOnFailure1(hr, "failed to connect to 'master' database on server %ls", wzServer);
+    ExitOnFailure(hr, "failed to connect to 'master' database on server %ls", wzServer);
 
     hr = SqlSessionCreateDatabase(pidbSession, wzDatabase, psfDatabase, psfLog, pbstrErrorDescription);
-    ExitOnFailure1(hr, "failed to create database: %ls", wzDatabase);
+    ExitOnFailure(hr, "failed to create database: %ls", wzDatabase);
 
     Assert(S_OK == hr);
 LExit:
@@ -457,10 +457,10 @@ extern "C" HRESULT DAPI SqlSessionCreateDatabase(
     ExitOnFailure(hr, "failed to escape database string");
 
     hr = StrAllocFormatted(&pwzQuery, L"CREATE DATABASE %s %s%s %s%s", pwzDatabaseEscaped, pwzDbFile ? L"ON " : L"", pwzDbFile ? pwzDbFile : L"", pwzLogFile ? L"LOG ON " : L"", pwzLogFile ? pwzLogFile : L"");
-    ExitOnFailure1(hr, "failed to allocate query to create database: %ls", pwzDatabaseEscaped);    
+    ExitOnFailure(hr, "failed to allocate query to create database: %ls", pwzDatabaseEscaped);    
 
     hr = SqlSessionExecuteQuery(pidbSession, pwzQuery, NULL, NULL, pbstrErrorDescription);
-    ExitOnFailure2(hr, "failed to create database: %ls, Query: %ls", pwzDatabaseEscaped, pwzQuery);
+    ExitOnFailure(hr, "failed to create database: %ls, Query: %ls", pwzDatabaseEscaped, pwzQuery);
 
 LExit:
     ReleaseStr(pwzQuery);
@@ -526,7 +526,7 @@ extern "C" HRESULT DAPI SqlSessionDropDatabase(
     LPWSTR pwzDatabaseEscaped = NULL;
 
     hr = SqlSessionDatabaseExists(pidbSession, wzDatabase, pbstrErrorDescription);
-    ExitOnFailure1(hr, "failed to determine if exists, database: %ls", wzDatabase);
+    ExitOnFailure(hr, "failed to determine if exists, database: %ls", wzDatabase);
     
     hr = EscapeSqlIdentifier(wzDatabase, &pwzDatabaseEscaped);
     ExitOnFailure(hr, "failed to escape database string");
@@ -534,7 +534,7 @@ extern "C" HRESULT DAPI SqlSessionDropDatabase(
     if (S_OK == hr)
     {
         hr = StrAllocFormatted(&pwzQuery, L"DROP DATABASE %s", pwzDatabaseEscaped);
-        ExitOnFailure1(hr, "failed to allocate query to drop database: %ls", pwzDatabaseEscaped);
+        ExitOnFailure(hr, "failed to allocate query to drop database: %ls", pwzDatabaseEscaped);
 
         hr = SqlSessionExecuteQuery(pidbSession, pwzQuery, NULL, NULL, pbstrErrorDescription);
         ExitOnFailure(hr, "Failed to drop database");
@@ -588,13 +588,13 @@ extern "C" HRESULT DAPI SqlSessionExecuteQuery(
     hr = picmd->QueryInterface(IID_ICommandText, (LPVOID*)&picmdText);
     ExitOnFailure(hr, "failed to get command text object for command");
     hr = picmdText->SetCommandText(DBGUID_DEFAULT , wzSql);
-    ExitOnFailure1(hr, "failed to set SQL string: %ls", wzSql);
+    ExitOnFailure(hr, "failed to set SQL string: %ls", wzSql);
 
     //
     // execute the command
     //
     hr = picmd->Execute(NULL, (ppirs) ? IID_IRowset : IID_NULL, NULL, &cRows, reinterpret_cast<IUnknown**>(ppirs));
-    ExitOnFailure1(hr, "failed to execute SQL string: %ls", wzSql);
+    ExitOnFailure(hr, "failed to execute SQL string: %ls", wzSql);
 
     if (DB_S_ERRORSOCCURRED == hr)
     {
@@ -661,13 +661,13 @@ extern "C" HRESULT DAPI SqlCommandExecuteQuery(
     hr = picmd->QueryInterface(IID_ICommandText, (LPVOID*)&picmdText);
     ExitOnFailure(hr, "failed to get command text object for command");
     hr = picmdText->SetCommandText(DBGUID_DEFAULT , wzSql);
-    ExitOnFailure1(hr, "failed to set SQL string: %ls", wzSql);
+    ExitOnFailure(hr, "failed to set SQL string: %ls", wzSql);
 
     //
     // execute the command
     //
     hr = picmd->Execute(NULL, (ppirs) ? IID_IRowset : IID_NULL, NULL, &cRows, reinterpret_cast<IUnknown**>(ppirs));
-    ExitOnFailure1(hr, "failed to execute SQL string: %ls", wzSql);
+    ExitOnFailure(hr, "failed to execute SQL string: %ls", wzSql);
 
     if (DB_S_ERRORSOCCURRED == hr)
     {
@@ -804,27 +804,27 @@ static HRESULT FileSpecToString(
     ExitOnNull(*psf->wzFilename, hr, E_INVALIDARG, "filename not specified in database file info");
 
     hr = StrAllocFormatted(&pwz, L"%sNAME=%s", pwz, psf->wzName);
-    ExitOnFailure1(hr, "failed to format database file info name: %ls", psf->wzName);
+    ExitOnFailure(hr, "failed to format database file info name: %ls", psf->wzName);
 
     hr = StrAllocFormatted(&pwz, L"%s, FILENAME='%s'", pwz, psf->wzFilename);
-    ExitOnFailure1(hr, "failed to format database file info filename: %ls", psf->wzFilename);
+    ExitOnFailure(hr, "failed to format database file info filename: %ls", psf->wzFilename);
 
     if (0 != psf->wzSize[0])
     {
         hr = StrAllocFormatted(&pwz, L"%s, SIZE=%s", pwz, psf->wzSize);
-        ExitOnFailure1(hr, "failed to format database file info size: %s", psf->wzSize);
+        ExitOnFailure(hr, "failed to format database file info size: %s", psf->wzSize);
     }
 
     if (0 != psf->wzMaxSize[0])
     {
         hr = StrAllocFormatted(&pwz, L"%s, MAXSIZE=%s", pwz, psf->wzMaxSize);
-        ExitOnFailure1(hr, "failed to format database file info maxsize: %s", psf->wzMaxSize);
+        ExitOnFailure(hr, "failed to format database file info maxsize: %s", psf->wzMaxSize);
     }
 
     if (0 != psf->wzGrow[0])
     {
         hr = StrAllocFormatted(&pwz, L"%s, FILEGROWTH=%s", pwz, psf->wzGrow);
-        ExitOnFailure1(hr, "failed to format database file info growth: %s", psf->wzGrow);
+        ExitOnFailure(hr, "failed to format database file info growth: %s", psf->wzGrow);
     }
 
     hr = StrAllocFormatted(&pwz, L"%s)", pwz);
@@ -861,13 +861,13 @@ static HRESULT EscapeSqlIdentifier(
     if (cchIdentifier == 0 || (wzIdentifier[0] == '[' && wzIdentifier[cchIdentifier-1] == ']'))
     {
         hr = StrAllocString(&pwz, wzIdentifier, 0);
-        ExitOnFailure1(hr, "failed to format database name: %ls", wzIdentifier);
+        ExitOnFailure(hr, "failed to format database name: %ls", wzIdentifier);
     }
     else
     {
         //escape it
         hr = StrAllocFormatted(&pwz, L"[%s]", wzIdentifier);
-        ExitOnFailure1(hr, "failed to format escaped database name: %ls", wzIdentifier);
+        ExitOnFailure(hr, "failed to format escaped database name: %ls", wzIdentifier);
     }
 
     *ppwz = pwz;

--- a/src/libs/dutil/strutil.cpp
+++ b/src/libs/dutil/strutil.cpp
@@ -95,7 +95,7 @@ static HRESULT AllocHelper(
     if (cch >= MAXDWORD / sizeof(WCHAR))
     {
         hr = E_OUTOFMEMORY;
-        ExitOnFailure1(hr, "Not enough memory to allocate string of size: %u", cch);
+        ExitOnFailure(hr, "Not enough memory to allocate string of size: %u", cch);
     }
 
     if (*ppwz)
@@ -117,7 +117,7 @@ static HRESULT AllocHelper(
         pwz = static_cast<LPWSTR>(MemAlloc(sizeof(WCHAR) * cch, TRUE));
     }
 
-    ExitOnNull1(pwz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
+    ExitOnNull(pwz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
 
     *ppwz = pwz;
 LExit:
@@ -223,7 +223,7 @@ extern "C" HRESULT DAPI StrAnsiAlloc(
     if (cch >= MAXDWORD / sizeof(WCHAR))
     {
         hr = E_OUTOFMEMORY;
-        ExitOnFailure1(hr, "Not enough memory to allocate string of size: %u", cch);
+        ExitOnFailure(hr, "Not enough memory to allocate string of size: %u", cch);
     }
 
     if (*ppsz)
@@ -235,7 +235,7 @@ extern "C" HRESULT DAPI StrAnsiAlloc(
         psz = static_cast<LPSTR>(MemAlloc(sizeof(CHAR) * cch, TRUE));
     }
 
-    ExitOnNull1(psz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
+    ExitOnNull(psz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
 
     *ppsz = psz;
 LExit:
@@ -452,7 +452,7 @@ extern "C" HRESULT DAPI StrAnsiAllocString(
         cchDest = ::WideCharToMultiByte(uiCodepage, 0, wzSource, -1, NULL, 0, NULL, NULL);
         if (0 == cchDest)
         {
-            ExitWithLastError1(hr, "failed to get required size for conversion to ANSI: %ls", wzSource);
+            ExitWithLastError(hr, "failed to get required size for conversion to ANSI: %ls", wzSource);
         }
 
         --cchDest; // subtract one because WideChageToMultiByte includes space for the NULL terminator that we track below
@@ -468,7 +468,7 @@ extern "C" HRESULT DAPI StrAnsiAllocString(
         if (cch >= MAXDWORD / sizeof(WCHAR))
         {
             hr = E_OUTOFMEMORY;
-            ExitOnFailure1(hr, "Not enough memory to allocate string of size: %u", cch);
+            ExitOnFailure(hr, "Not enough memory to allocate string of size: %u", cch);
         }
 
         if (*ppsz)
@@ -479,14 +479,14 @@ extern "C" HRESULT DAPI StrAnsiAllocString(
         {
             psz = static_cast<LPSTR>(MemAlloc(sizeof(CHAR) * cch, TRUE));
         }
-        ExitOnNull1(psz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
+        ExitOnNull(psz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
 
         *ppsz = psz;
     }
 
     if (0 == ::WideCharToMultiByte(uiCodepage, 0, wzSource, 0 == cchSource ? -1 : (int)cchSource, *ppsz, (int)cch, NULL, NULL))
     {
-        ExitWithLastError1(hr, "failed to convert to ansi: %ls", wzSource);
+        ExitWithLastError(hr, "failed to convert to ansi: %ls", wzSource);
     }
     (*ppsz)[cchDest] = L'\0';
 
@@ -532,7 +532,7 @@ extern "C" HRESULT DAPI StrAllocStringAnsi(
         cchDest = ::MultiByteToWideChar(uiCodepage, 0, szSource, -1, NULL, 0);
         if (0 == cchDest)
         {
-            ExitWithLastError1(hr, "failed to get required size for conversion to unicode: %s", szSource);
+            ExitWithLastError(hr, "failed to get required size for conversion to unicode: %s", szSource);
         }
 
         --cchDest; //subtract one because MultiByteToWideChar includes space for the NULL terminator that we track below
@@ -548,7 +548,7 @@ extern "C" HRESULT DAPI StrAllocStringAnsi(
         if (cch >= MAXDWORD / sizeof(WCHAR))
         {
             hr = E_OUTOFMEMORY;
-            ExitOnFailure1(hr, "Not enough memory to allocate string of size: %u", cch);
+            ExitOnFailure(hr, "Not enough memory to allocate string of size: %u", cch);
         }
 
         if (*ppwz)
@@ -560,14 +560,14 @@ extern "C" HRESULT DAPI StrAllocStringAnsi(
             pwz = static_cast<LPWSTR>(MemAlloc(sizeof(WCHAR) * cch, TRUE));
         }
 
-        ExitOnNull1(pwz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
+        ExitOnNull(pwz, hr, E_OUTOFMEMORY, "failed to allocate string, len: %u", cch);
 
         *ppwz = pwz;
     }
 
     if (0 == ::MultiByteToWideChar(uiCodepage, 0, szSource, 0 == cchSource ? -1 : (int)cchSource, *ppwz, (int)cch))
     {
-        ExitWithLastError1(hr, "failed to convert to unicode: %s", szSource);
+        ExitWithLastError(hr, "failed to convert to unicode: %s", szSource);
     }
     (*ppwz)[cchDest] = L'\0';
 
@@ -678,7 +678,7 @@ extern "C" HRESULT DAPI StrAllocPrefix(
     {
         cch = cchPrefix + cchLen + 1;
         hr = StrAlloc(ppwz, cch);
-        ExitOnFailure1(hr, "failed to allocate string from string: %ls", wzPrefix);
+        ExitOnFailure(hr, "failed to allocate string from string: %ls", wzPrefix);
     }
 
     if (*ppwz)
@@ -784,7 +784,7 @@ static HRESULT AllocConcatHelper(
     {
         cch = (cchSource + cchLen + 1) * 2;
         hr = AllocHelper(ppwz, cch, fZeroOnRealloc);
-        ExitOnFailure1(hr, "failed to allocate string from string: %ls", wzSource);
+        ExitOnFailure(hr, "failed to allocate string from string: %ls", wzSource);
     }
 
     if (*ppwz)
@@ -853,7 +853,7 @@ extern "C" HRESULT DAPI StrAnsiAllocConcat(
     {
         cch = (cchSource + cchLen + 1) * 2;
         hr = StrAnsiAlloc(ppz, cch);
-        ExitOnFailure1(hr, "failed to allocate string from string: %ls", pzSource);
+        ExitOnFailure(hr, "failed to allocate string from string: %ls", pzSource);
     }
 
     if (*ppz)
@@ -1025,7 +1025,7 @@ static HRESULT AllocFormattedArgsHelper(
         cch = 256;
 
         hr = AllocHelper(ppwz, cch, fZeroOnRealloc);
-        ExitOnFailure1(hr, "failed to allocate string to format: %ls", wzFormat);
+        ExitOnFailure(hr, "failed to allocate string to format: %ls", wzFormat);
     }
 
     // format the message (grow until it fits or there is a failure)
@@ -1049,7 +1049,7 @@ static HRESULT AllocFormattedArgsHelper(
             cch *= 2;
 
             hr = AllocHelper(ppwz, cch, fZeroOnRealloc);
-            ExitOnFailure1(hr, "failed to allocate string to format: %ls", wzFormat);
+            ExitOnFailure(hr, "failed to allocate string to format: %ls", wzFormat);
 
             hr = S_FALSE;
         }
@@ -1104,7 +1104,7 @@ extern "C" HRESULT DAPI StrAnsiAllocFormattedArgs(
     {
         cch = 256;
         hr = StrAnsiAlloc(ppsz, cch);
-        ExitOnFailure1(hr, "failed to allocate string to format: %s", szFormat);
+        ExitOnFailure(hr, "failed to allocate string to format: %s", szFormat);
     }
 
     // format the message (grow until it fits or there is a failure)
@@ -1128,7 +1128,7 @@ extern "C" HRESULT DAPI StrAnsiAllocFormattedArgs(
             }
             cch *= 2;
             hr = StrAnsiAlloc(ppsz, cch);
-            ExitOnFailure1(hr, "failed to allocate string to format: %ls", szFormat);
+            ExitOnFailure(hr, "failed to allocate string to format: %ls", szFormat);
             hr = S_FALSE;
         }
     } while (S_FALSE == hr);
@@ -1169,7 +1169,7 @@ extern "C" HRESULT DAPI StrAllocFromError(
 
     if (0 == cchMessage)
     {
-        ExitWithLastError1(hr, "Failed to format message for error: 0x%x", hrError);
+        ExitWithLastError(hr, "Failed to format message for error: 0x%x", hrError);
     }
 
     hr = StrAllocString(ppwzMessage, reinterpret_cast<LPCWSTR>(pvMessage), cchMessage);
@@ -1425,7 +1425,7 @@ extern "C" HRESULT DAPI StrHexDecode(
     if (cbDest < cchSource / 2)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
-        ExitOnRootFailure3(hr, "Insufficient buffer to decode string '%ls' len: %u into %u bytes.", wzSource, cchSource, cbDest);
+        ExitOnRootFailure(hr, "Insufficient buffer to decode string '%ls' len: %u into %u bytes.", wzSource, cchSource, cbDest);
     }
 
     for (i = 0; i < cchSource / 2; ++i)
@@ -1843,7 +1843,7 @@ extern "C" HRESULT DAPI MultiSzPrepend(
  
     // Prepend
     hr = ::StringCchCopyW(pwzResult, cchResult, pwzInsert);
-    ExitOnFailure1(hr, "failed to copy prepend string: %ls", pwzInsert);
+    ExitOnFailure(hr, "failed to copy prepend string: %ls", pwzInsert);
 
     // If there was no MULTISZ, double null terminate our result, otherwise, copy the MULTISZ in
     if (0 == cchMultiSz)
@@ -2136,7 +2136,7 @@ extern "C" HRESULT DAPI MultiSzInsertString(
         if ((dwCurrentIndex + 1 != dwIndex && L'\0' == *(wz + 1)) || cchProgress >= cchMultiSz)
         {
             hr = HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND);
-            ExitOnRootFailure1(hr, "requested to insert into an invalid index: %u in a MULTISZ", dwIndex);
+            ExitOnRootFailure(hr, "requested to insert into an invalid index: %u in a MULTISZ", dwIndex);
         }
 
         // Move on to the next string
@@ -2197,10 +2197,10 @@ extern "C" HRESULT DAPI MultiSzReplaceString(
     HRESULT hr = S_OK;
 
     hr = MultiSzRemoveString(ppwzMultiSz, dwIndex);
-    ExitOnFailure1(hr, "failed to remove string from MULTISZ at the specified index: %u", dwIndex);
+    ExitOnFailure(hr, "failed to remove string from MULTISZ at the specified index: %u", dwIndex);
 
     hr = MultiSzInsertString(ppwzMultiSz, NULL, dwIndex, pwzString);
-    ExitOnFailure1(hr, "failed to insert string into MULTISZ at the specified index: %u", dwIndex);
+    ExitOnFailure(hr, "failed to insert string into MULTISZ at the specified index: %u", dwIndex);
 
 LExit:
     return hr;
@@ -2555,7 +2555,7 @@ extern "C" HRESULT DAPI StrArrayFree(
         if (NULL != rgsczStrArray[i])
         {
             hr = StrFree(rgsczStrArray[i]);
-            ExitOnFailure1(hr, "Failed to free the string at index %u.", i);
+            ExitOnFailure(hr, "Failed to free the string at index %u.", i);
         }
     }
 

--- a/src/libs/dutil/thmutil.cpp
+++ b/src/libs/dutil/thmutil.cpp
@@ -520,7 +520,7 @@ DAPI_(HRESULT) ThemeLoadControls(
             wzWindowClass = WC_STATICW;
             break;
         }
-        ExitOnFailure1(hr, "Failed to configure control %u.", i);
+        ExitOnFailure(hr, "Failed to configure control %u.", i);
 
         // If the control has a window, set the other information.
         if (wzWindowClass)
@@ -573,7 +573,7 @@ DAPI_(HRESULT) ThemeLoadControls(
 
                     if (-1 == ::SendMessageW(pControl->hWnd, LVM_INSERTCOLUMNW, (WPARAM)(int)(j), (LPARAM)(const LV_COLUMNW *)(&lvc)))
                     {
-                        ExitWithLastError1(hr, "Failed to insert listview column %u into tab control", j);
+                        ExitWithLastError(hr, "Failed to insert listview column %u into tab control", j);
                     }
 
                     // Return value tells us old image list, we don't care
@@ -622,7 +622,7 @@ DAPI_(HRESULT) ThemeLoadControls(
 
                     if (-1 == ::SendMessageW(pControl->hWnd, TCM_INSERTITEMW, (WPARAM)(int)(j), (LPARAM)(const TC_ITEMW *)(&tci)))
                     {
-                        ExitWithLastError1(hr, "Failed to insert tab %u into tab control", j);
+                        ExitWithLastError(hr, "Failed to insert tab %u into tab control", j);
                     }
                 }
             }
@@ -978,7 +978,7 @@ extern "C" LRESULT CALLBACK ThemeDefWindowProc(
                         {
                             if (-1 == ::SendMessageW(pTheme->rgControls[i].hWnd, LVM_SETCOLUMNWIDTH, (WPARAM)(int)(j), (LPARAM)(pTheme->rgControls[i].ptcColumns[j].nWidth)))
                             {
-                                Trace2(REPORT_DEBUG, "Failed to resize listview column %u with error %u", j, ::GetLastError());
+                                Trace(REPORT_DEBUG, "Failed to resize listview column %u with error %u", j, ::GetLastError());
                                 return 0;
                             }
                         }
@@ -1907,7 +1907,7 @@ static HRESULT ParseApplication(
         ReleaseNullBSTR(bstr);
 
         pTheme->hIcon = ::LoadImageW(NULL, sczIconFile, IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE);
-        ExitOnNullWithLastError1(pTheme->hIcon, hr, "Failed to load application icon: %ls.", bstr);
+        ExitOnNullWithLastError(pTheme->hIcon, hr, "Failed to load application icon: %ls.", bstr);
     }
 
     hr = XmlGetAttributeNumber(pixn, L"SourceX", reinterpret_cast<DWORD*>(&pTheme->nSourceX));
@@ -2259,7 +2259,7 @@ static HRESULT ParseImageLists(
                     hBitmap = NULL;
                 }
                 hr = ParseImage(NULL, NULL, pixnImage, &hBitmap);
-                ExitOnFailure1(hr, "Failed to parse image: %u", i);
+                ExitOnFailure(hr, "Failed to parse image: %u", i);
 
                 if (0 == i)
                 {
@@ -2272,7 +2272,7 @@ static HRESULT ParseImageLists(
                 iRetVal = ImageList_Add(pTheme->rgImageLists[dwImageListIndex].hImageList, hBitmap, NULL);
                 if (-1 == iRetVal)
                 {
-                    ExitWithLastError1(hr, "Failed to add image %u to image list", i);
+                    ExitWithLastError(hr, "Failed to add image %u to image list", i);
                 }
 
                 ++i;
@@ -2335,7 +2335,7 @@ static HRESULT ParseControls(
     if (pPage)
     {
         hr = ::SizeTMult(sizeof(DWORD), cNewControls, &cbAllocSize);
-        ExitOnFailure1(hr, "Overflow while calculating allocation size for %u control indices", cNewControls);
+        ExitOnFailure(hr, "Overflow while calculating allocation size for %u control indices", cNewControls);
 
         pPage->rgdwControlIndices = static_cast<DWORD*>(MemAlloc(cbAllocSize, TRUE));
         ExitOnNull(pPage->rgdwControlIndices, hr, E_OUTOFMEMORY, "Failed to allocate theme page controls.");
@@ -2896,7 +2896,7 @@ static HRESULT ParseBillboards(
     if (0 < pControl->cBillboards)
     {
         hr = ::SizeTMult(sizeof(THEME_BILLBOARD), pControl->cBillboards, &cbAllocSize);
-        ExitOnFailure1(hr, "Overflow while calculating allocation size for %u THEME_BILLBOARD structs", pControl->cBillboards);
+        ExitOnFailure(hr, "Overflow while calculating allocation size for %u THEME_BILLBOARD structs", pControl->cBillboards);
 
         pControl->ptbBillboards = static_cast<THEME_BILLBOARD*>(MemAlloc(cbAllocSize, TRUE));
         ExitOnNull(pControl->ptbBillboards, hr, E_OUTOFMEMORY, "Failed to allocate billboard image structs.");
@@ -2953,7 +2953,7 @@ static HRESULT ParseColumns(
     if (0 < pControl->cColumns)
     {
         hr = ::SizeTMult(sizeof(THEME_COLUMN), pControl->cColumns, &cbAllocSize);
-        ExitOnFailure1(hr, "Overflow while calculating allocation size for %u THEME_COLUMN structs", pControl->cColumns);
+        ExitOnFailure(hr, "Overflow while calculating allocation size for %u THEME_COLUMN structs", pControl->cColumns);
 
         pControl->ptcColumns = static_cast<THEME_COLUMN*>(MemAlloc(cbAllocSize, TRUE));
         ExitOnNull(pControl->ptcColumns, hr, E_OUTOFMEMORY, "Failed to allocate column structs.");
@@ -3020,7 +3020,7 @@ static HRESULT ParseTabs(
     if (0 < pControl->cTabs)
     {
         hr = ::SizeTMult(sizeof(THEME_TAB), pControl->cTabs, &cbAllocSize);
-        ExitOnFailure1(hr, "Overflow while calculating allocation size for %u THEME_TAB structs", pControl->cTabs);
+        ExitOnFailure(hr, "Overflow while calculating allocation size for %u THEME_TAB structs", pControl->cTabs);
 
         pControl->pttTabs = static_cast<THEME_TAB*>(MemAlloc(cbAllocSize, TRUE));
         ExitOnNull(pControl->pttTabs, hr, E_OUTOFMEMORY, "Failed to allocate tab structs.");
@@ -3512,7 +3512,7 @@ static HRESULT OnRichEditEnLink(
         if (0 < ::SendMessageW(hWndRichEdit, EM_GETTEXTRANGE, 0, reinterpret_cast<LPARAM>(&tr)))
         {
             hr = ShelExec(sczLink, NULL, L"open", NULL, SW_SHOWDEFAULT, hWnd, NULL);
-            ExitOnFailure1(hr, "Failed to launch link: %ls", sczLink);
+            ExitOnFailure(hr, "Failed to launch link: %ls", sczLink);
         }
         
         break;

--- a/src/libs/dutil/timeutil.cpp
+++ b/src/libs/dutil/timeutil.cpp
@@ -69,7 +69,7 @@ extern "C" HRESULT DAPI TimeFromString(
             {
                 case DayOfWeek:
                     hr = DayFromString(pwzStart, &sysTime.wDayOfWeek);
-                    ExitOnFailure1(hr, "Failed to convert string to day: %ls", pwzStart);
+                    ExitOnFailure(hr, "Failed to convert string to day: %ls", pwzStart);
                     break;
 
                 case DayOfMonth:
@@ -78,7 +78,7 @@ extern "C" HRESULT DAPI TimeFromString(
 
                 case MonthOfYear:
                     hr = MonthFromString(pwzStart, &sysTime.wMonth);
-                    ExitOnFailure1(hr, "Failed to convert to month: %ls", pwzStart);
+                    ExitOnFailure(hr, "Failed to convert to month: %ls", pwzStart);
                     break;
 
                 case Year:

--- a/src/libs/dutil/uncutil.cpp
+++ b/src/libs/dutil/uncutil.cpp
@@ -36,7 +36,7 @@ DAPI_(HRESULT) UncConvertFromMountedDrive(
         er = ERROR_SUCCESS;
 
         hr = StrAlloc(psczUNCPath, dwLength);
-        ExitOnFailure1(hr, "Failed to allocate string to get raw UNC path of length %u", dwLength);
+        ExitOnFailure(hr, "Failed to allocate string to get raw UNC path of length %u", dwLength);
 
         er = ::WNetGetConnectionW(sczDrive, *psczUNCPath, &dwLength);
         if (ERROR_CONNECTION_UNAVAIL == er)
@@ -44,7 +44,7 @@ DAPI_(HRESULT) UncConvertFromMountedDrive(
             // This means the drive is remembered but not currently connected, this can mean the location is accessible via UNC path but not via mounted drive path
             er = ERROR_SUCCESS;
         }
-        ExitOnWin32Error1(er, hr, "::WNetGetConnectionW() failed with buffer provided on drive %ls", sczDrive);
+        ExitOnWin32Error(er, hr, "::WNetGetConnectionW() failed with buffer provided on drive %ls", sczDrive);
 
         // Skip drive letter and colon
         hr = StrAllocConcat(psczUNCPath, sczMountedDrivePath + 2, 0);
@@ -57,7 +57,7 @@ DAPI_(HRESULT) UncConvertFromMountedDrive(
             er = ERROR_NO_DATA;
         }
 
-        ExitOnWin32Error1(er, hr, "::WNetGetConnectionW() failed on drive %ls", sczDrive);
+        ExitOnWin32Error(er, hr, "::WNetGetConnectionW() failed on drive %ls", sczDrive);
     }
 
 LExit:

--- a/src/libs/dutil/uriutil.cpp
+++ b/src/libs/dutil/uriutil.cpp
@@ -474,7 +474,7 @@ extern "C" HRESULT DAPI UriResolve(
     URI_PROTOCOL protocol = URI_PROTOCOL_UNKNOWN;
 
     hr = UriProtocol(wzUri, &protocol);
-    ExitOnFailure1(hr, "Failed to determine protocol for URL: %ls", wzUri);
+    ExitOnFailure(hr, "Failed to determine protocol for URL: %ls", wzUri);
 
     ExitOnNull(ppwzResolvedUri, hr, E_INVALIDARG, "Failed to resolve URI, because no method of output was provided");
 
@@ -485,7 +485,7 @@ extern "C" HRESULT DAPI UriResolve(
         if (L'/' == *wzUri || L'\\' == *wzUri)
         {
             hr = UriRoot(wzBaseUri, ppwzResolvedUri, &protocol);
-            ExitOnFailure1(hr, "Failed to get root from URI: %ls", wzBaseUri);
+            ExitOnFailure(hr, "Failed to get root from URI: %ls", wzBaseUri);
 
             hr = StrAllocConcat(ppwzResolvedUri, wzUri, 0);
             ExitOnFailure(hr, "Failed to concat file to base URI.");
@@ -493,13 +493,13 @@ extern "C" HRESULT DAPI UriResolve(
         else
         {
             hr = UriProtocol(wzBaseUri, &protocol);
-            ExitOnFailure1(hr, "Failed to get protocol of base URI: %ls", wzBaseUri);
+            ExitOnFailure(hr, "Failed to get protocol of base URI: %ls", wzBaseUri);
 
             LPCWSTR pwcFile = const_cast<LPCWSTR> (UriFile(wzBaseUri));
             if (!pwcFile)
             {
                 hr = E_INVALIDARG;
-                ExitOnFailure1(hr, "Failed to get file from base URI: %ls", wzBaseUri);
+                ExitOnFailure(hr, "Failed to get file from base URI: %ls", wzBaseUri);
             }
 
             hr = StrAllocString(ppwzResolvedUri, wzBaseUri, pwcFile - wzBaseUri);

--- a/src/libs/dutil/wiutil.cpp
+++ b/src/libs/dutil/wiutil.cpp
@@ -373,7 +373,7 @@ extern "C" HRESULT DAPI WiuQueryFeatureState(
     if (INSTALLSTATE_INVALIDARG == *pInstallState)
     {
         hr = E_INVALIDARG;
-        ExitOnRootFailure2(hr, "Failed to query state of feature: %ls in product: %ls", wzFeature, wzProduct);
+        ExitOnRootFailure(hr, "Failed to query state of feature: %ls in product: %ls", wzFeature, wzProduct);
     }
 
 LExit:
@@ -626,7 +626,7 @@ extern "C" HRESULT DAPI WiuEnumRelatedProducts(
     {
         ExitFunction1(hr = HRESULT_FROM_WIN32(er));
     }
-    ExitOnWin32Error1(er, hr, "Failed to enumerate related products for updgrade code: %ls", wzUpgradeCode);
+    ExitOnWin32Error(er, hr, "Failed to enumerate related products for updgrade code: %ls", wzUpgradeCode);
 
 LExit:
     return hr;
@@ -666,16 +666,16 @@ extern "C" HRESULT DAPI WiuEnumRelatedProductCodes(
             hr = S_OK;
             break;
         }
-        ExitOnFailure1(hr, "Failed to enumerate related products for upgrade code: %ls", wzUpgradeCode);
+        ExitOnFailure(hr, "Failed to enumerate related products for upgrade code: %ls", wzUpgradeCode);
 
         if (fReturnHighestVersionOnly)
         {
             // get the version
             hr = WiuGetProductInfo(wzCurrentProductCode, L"VersionString", &sczInstalledVersion);
-            ExitOnFailure1(hr, "Failed to get version for product code: %ls", wzCurrentProductCode);
+            ExitOnFailure(hr, "Failed to get version for product code: %ls", wzCurrentProductCode);
 
             hr = FileVersionFromStringEx(sczInstalledVersion, 0, &qwCurrentVersion);
-            ExitOnFailure2(hr, "Failed to convert version: %ls to DWORD64 for product code: %ls", sczInstalledVersion, wzCurrentProductCode);
+            ExitOnFailure(hr, "Failed to convert version: %ls to DWORD64 for product code: %ls", sczInstalledVersion, wzCurrentProductCode);
 
             // if this is the first product found then it is the highest version (for now)
             if (0 == *pcRelatedProducts)
@@ -813,7 +813,7 @@ extern "C" HRESULT DAPI WiuConfigureProductEx(
 
     er = vpfnMsiConfigureProductExW(wzProduct, iInstallLevel, eInstallState, wzCommandLine);
     er = CheckForRestartErrorCode(er, pRestart);
-    ExitOnWin32Error1(er, hr, "Failed to configure product: %ls", wzProduct);
+    ExitOnWin32Error(er, hr, "Failed to configure product: %ls", wzProduct);
 
 LExit:
     return hr;
@@ -831,7 +831,7 @@ extern "C" HRESULT DAPI WiuInstallProduct(
 
     er = vpfnMsiInstallProductW(wzPackagePath, wzCommandLine);
     er = CheckForRestartErrorCode(er, pRestart);
-    ExitOnWin32Error1(er, hr, "Failed to install product: %ls", wzPackagePath);
+    ExitOnWin32Error(er, hr, "Failed to install product: %ls", wzPackagePath);
 
 LExit:
     return hr;
@@ -988,7 +988,7 @@ static INT HandleInstallMessage(
 {
     INT nResult = IDNOACTION;
 
-Trace2(REPORT_STANDARD, "MSI install[%x]: %ls", pContext->dwCurrentProgressIndex, wzMessage);
+Trace(REPORT_STANDARD, "MSI install[%x]: %ls", pContext->dwCurrentProgressIndex, wzMessage);
 
     // Handle the message.
     switch (mt)
@@ -1138,7 +1138,7 @@ static INT HandleInstallProgress(
 #ifdef _DEBUG
     WCHAR wz[256];
     ::StringCchPrintfW(wz, countof(wz), L"1: %d 2: %d 3: %d 4: %d", iFields[0], iFields[1], iFields[2], iFields[3]);
-    Trace2(REPORT_STANDARD, "MSI progress[%x]: %ls", pContext->dwCurrentProgressIndex, wz);
+    Trace(REPORT_STANDARD, "MSI progress[%x]: %ls", pContext->dwCurrentProgressIndex, wz);
 #endif
 
     // Verify that we have the enough field values.
@@ -1153,10 +1153,10 @@ static INT HandleInstallProgress(
     case 0: // master progress reset
         if (4 > cFields)
         {
-            Trace2(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
+            Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
             ExitFunction();
         }
-        //Trace3(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - MASTER RESET - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
+        //Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - MASTER RESET - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
 
         // Update the index into progress array.
         if (WIU_MSI_PROGRESS_INVALID == pContext->dwCurrentProgressIndex)
@@ -1198,10 +1198,10 @@ static INT HandleInstallProgress(
     case 1: // action info.
         if (3 > cFields)
         {
-            Trace2(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
+            Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
             ExitFunction();
         }
-        //Trace3(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - ACTION INFO - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
+        //Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - ACTION INFO - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
 
         if (0 == iFields[2])
         {
@@ -1217,11 +1217,11 @@ static INT HandleInstallProgress(
     case 2: // progress report.
         if (2 > cFields)
         {
-            Trace2(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
+            Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - Invalid field count %d, '%ls'", cFields, wzMessage);
             break;
         }
 
-        //Trace3(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - PROGRESS REPORT - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
+        //Trace(REPORT_STANDARD, "INSTALLMESSAGE_PROGRESS - PROGRESS REPORT - %d, %d, %d", iFields[1], iFields[2], iFields[3]);
 
         if (WIU_MSI_PROGRESS_INVALID == pContext->dwCurrentProgressIndex)
         {
@@ -1398,7 +1398,7 @@ static INT SendProgressUpdate(
 #ifdef _DEBUG
     DWORD64 qwCompleted = pContext->rgMsiProgress[pContext->dwCurrentProgressIndex].dwCompleted;
     DWORD64 qwTotal = pContext->rgMsiProgress[pContext->dwCurrentProgressIndex].dwTotal;
-    Trace3(REPORT_STANDARD, "MSI progress: %I64u/%I64u (%u%%)", qwCompleted, qwTotal, dwPercentage);
+    Trace(REPORT_STANDARD, "MSI progress: %I64u/%I64u (%u%%)", qwCompleted, qwTotal, dwPercentage);
     //AssertSz(qwCompleted <= qwTotal, "Completed progress is larger than total progress.");
 #endif
 

--- a/src/libs/dutil/xmlutil.cpp
+++ b/src/libs/dutil/xmlutil.cpp
@@ -234,28 +234,28 @@ static void XmlReportParseError(
 
     hr = pixpe->get_errorCode(&lNumber);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.errorCode.");
-    Trace1(REPORT_STANDARD, "errorCode = 0x%x", lNumber);
+    Trace(REPORT_STANDARD, "errorCode = 0x%x", lNumber);
 
     hr = pixpe->get_filepos(&lNumber);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.filepos.");
-    Trace1(REPORT_STANDARD, "filepos = %d", lNumber);
+    Trace(REPORT_STANDARD, "filepos = %d", lNumber);
 
     hr = pixpe->get_line(&lNumber);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.line.");
-    Trace1(REPORT_STANDARD, "line = %d", lNumber);
+    Trace(REPORT_STANDARD, "line = %d", lNumber);
 
     hr = pixpe->get_linepos(&lNumber);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.linepos.");
-    Trace1(REPORT_STANDARD, "linepos = %d", lNumber);
+    Trace(REPORT_STANDARD, "linepos = %d", lNumber);
 
     hr = pixpe->get_reason(&bstr);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.reason.");
-    Trace1(REPORT_STANDARD, "reason = %ls", bstr);
+    Trace(REPORT_STANDARD, "reason = %ls", bstr);
     ReleaseNullBSTR(bstr);
 
     hr = pixpe->get_srcText (&bstr);
     ExitOnFailure(hr, "Failed to query IXMLDOMParseError.srcText .");
-    Trace1(REPORT_STANDARD, "srcText = %ls", bstr);
+    Trace(REPORT_STANDARD, "srcText = %ls", bstr);
     ReleaseNullBSTR(bstr);
 
 LExit:
@@ -403,7 +403,7 @@ extern "C" HRESULT DAPI XmlLoadDocumentFromFileEx(
         XmlReportParseError(pixpe);
     }
 
-    ExitOnFailure1(hr, "failed to load XML from: %ls", wzPath);
+    ExitOnFailure(hr, "failed to load XML from: %ls", wzPath);
 
     if (ppixdDocument)
     {
@@ -502,7 +502,7 @@ extern "C" HRESULT DAPI XmlSetAttribute(
     ExitOnNull(bstrAttributeName, hr, E_OUTOFMEMORY, "failed to allocate bstr for AttributeName in XmlSetAttribute");
 
     hr = pixnNode->get_attributes(&pixnnmAttributes);
-    ExitOnFailure1(hr, "failed get_attributes in XmlSetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed get_attributes in XmlSetAttribute(%ls)", pwzAttribute);
 
     hr = pixnNode->get_ownerDocument(&pixdDocument);
     if (hr == S_FALSE)
@@ -512,7 +512,7 @@ extern "C" HRESULT DAPI XmlSetAttribute(
     ExitOnFailure(hr, "failed get_ownerDocument in XmlSetAttribute");
 
     hr = pixdDocument->createAttribute(bstrAttributeName, &pixaAttribute);
-    ExitOnFailure1(hr, "failed createAttribute in XmlSetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed createAttribute in XmlSetAttribute(%ls)", pwzAttribute);
 
     varAttributeValue.vt = VT_BSTR;
     varAttributeValue.bstrVal = ::SysAllocString(pwzAttributeValue);
@@ -523,10 +523,10 @@ extern "C" HRESULT DAPI XmlSetAttribute(
     ExitOnFailure(hr, "failed SysAllocString in XmlSetAttribute");
 
     hr = pixaAttribute->put_nodeValue(varAttributeValue);
-    ExitOnFailure1(hr, "failed put_nodeValue in XmlSetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed put_nodeValue in XmlSetAttribute(%ls)", pwzAttribute);
 
     hr = pixnnmAttributes->setNamedItem(pixaAttribute, &pixaNode);
-    ExitOnFailure1(hr, "failed setNamedItem in XmlSetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed setNamedItem in XmlSetAttribute(%ls)", pwzAttribute);
 
 LExit:
     ReleaseObject(pixdDocument);
@@ -640,10 +640,10 @@ extern "C" HRESULT DAPI XmlGetAttribute(
         // hr = E_FAIL;
         ExitFunction();
     }
-    ExitOnFailure1(hr, "failed getNamedItem in XmlGetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed getNamedItem in XmlGetAttribute(%ls)", pwzAttribute);
 
     hr = pixnAttribute->get_nodeValue(&varAttributeValue);
-    ExitOnFailure1(hr, "failed get_nodeValue in XmlGetAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed get_nodeValue in XmlGetAttribute(%ls)", pwzAttribute);
 
     // steal the BSTR from the VARIANT
     if (S_OK == hr && pbstrAttributeValue)
@@ -693,14 +693,14 @@ HRESULT DAPI XmlGetAttributeEx(
     {
         ExitFunction1(hr = E_NOTFOUND);
     }
-    ExitOnFailure1(hr, "Failed getNamedItem in XmlGetAttribute(%ls)", wzAttribute);
+    ExitOnFailure(hr, "Failed getNamedItem in XmlGetAttribute(%ls)", wzAttribute);
 
     hr = pixnAttribute->get_nodeValue(&varAttributeValue);
     if (S_FALSE == hr)
     {
         ExitFunction1(hr = E_NOTFOUND);
     }
-    ExitOnFailure1(hr, "Failed get_nodeValue in XmlGetAttribute(%ls)", wzAttribute);
+    ExitOnFailure(hr, "Failed get_nodeValue in XmlGetAttribute(%ls)", wzAttribute);
 
     // copy value
     hr = StrAllocString(psczAttributeValue, varAttributeValue.bstrVal, 0);
@@ -913,10 +913,10 @@ extern "C" HRESULT DAPI XmlSetText(
         ExitOnFailure(hr, "failed get_ownerDocument in XmlSetAttribute");
 
         hr = XmlCreateTextNode(pixdDocument, pwzText, &pixtTextNode);
-        ExitOnFailure1(hr, "failed createTextNode in XmlSetText(%ls)", pwzText);
+        ExitOnFailure(hr, "failed createTextNode in XmlSetText(%ls)", pwzText);
 
         hr = pixnNode->appendChild(pixtTextNode, NULL);
-        ExitOnFailure1(hr, "failed appendChild in XmlSetText(%ls)", pwzText);
+        ExitOnFailure(hr, "failed appendChild in XmlSetText(%ls)", pwzText);
     }
 
     hr = *pwzText ? S_OK : S_FALSE;
@@ -1019,10 +1019,10 @@ extern "C" HRESULT DAPI XmlRemoveAttribute(
     ExitOnNull(bstrAttribute, hr, E_OUTOFMEMORY, "failed to allocate bstr for attribute in XmlRemoveAttribute");
 
     hr = pixnNode->get_attributes(&pixnnmAttributes);
-    ExitOnFailure1(hr, "failed get_attributes in RemoveXmlAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed get_attributes in RemoveXmlAttribute(%ls)", pwzAttribute);
 
     hr = pixnnmAttributes->removeNamedItem(bstrAttribute, NULL);
-    ExitOnFailure1(hr, "failed removeNamedItem in RemoveXmlAttribute(%ls)", pwzAttribute);
+    ExitOnFailure(hr, "failed removeNamedItem in RemoveXmlAttribute(%ls)", pwzAttribute);
 
 LExit:
     ReleaseObject(pixnnmAttributes);

--- a/src/libs/wcautil/wcascript.cpp
+++ b/src/libs/wcautil/wcascript.cpp
@@ -67,7 +67,7 @@ extern "C" HRESULT WIXAPI WcaCaScriptCreate(
     hScriptFile = ::CreateFileW(pwzScriptPath, GENERIC_WRITE, FILE_SHARE_READ, NULL, fAppend ? OPEN_ALWAYS : CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hScriptFile)
     {
-        ExitWithLastError1(hr, "Failed to open CaScript: %ls", pwzScriptPath);
+        ExitWithLastError(hr, "Failed to open CaScript: %ls", pwzScriptPath);
     }
 
     if (fAppend && INVALID_SET_FILE_POINTER == ::SetFilePointer(hScriptFile, 0, NULL, FILE_END))
@@ -117,7 +117,7 @@ extern "C" HRESULT WIXAPI WcaCaScriptOpen(
     hScriptFile = ::CreateFileW(pwzScriptPath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (INVALID_HANDLE_VALUE == hScriptFile)
     {
-        ExitWithLastError1(hr, "Failed to open CaScript: %ls", pwzScriptPath);
+        ExitWithLastError(hr, "Failed to open CaScript: %ls", pwzScriptPath);
     }
 
     *phScript = static_cast<WCA_CASCRIPT_HANDLE>(MemAlloc(sizeof(WCA_CASCRIPT_STRUCT), TRUE));
@@ -381,7 +381,7 @@ extern "C" void WIXAPI WcaCaScriptCleanup(
     hff = ::FindFirstFileW(pwzWildCardPath, &fd);
     if (INVALID_HANDLE_VALUE == hff)
     {
-        ExitWithLastError1(hr, "Failed to find files with pattern: %ls", pwzWildCardPath);
+        ExitWithLastError(hr, "Failed to find files with pattern: %ls", pwzWildCardPath);
     }
 
     do

--- a/src/libs/wcautil/wcautil.cpp
+++ b/src/libs/wcautil/wcautil.cpp
@@ -96,7 +96,7 @@ extern "C" HRESULT WIXAPI WcaInitialize(
     s_hDatabase = ::MsiGetActiveDatabase(s_hInstall); // may return null if deferred CustomAction
 
     hr = ::StringCchCopy(s_szCustomActionLogName, countof(s_szCustomActionLogName), szCustomActionLogName);
-    ExitOnFailure1(hr, "Failed to copy CustomAction log name: %s", szCustomActionLogName);
+    ExitOnFailure(hr, "Failed to copy CustomAction log name: %s", szCustomActionLogName);
 
     // If we got the database handle IE: immediate CA
     if (s_hDatabase)

--- a/src/libs/wcautil/wcautil.h
+++ b/src/libs/wcautil/wcautil.h
@@ -24,17 +24,17 @@ extern "C" {
 
 #include "dutil.h"
 
-#define MessageExitOnLastError(x, e, s)      { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace(x, "%s", s); WcaErrorMessage(e, x, MB_OK, 0);  goto LExit; } }
-#define MessageExitOnLastError1(x, e, f, s)  { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace1(x, f, s); WcaErrorMessage(e, x, MB_OK, 1, s);  goto LExit; } }
+#define MessageExitOnLastError(x, e, s, ...)      { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; } }
+#define MessageExitOnLastError1 MessageExitOnLastError
 
-#define MessageExitOnFailure(x, e, s)           if (FAILED(x)) { ExitTrace(x, "%s", s); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 0);  goto LExit; }
-#define MessageExitOnFailure1(x, e, f, s)       if (FAILED(x)) { ExitTrace1(x, f, s); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 1, s);  goto LExit; }
-#define MessageExitOnFailure2(x, e, f, s, t)    if (FAILED(x)) { ExitTrace2(x, f, s, t); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 2, s, t);  goto LExit; }
-#define MessageExitOnFailure3(x, e, f, s, t, u) if (FAILED(x)) { ExitTrace2(x, f, s, t, u); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 3, s, t, u);  goto LExit; }
+#define MessageExitOnFailure(x, e, s, ...)           if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 0, __VA_ARGS__);  goto LExit; }
+#define MessageExitOnFailure1 MessageExitOnFailure
+#define MessageExitOnFailure2 MessageExitOnFailure
+#define MessageExitOnFailure3 MessageExitOnFailure
 
-#define MessageExitOnNullWithLastError(p, x, e, s) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, "%s", s); WcaErrorMessage(e, x, MB_OK, 0);  goto LExit; }
-#define MessageExitOnNullWithLastError1(p, x, e, f, s) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, f, s); WcaErrorMessage(e, x, MB_OK, 1, s);  goto LExit; }
-#define MessageExitOnNullWithLastError2(p, x, e, f, s, t) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, f, s, t); WcaErrorMessage(e, x, MB_OK, 2, s, t);  goto LExit; }
+#define MessageExitOnNullWithLastError(p, x, e, s, ...) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; }
+#define MessageExitOnNullWithLastError1 MessageExitOnNullWithLastError
+#define MessageExitOnNullWithLastError2 MessageExitOnNullWithLastError
 
 // Generic action enum.
 typedef enum WCA_ACTION

--- a/src/libs/wcautil/wcautil.h
+++ b/src/libs/wcautil/wcautil.h
@@ -6,7 +6,7 @@
 //   The license and further copyright text can be found in the file
 //   LICENSE.TXT at the root directory of the distribution.
 // </copyright>
-// 
+//
 // <summary>
 //    WiX CustomAction utility library.
 // </summary>
@@ -18,23 +18,12 @@ extern "C" {
 
 #define WIXAPI __stdcall
 #define ExitTrace WcaLogError
-#define ExitTrace1 WcaLogError
-#define ExitTrace2 WcaLogError
-#define ExitTrace3 WcaLogError
 
 #include "dutil.h"
 
 #define MessageExitOnLastError(x, e, s, ...)      { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; } }
-#define MessageExitOnLastError1 MessageExitOnLastError
-
 #define MessageExitOnFailure(x, e, s, ...)           if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 0, __VA_ARGS__);  goto LExit; }
-#define MessageExitOnFailure1 MessageExitOnFailure
-#define MessageExitOnFailure2 MessageExitOnFailure
-#define MessageExitOnFailure3 MessageExitOnFailure
-
 #define MessageExitOnNullWithLastError(p, x, e, s, ...) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; }
-#define MessageExitOnNullWithLastError1 MessageExitOnNullWithLastError
-#define MessageExitOnNullWithLastError2 MessageExitOnNullWithLastError
 
 // Generic action enum.
 typedef enum WCA_ACTION
@@ -54,7 +43,7 @@ typedef enum WCA_CASCRIPT_CLOSE
 {
     WCA_CASCRIPT_CLOSE_PRESERVE,
     WCA_CASCRIPT_CLOSE_DELETE,
-} WCA_CASCRIPT_CLOSE; 
+} WCA_CASCRIPT_CLOSE;
 
 typedef enum WCA_TODO
 {
@@ -96,7 +85,7 @@ BOOL WIXAPI WcaCancelDetected();
 
 #define LOG_BUFFER 2048
 typedef enum LOGLEVEL
-{ 
+{
     LOGMSG_TRACEONLY,  // Never written to the log file (except in DEBUG builds)
     LOGMSG_VERBOSE,    // Written to log when LOGVERBOSE
     LOGMSG_STANDARD    // Written to log whenever informational logging is enabled
@@ -120,10 +109,10 @@ UINT WIXAPI WcaProcessMessage(
     __in MSIHANDLE hRecord
     );
 UINT __cdecl WcaErrorMessage(
-    __in int iError, 
-    __in HRESULT hrError, 
-    __in UINT uiType, 
-    __in DWORD cArgs, 
+    __in int iError,
+    __in HRESULT hrError,
+    __in UINT uiType,
+    __in DWORD cArgs,
     ...
     );
 HRESULT WIXAPI WcaProgressMessage(
@@ -282,7 +271,7 @@ HRESULT WIXAPI WcaWriteStringToCaData(
     __deref_inout_z LPWSTR* ppwzCustomActionData
     );
 HRESULT WIXAPI WcaWriteIntegerToCaData(
-    __in int i, 
+    __in int i,
     __deref_out_z_opt LPWSTR* ppwzCustomActionData
     );
 HRESULT WIXAPI WcaWriteStreamToCaData(

--- a/src/libs/wcautil/wcawrap.cpp
+++ b/src/libs/wcautil/wcawrap.cpp
@@ -38,6 +38,7 @@ WcaErrorMessage() - sends an error message from the CustomAction using
 the Error table
 
 NOTE: Any and all var_args (...) must be WCHAR*
+      If you pass -1 to cArgs the count will be determined
 ********************************************************************/
 extern "C" UINT __cdecl WcaErrorMessage(
     __in int iError,
@@ -50,6 +51,7 @@ extern "C" UINT __cdecl WcaErrorMessage(
     UINT er;
     MSIHANDLE hRec = NULL;
     va_list args;
+    va_list iter;
 
     uiType |= INSTALLMESSAGE_ERROR;  // ensure error type is set
     hRec = ::MsiCreateRecord(cArgs + 2);
@@ -66,6 +68,19 @@ extern "C" UINT __cdecl WcaErrorMessage(
     ExitOnFailure(HRESULT_FROM_WIN32(er), "failed to set hresult code into error message");
 
     va_start(args, cArgs);
+    if (-1 == cArgs)
+    {
+        LPCWSTR wzArg;
+        cArgs = 0;
+
+        va_copy(iter, args);
+        while (NULL != (wzArg = va_arg(iter, WCHAR*)) && L'\0' != *wzArg)
+        {
+            ++cArgs;
+        }
+        va_end(iter);
+    }
+
     for (DWORD i = 0; i < cArgs; i++)
     {
         er = ::MsiRecordSetStringW(hRec, i + 3, va_arg(args, WCHAR*));
@@ -322,7 +337,7 @@ extern "C" HRESULT WIXAPI WcaOpenView(
 
     HRESULT hr = S_OK;
     UINT er = ::MsiDatabaseOpenViewW(WcaGetDatabaseHandle(), wzSql, phView);
-    ExitOnWin32Error1(er, hr, "failed to open view on database with SQL: %ls", wzSql);
+    ExitOnWin32Error(er, hr, "failed to open view on database with SQL: %ls", wzSql);
 
 LExit:
     return hr;
@@ -474,7 +489,7 @@ extern "C" HRESULT WIXAPI WcaGetProperty(
         {
             hr = HRESULT_FROM_WIN32(er);
         }
-        ExitOnFailure1(hr, "Failed to allocate string for Property '%ls'", wzProperty);
+        ExitOnFailure(hr, "Failed to allocate string for Property '%ls'", wzProperty);
     }
     else
     {
@@ -487,11 +502,11 @@ extern "C" HRESULT WIXAPI WcaGetProperty(
     {
         Assert(*ppwzData);
         hr = StrAlloc(ppwzData, ++cch);
-        ExitOnFailure1(hr, "Failed to allocate string for Property '%ls'", wzProperty);
+        ExitOnFailure(hr, "Failed to allocate string for Property '%ls'", wzProperty);
 
         er = ::MsiGetPropertyW(WcaGetInstallHandle(), wzProperty, *ppwzData, (DWORD *)&cch);
     }
-    ExitOnWin32Error1(er, hr, "Failed to get data for property '%ls'", wzProperty);
+    ExitOnWin32Error(er, hr, "Failed to get data for property '%ls'", wzProperty);
 
 LExit:
     return hr;
@@ -517,10 +532,10 @@ extern "C" HRESULT WIXAPI WcaGetFormattedProperty(
     LPWSTR pwzPropertyValue = NULL;
 
     hr = WcaGetProperty(wzProperty, &pwzPropertyValue);
-    ExitOnFailure1(hr, "failed to get %ls", wzProperty);
+    ExitOnFailure(hr, "failed to get %ls", wzProperty);
 
     hr = WcaGetFormattedString(pwzPropertyValue, ppwzData);
-    ExitOnFailure2(hr, "failed to get formatted value for property: '%ls' with value: '%ls'", wzProperty, pwzPropertyValue);
+    ExitOnFailure(hr, "failed to get formatted value for property: '%ls' with value: '%ls'", wzProperty, pwzPropertyValue);
 
 LExit:
     ReleaseStr(pwzPropertyValue);
@@ -550,7 +565,7 @@ extern "C" HRESULT WIXAPI WcaGetFormattedString(
     DWORD_PTR cch = 0;
 
     er = ::MsiRecordSetStringW(hRecord, 0, wzString);
-    ExitOnWin32Error1(er, hr, "Failed to set record field 0 with '%ls'", wzString);
+    ExitOnWin32Error(er, hr, "Failed to set record field 0 with '%ls'", wzString);
 
     if (!*ppwzData)
     {
@@ -564,7 +579,7 @@ extern "C" HRESULT WIXAPI WcaGetFormattedString(
         {
             hr = HRESULT_FROM_WIN32(er);
         }
-        ExitOnFailure1(hr, "Failed to allocate string for formatted string: '%ls'", wzString);
+        ExitOnFailure(hr, "Failed to allocate string for formatted string: '%ls'", wzString);
     }
     else
     {
@@ -576,11 +591,11 @@ extern "C" HRESULT WIXAPI WcaGetFormattedString(
     if (ERROR_MORE_DATA == er)
     {
         hr = StrAlloc(ppwzData, ++cch);
-        ExitOnFailure1(hr, "Failed to allocate string for formatted string: '%ls'", wzString);
+        ExitOnFailure(hr, "Failed to allocate string for formatted string: '%ls'", wzString);
 
         er = ::MsiFormatRecordW(WcaGetInstallHandle(), hRecord, *ppwzData, (DWORD *)&cch);
     }
-    ExitOnWin32Error1(er, hr, "Failed to get formatted string: '%ls'", wzString);
+    ExitOnWin32Error(er, hr, "Failed to get formatted string: '%ls'", wzString);
 
 LExit:
     return hr;
@@ -606,7 +621,7 @@ extern "C" HRESULT WIXAPI WcaGetIntProperty(
     DWORD cch = countof(wzValue) - 1;
 
     er = ::MsiGetPropertyW(WcaGetInstallHandle(), wzProperty, wzValue, &cch);
-    ExitOnWin32Error1(er, hr, "Failed to get data for property '%ls'", wzProperty);
+    ExitOnWin32Error(er, hr, "Failed to get data for property '%ls'", wzProperty);
 
     *piData = wcstol(wzValue, NULL, 10);
 
@@ -645,7 +660,7 @@ extern "C" HRESULT WIXAPI WcaGetTargetPath(
         {
             hr = HRESULT_FROM_WIN32(er);
         }
-        ExitOnFailure1(hr, "Failed to allocate string for target path of folder: '%ls'", wzFolder);
+        ExitOnFailure(hr, "Failed to allocate string for target path of folder: '%ls'", wzFolder);
     }
     else
     {
@@ -658,11 +673,11 @@ extern "C" HRESULT WIXAPI WcaGetTargetPath(
     {
         ++cch;
         hr = StrAlloc(ppwzData, cch);
-        ExitOnFailure1(hr, "Failed to allocate string for target path of folder: '%ls'", wzFolder);
+        ExitOnFailure(hr, "Failed to allocate string for target path of folder: '%ls'", wzFolder);
 
         er = ::MsiGetTargetPathW(WcaGetInstallHandle(), wzFolder, *ppwzData, (DWORD*)&cch);
     }
-    ExitOnWin32Error1(er, hr, "Failed to get target path for folder '%ls'", wzFolder);
+    ExitOnWin32Error(er, hr, "Failed to get target path for folder '%ls'", wzFolder);
 
 LExit:
     return hr;
@@ -684,7 +699,7 @@ extern "C" HRESULT WIXAPI WcaSetProperty(
         return E_INVALIDARG;
 
     UINT er = ::MsiSetPropertyW(WcaGetInstallHandle(), wzPropertyName, wzPropertyValue);
-    ExitOnWin32Error1(er, hr, "failed to set property: %ls", wzPropertyName);
+    ExitOnWin32Error(er, hr, "failed to set property: %ls", wzPropertyName);
 
 LExit:
     return hr;
@@ -706,10 +721,10 @@ extern "C" HRESULT WIXAPI WcaSetIntProperty(
     // 12 characters should be enough for a 32-bit int: 10 digits, 1 sign, 1 null
     WCHAR wzPropertyValue[13];
     HRESULT hr = StringCchPrintfW(wzPropertyValue, countof(wzPropertyValue), L"%d", nPropertyValue);
-    ExitOnFailure1(hr, "failed to convert into string property value: %d", nPropertyValue);
+    ExitOnFailure(hr, "failed to convert into string property value: %d", nPropertyValue);
 
     UINT er = ::MsiSetPropertyW(WcaGetInstallHandle(), wzPropertyName, wzPropertyValue);
-    ExitOnWin32Error1(er, hr, "failed to set property: %ls", wzPropertyName);
+    ExitOnWin32Error(er, hr, "failed to set property: %ls", wzPropertyName);
 
 LExit:
     return hr;
@@ -965,7 +980,7 @@ extern "C" HRESULT WIXAPI WcaGetRecordFormattedInteger(
     LPWSTR pwzData = NULL;
 
     hr = WcaGetRecordFormattedString(hRec, uiField, &pwzData);
-    ExitOnFailure1(hr, "failed to get record field: %u", uiField);
+    ExitOnFailure(hr, "failed to get record field: %u", uiField);
     if (pwzData && *pwzData)
     {
         LPWSTR wz = NULL;
@@ -973,7 +988,7 @@ extern "C" HRESULT WIXAPI WcaGetRecordFormattedInteger(
         if (wz && *wz)
         {
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "failed to parse record field: %u as number: %ls", uiField, pwzData);
+            ExitOnFailure(hr, "failed to parse record field: %u as number: %ls", uiField, pwzData);
         }
     }
     else
@@ -1432,14 +1447,14 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
 
         // Open and Execute the temp View
         hr = WcaOpenExecuteView(pwzQuery, phTableView);
-        ExitOnFailure1(hr, "failed to openexecute temp view with query %ls", pwzQuery);
+        ExitOnFailure(hr, "failed to openexecute temp view with query %ls", pwzQuery);
     }
 
     if (NULL == *phColumns)
     {
         // use GetColumnInfo to populate the datatype record
         er = ::MsiViewGetColumnInfo(*phTableView, MSICOLINFO_TYPES, phColumns);
-        ExitOnWin32Error1(er, hr, "failed to columns for table: %ls", wzTable);
+        ExitOnWin32Error(er, hr, "failed to columns for table: %ls", wzTable);
     }
     AssertSz(::MsiRecordGetFieldCount(*phColumns) == cColumns, "passed in argument does not match number of columns in table");
 
@@ -1447,7 +1462,7 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
     // create the temp record
     //
     hTempRec = ::MsiCreateRecord(cColumns);
-    ExitOnNull1(hTempRec, hr, E_UNEXPECTED, "could not create temp record for table: %ls", wzTable);
+    ExitOnNull(hTempRec, hr, E_UNEXPECTED, "could not create temp record for table: %ls", wzTable);
 
     //
     // loop through all the columns filling in the data
@@ -1456,7 +1471,7 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
     for (i = 1; i <= cColumns; i++)
     {
         hr = WcaGetRecordString(*phColumns, i, &pwzData);
-        ExitOnFailure1(hr, "failed to get the data type for %d", i);
+        ExitOnFailure(hr, "failed to get the data type for %d", i);
 
         // if data type is string write string
         if (L's' == *pwzData || L'S' == *pwzData || L'g' == *pwzData || L'G' == *pwzData || L'l' == *pwzData || L'L' == *pwzData)
@@ -1467,13 +1482,13 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
             if (uiUniquifyColumn == i)
             {
                 hr = StrAllocFormatted(&pwzUniquify, L"%s%u", wz, ++dwUniquifyValue);   // up the count so we have no collisions on the unique name
-                ExitOnFailure1(hr, "failed to allocate string for unique column: %d", uiUniquifyColumn);
+                ExitOnFailure(hr, "failed to allocate string for unique column: %d", uiUniquifyColumn);
 
                 wz = pwzUniquify;
             }
 
             er = ::MsiRecordSetStringW(hTempRec, i, wz);
-            ExitOnWin32Error1(er, hr, "failed to set string value at position %d", i);
+            ExitOnWin32Error(er, hr, "failed to set string value at position %d", i);
         }
         // if data type is integer write integer
         else if (L'i' == *pwzData || L'I' == *pwzData || L'j' == *pwzData || L'J' == *pwzData)
@@ -1482,13 +1497,13 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
             int iData = va_arg(args, int);
 
             er = ::MsiRecordSetInteger(hTempRec, i, iData);
-            ExitOnWin32Error1(er, hr, "failed to set integer value at position %d", i);
+            ExitOnWin32Error(er, hr, "failed to set integer value at position %d", i);
         }
         else
         {
             // not supporting binary streams so error out
             hr = HRESULT_FROM_WIN32(ERROR_DATATYPE_MISMATCH);
-            ExitOnRootFailure2(hr, "unsupported data type '%ls' in column: %d", pwzData, i);
+            ExitOnRootFailure(hr, "unsupported data type '%ls' in column: %d", pwzData, i);
         }
     }
     va_end(args);
@@ -1516,7 +1531,7 @@ extern "C" HRESULT __cdecl WcaAddTempRecord(
         {
             *pdbError = dbErr;
         }
-        ExitOnFailure2(hr, "failed to add temporary row, dberr: %d, err: %ls", dbErr, wzBuf);
+        ExitOnFailure(hr, "failed to add temporary row, dberr: %d, err: %ls", dbErr, wzBuf);
     }
 
 LExit:
@@ -1553,12 +1568,12 @@ extern "C" HRESULT WIXAPI WcaDumpTable(
 
     // Open and Execute the temp View
     hr = WcaOpenExecuteView(pwzQuery, &hView);
-    ExitOnFailure1(hr, "failed to openexecute temp view with query %ls", pwzQuery);
+    ExitOnFailure(hr, "failed to openexecute temp view with query %ls", pwzQuery);
 
     // Use GetColumnInfo to populate the names of the columns.
     er = ::MsiViewGetColumnInfo(hView, MSICOLINFO_NAMES, &hColumns);
     hr = HRESULT_FROM_WIN32(er);
-    ExitOnFailure1(hr, "failed to get column info for table: %ls", wzTable);
+    ExitOnFailure(hr, "failed to get column info for table: %ls", wzTable);
 
     cColumns = ::MsiRecordGetFieldCount(hColumns);
 
@@ -1568,7 +1583,7 @@ extern "C" HRESULT WIXAPI WcaDumpTable(
     for (DWORD i = 1; i <= cColumns; i++)
     {
         hr = WcaGetRecordString(hColumns, i, &pwzData);
-        ExitOnFailure1(hr, "failed to get the column name for %d", i);
+        ExitOnFailure(hr, "failed to get the column name for %d", i);
 
         hr = StrAllocConcat(&pwzPrint, pwzData, 0);
         ExitOnFailure(hr, "Failed to add column name.");
@@ -1590,7 +1605,7 @@ extern "C" HRESULT WIXAPI WcaDumpTable(
         for (DWORD i = 1; i <= cColumns; i++)
         {
             hr = WcaGetRecordString(hRec, i, &pwzData);
-            ExitOnFailure1(hr, "failed to get the column name for %d", i);
+            ExitOnFailure(hr, "failed to get the column name for %d", i);
 
             hr = StrAllocConcat(&pwzPrint, pwzData, 0);
             ExitOnFailure(hr, "Failed to add column name.");

--- a/src/libs/wcautil/wcawrapquery.cpp
+++ b/src/libs/wcautil/wcawrapquery.cpp
@@ -227,7 +227,7 @@ HRESULT WIXAPI WcaWrapQuery(
     else if (0xFFFFFFFF != dwComponentColumn)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Component column %d out of range", dwComponentColumn);
+        ExitOnFailure(hr, "Component column %d out of range", dwComponentColumn);
     }
 
     if (cViewColumns >= dwDirectoryColumn)
@@ -237,7 +237,7 @@ HRESULT WIXAPI WcaWrapQuery(
     else if (0xFFFFFFFF != dwDirectoryColumn)
     {
         hr = E_INVALIDARG;
-        ExitOnFailure1(hr, "Directory column %d out of range", dwDirectoryColumn);
+        ExitOnFailure(hr, "Directory column %d out of range", dwDirectoryColumn);
     }
 
     hr = WcaWriteIntegerToCaData(static_cast<int>(cViewColumns) + 2 * static_cast<int>(fAddComponentState) + 2 * static_cast<int>(fAddDirectoryPath), ppwzCustomActionData);
@@ -250,55 +250,55 @@ HRESULT WIXAPI WcaWrapQuery(
     for (DWORD i = 0; i < cViewColumns; i++)
     {
         hr = WcaGetRecordString(hColumnNames, i+1, &pwzData);
-        ExitOnFailure1(hr, "Failed to get the column %d name", i+1);
+        ExitOnFailure(hr, "Failed to get the column %d name", i+1);
 
         hr = WcaWriteStringToCaData(pwzData, &pwzColumnData);
-        ExitOnFailure2(hr, "Failed to write column %d name %ls to custom action data", i+1, pwzData);
+        ExitOnFailure(hr, "Failed to write column %d name %ls to custom action data", i+1, pwzData);
 
         hr = WcaGetRecordString(hColumnTypes, i+1, &pwzData);
-        ExitOnFailure1(hr, "Failed to get the column type string for column %d", i+1);
+        ExitOnFailure(hr, "Failed to get the column type string for column %d", i+1);
 
         pcdtColumnTypeList[i] = GetDataTypeFromString(pwzData);
 
         if (cdtUnknown == pcdtColumnTypeList[i])
         {
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Failed to recognize column %d type string: %ls", i+1, pwzData);
+            ExitOnFailure(hr, "Failed to recognize column %d type string: %ls", i+1, pwzData);
         }
 
         hr = WcaWriteIntegerToCaData(pcdtColumnTypeList[i], &pwzColumnData);
-        ExitOnFailure1(hr, "Failed to write column %d type enumeration to custom action data", i+1);
+        ExitOnFailure(hr, "Failed to write column %d type enumeration to custom action data", i+1);
     }
 
     // Add two integer columns to the right side of the query - ISInstalled, and ISAction
     if (fAddComponentState)
     {
         hr = WcaWriteStringToCaData(ISINSTALLEDCOLUMNNAME, &pwzColumnData);
-        ExitOnFailure2(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, ISINSTALLEDCOLUMNNAME);
+        ExitOnFailure(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, ISINSTALLEDCOLUMNNAME);
 
         hr = WcaWriteIntegerToCaData(cdtInt, &pwzColumnData);
-        ExitOnFailure1(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
+        ExitOnFailure(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
 
         hr = WcaWriteStringToCaData(ISACTIONCOLUMNNAME, &pwzColumnData);
-        ExitOnFailure2(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, ISACTIONCOLUMNNAME);
+        ExitOnFailure(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, ISACTIONCOLUMNNAME);
 
         hr = WcaWriteIntegerToCaData(cdtInt, &pwzColumnData);
-        ExitOnFailure1(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
+        ExitOnFailure(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
     }
 
     if (fAddDirectoryPath)
     {
         hr = WcaWriteStringToCaData(SOURCEPATHCOLUMNNAME, &pwzColumnData);
-        ExitOnFailure2(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, SOURCEPATHCOLUMNNAME);
+        ExitOnFailure(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, SOURCEPATHCOLUMNNAME);
 
         hr = WcaWriteIntegerToCaData(cdtString, &pwzColumnData);
-        ExitOnFailure1(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
+        ExitOnFailure(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
 
         hr = WcaWriteStringToCaData(TARGETPATHCOLUMNNAME, &pwzColumnData);
-        ExitOnFailure2(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, TARGETPATHCOLUMNNAME);
+        ExitOnFailure(hr, "Failed to write extra column %d name %ls to custom action data", cViewColumns + 1, TARGETPATHCOLUMNNAME);
 
         hr = WcaWriteIntegerToCaData(cdtString, &pwzColumnData);
-        ExitOnFailure1(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
+        ExitOnFailure(hr, "Failed to write extra column %d type to custom action data", cViewColumns + 1);
     }
 
     // Begin wrapping actual table data
@@ -322,10 +322,10 @@ HRESULT WIXAPI WcaWrapQuery(
                 {
                     hr = WcaGetRecordString(hRec, i + 1, &pwzData);
                 }
-                ExitOnFailure1(hr, "Failed to get string for column %d", i + 1);
+                ExitOnFailure(hr, "Failed to get string for column %d", i + 1);
 
                 hr = WcaWriteStringToCaData(pwzData, &pwzRecordData);
-                ExitOnFailure1(hr, "Failed to write string to temporary record custom action data for column %d", i + 1);
+                ExitOnFailure(hr, "Failed to write string to temporary record custom action data for column %d", i + 1);
                 break;
 
             case cdtInt:
@@ -337,21 +337,21 @@ HRESULT WIXAPI WcaWrapQuery(
                 {
                     hr = WcaGetRecordInteger(hRec, i + 1, &iTempInteger);
                 }
-                ExitOnFailure1(hr, "Failed to get integer for column %d", i + 1);
+                ExitOnFailure(hr, "Failed to get integer for column %d", i + 1);
 
                 hr = WcaWriteIntegerToCaData(iTempInteger, &pwzRecordData);
-                ExitOnFailure1(hr, "Failed to write integer to temporary record custom action data for column %d", i + 1);
+                ExitOnFailure(hr, "Failed to write integer to temporary record custom action data for column %d", i + 1);
                 break;
 
             case cdtStream:
                 hr = E_NOTIMPL;
-                ExitOnFailure1(hr, "A query was wrapped which contained a binary stream data field in column %d - however, the ability to wrap stream data fields is not implemented at this time", i);
+                ExitOnFailure(hr, "A query was wrapped which contained a binary stream data field in column %d - however, the ability to wrap stream data fields is not implemented at this time", i);
                 break;
 
             case cdtUnknown:
             default:
                 hr = E_INVALIDARG;
-                ExitOnFailure2(hr, "Failed to recognize column type enumeration %d for column %d", pcdtColumnTypeList[i], i + 1);
+                ExitOnFailure(hr, "Failed to recognize column type enumeration %d for column %d", pcdtColumnTypeList[i], i + 1);
             }
         }
 
@@ -360,7 +360,7 @@ HRESULT WIXAPI WcaWrapQuery(
         {
             // Get the component ID
             hr = WcaGetRecordString(hRec, dwComponentColumn, &pwzData);
-            ExitOnFailure1(hr, "Failed to get component from column %d while adding extra columns", dwComponentColumn);
+            ExitOnFailure(hr, "Failed to get component from column %d while adding extra columns", dwComponentColumn);
 
             if (0 == lstrlenW(pwzData))
             {
@@ -374,7 +374,7 @@ HRESULT WIXAPI WcaWrapQuery(
                 // If we don't get the component state, that may be because the component ID was invalid, but isn't necessarily an error, so write NULL's
                 if (FAILED(HRESULT_FROM_WIN32(er)))
                 {
-                    ExitOnFailure1(hr, "Failed to get component state for component %ls", pwzData);
+                    ExitOnFailure(hr, "Failed to get component state for component %ls", pwzData);
                 }
             }
 
@@ -401,7 +401,7 @@ HRESULT WIXAPI WcaWrapQuery(
                     if (dwLen > countof(wzPath))
                     {
                         hr = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
-                        ExitOnRootFailure1(hr, "Failed to record entire Source Path for Directory %ls because its length was greater than MAX_PATH.", pwzData);
+                        ExitOnRootFailure(hr, "Failed to record entire Source Path for Directory %ls because its length was greater than MAX_PATH.", pwzData);
                     }
 
                     if (SUCCEEDED(hrTemp))
@@ -427,7 +427,7 @@ HRESULT WIXAPI WcaWrapQuery(
                 if (dwLen > countof(wzPath))
                 {
                     hr = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
-                    ExitOnRootFailure1(hr, "Failed to record entire Source Path for Directory %ls because its length was greater than MAX_PATH.", pwzData);
+                    ExitOnRootFailure(hr, "Failed to record entire Source Path for Directory %ls because its length was greater than MAX_PATH.", pwzData);
                 }
                 if (SUCCEEDED(hrTemp))
                 {
@@ -510,7 +510,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
     {
         hr = E_INVALIDARG;
     }
-    ExitOnFailure1(hr, "Failed to read table begin marker from custom action data (read %d instead)", iTempInteger);
+    ExitOnFailure(hr, "Failed to read table begin marker from custom action data (read %d instead)", iTempInteger);
 
     hr = WcaReadIntegerFromCaData(ppwzCustomActionData, &iColumns);
     ExitOnFailure(hr, "Failed to read number of columns from custom action data");
@@ -523,19 +523,19 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
     {
         hr = E_POINTER;
     }
-    ExitOnFailure2(hr, "Failed to get a query instance with %d columns and %d rows", iColumns, iRows);
+    ExitOnFailure(hr, "Failed to get a query instance with %d columns and %d rows", iColumns, iRows);
 
     for (int i = 0; i < iColumns; i++)
     {
         hr = WcaReadStringFromCaData(ppwzCustomActionData, &(hWrapQuery->ppwzColumnNames[i]));
-        ExitOnFailure1(hr, "Failed to read column %d's name from custom action data", i+1);
+        ExitOnFailure(hr, "Failed to read column %d's name from custom action data", i+1);
 
         hr = WcaReadIntegerFromCaData(ppwzCustomActionData, &iTempInteger);
         if (cdtString != iTempInteger && cdtInt != iTempInteger && cdtStream != iTempInteger)
         {
             hr = E_INVALIDARG;
         }
-        ExitOnFailure1(hr, "Failed to read column %d's type from custom action data", i+1);
+        ExitOnFailure(hr, "Failed to read column %d's type from custom action data", i+1);
 
         // Set the column type into the actual data structure
         hWrapQuery->pcdtColumnType[i] = (eColumnDataType)iTempInteger;
@@ -548,7 +548,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
         {
             hr = E_INVALIDARG;
         }
-        ExitOnFailure1(hr, "Failed to read begin row marker from custom action data (read %d instead)", iTempInteger);
+        ExitOnFailure(hr, "Failed to read begin row marker from custom action data (read %d instead)", iTempInteger);
 
         hWrapQuery->phRecords[i] = ::MsiCreateRecord((unsigned int)iColumns);
 
@@ -561,7 +561,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
                 ExitOnFailure(hr, "Failed to read string from custom action data");
 
                 hr = WcaSetRecordString(hWrapQuery->phRecords[i], j+1, pwzData);
-                ExitOnFailure2(hr, "Failed to write string %ls to record in column %d", pwzData, j+1);
+                ExitOnFailure(hr, "Failed to write string %ls to record in column %d", pwzData, j+1);
                 break;
 
             case cdtInt:
@@ -569,7 +569,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
                 ExitOnFailure(hr, "Failed to read integer from custom action data");
 
                 WcaSetRecordInteger(hWrapQuery->phRecords[i], j+1, iTempInteger);
-                ExitOnFailure2(hr, "Failed to write integer %d to record in column %d", iTempInteger, j+1);
+                ExitOnFailure(hr, "Failed to write integer %d to record in column %d", iTempInteger, j+1);
                 break;
 
             case cdtStream:
@@ -580,7 +580,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
             case cdtUnknown:
             default:
                 hr = E_INVALIDARG;
-                ExitOnFailure2(hr, "Failed to recognize column type enumeration %d for column %d", hWrapQuery->pcdtColumnType[j+1], i+1);
+                ExitOnFailure(hr, "Failed to recognize column type enumeration %d for column %d", hWrapQuery->pcdtColumnType[j+1], i+1);
             }
         }
 
@@ -589,7 +589,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
         {
             hr = E_INVALIDARG;
         }
-        ExitOnFailure1(hr, "Failed to read row finish marker from custom action data (read %d instead)", iTempInteger);
+        ExitOnFailure(hr, "Failed to read row finish marker from custom action data (read %d instead)", iTempInteger);
     }
 
     hr = WcaReadIntegerFromCaData(ppwzCustomActionData, &iTempInteger);
@@ -597,7 +597,7 @@ HRESULT WIXAPI WcaBeginUnwrapQuery(
     {
         hr = E_INVALIDARG;
     }
-    ExitOnFailure1(hr, "Failed to read table finish marker from custom action data (read %d instead)", iTempInteger);
+    ExitOnFailure(hr, "Failed to read table finish marker from custom action data (read %d instead)", iTempInteger);
 
     *phWrapQuery = hWrapQuery;
 
@@ -673,7 +673,7 @@ HRESULT WIXAPI WcaFetchWrappedRecordWhereString(
         ExitOnFailure(hr, "Failed to fetch a wrapped record");
 
         hr = WcaGetRecordString(hRec, dwComparisonColumn, &pwzData);
-        ExitOnFailure1(hr, "Failed to get record string in column %d", dwComparisonColumn);
+        ExitOnFailure(hr, "Failed to get record string in column %d", dwComparisonColumn);
 
         if (0 == lstrcmpW(pwzData, pwzExpectedValue))
         {
@@ -684,7 +684,7 @@ HRESULT WIXAPI WcaFetchWrappedRecordWhereString(
     // If we errored here but not because there were no records left, write an error to the log
     if (hr != E_NOMOREITEMS)
     {
-        ExitOnFailure2(hr, "Failed while searching for a wrapped record where column %d is set to %ls", dwComparisonColumn, pwzExpectedValue);
+        ExitOnFailure(hr, "Failed while searching for a wrapped record where column %d is set to %ls", dwComparisonColumn, pwzExpectedValue);
     }
 
 LExit:

--- a/src/tools/thmviewer/load.cpp
+++ b/src/tools/thmviewer/load.cpp
@@ -99,7 +99,7 @@ static DWORD WINAPI LoadThreadProc(
     hDirectory = ::CreateFileW(sczDirectory, FILE_LIST_DIRECTORY, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (INVALID_HANDLE_VALUE == hDirectory)
     {
-        ExitWithLastError1(hr, "Failed to open directory: %ls", sczDirectory);
+        ExitWithLastError(hr, "Failed to open directory: %ls", sczDirectory);
     }
 
     BOOL fUpdated = FALSE;
@@ -132,7 +132,7 @@ static DWORD WINAPI LoadThreadProc(
             DWORD cbRead = 0;
             if (!::ReadDirectoryChangesW(hDirectory, rgbNotifications, sizeof(rgbNotifications), FALSE, FILE_NOTIFY_CHANGE_LAST_WRITE, &cbRead, NULL, NULL))
             {
-                ExitWithLastError1(hr, "Failed while watching directory: %ls", sczDirectory);
+                ExitWithLastError(hr, "Failed while watching directory: %ls", sczDirectory);
             }
 
             // Wait for half a second to let all the file handles get closed to minimize access

--- a/src/tools/winterop/winterop.cpp
+++ b/src/tools/winterop/winterop.cpp
@@ -72,7 +72,7 @@ HRESULT ResetAcls(
         hr = ::SetNamedSecurityInfoW(const_cast<LPWSTR>(pwzFiles[i]), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, NULL, NULL, pacl, NULL);
         if (ERROR_FILE_NOT_FOUND != hr && ERROR_PATH_NOT_FOUND != hr)
         {
-            ExitOnFailure1(hr = HRESULT_FROM_WIN32(hr), "failed to set security descriptor for file: %S", pwzFiles[i]);
+            ExitOnFailure(hr = HRESULT_FROM_WIN32(hr), "failed to set security descriptor for file: %S", pwzFiles[i]);
         }
     }
 
@@ -138,7 +138,7 @@ HRESULT CreateCabAddFiles(
             pmfHash[i],
             hContext
             );
-        ExitOnFailure1(hr, "Failed to add file %S to cab", pwzFiles[i]);
+        ExitOnFailure(hr, "Failed to add file %S to cab", pwzFiles[i]);
     }
 
 LExit:

--- a/test/src/SettingsEngineTests/AdminBasicTest.cpp
+++ b/test/src/SettingsEngineTests/AdminBasicTest.cpp
@@ -34,28 +34,28 @@ namespace CfgTests
             if (dwIndex >= dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Planned to check product at index %u, but only %u products exist in the data store!", dwIndex, dwCount);
+                ExitOnFailure(hr, "Planned to check product at index %u, but only %u products exist in the data store!", dwIndex, dwCount);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_PRODUCTNAME, &wzString);
             if (0 != lstrcmpW(wzString, wzProductName))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected product name: %ls, found product name:%ls", wzProductName, wzString);
+                ExitOnFailure(hr, "Expected product name: %ls, found product name:%ls", wzProductName, wzString);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_VERSION, &wzString);
             if (0 != lstrcmpW(wzString, wzVersion))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected version: %ls, found version:%ls", wzVersion, wzString);
+                ExitOnFailure(hr, "Expected version: %ls, found version:%ls", wzVersion, wzString);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_PUBLICKEY, &wzString);
             if (0 != lstrcmpW(wzString, wzPublicKey))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected public key: %ls, found public key:%ls", wzPublicKey, wzString);
+                ExitOnFailure(hr, "Expected public key: %ls, found public key:%ls", wzPublicKey, wzString);
             }
 
         LExit:
@@ -74,7 +74,7 @@ namespace CfgTests
             if (dwExpectedNumber != dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected %u products registered, but found %u products!", dwExpectedNumber, dwCount);
+                ExitOnFailure(hr, "Expected %u products registered, but found %u products!", dwExpectedNumber, dwCount);
             }
 
         LExit:

--- a/test/src/SettingsEngineTests/EnumPastValuesTest.cpp
+++ b/test/src/SettingsEngineTests/EnumPastValuesTest.cpp
@@ -30,24 +30,24 @@ namespace CfgTests
             SYSTEMTIME st;
 
             hr = CfgEnumReadDataType(cehHandle, dwIndex, ENUM_DATA_VALUETYPE, &cvType);
-            ExitOnFailure1(hr, "Failed to get value type: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to get value type: %u", dwIndex);
 
             if (VALUE_STRING != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find string value, found type: %d", cvType);
+                ExitOnFailure(hr, "Expected to find string value, found type: %d", cvType);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_VALUESTRING, &wzValueFromEnum);
-            ExitOnFailure1(hr, "Failed to enumerate string value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to enumerate string value: %u", dwIndex);
             if (0 != lstrcmpW(wzValue, wzValueFromEnum))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected value '%ls', found value '%ls'", wzValue, wzValueFromEnum);
+                ExitOnFailure(hr, "Expected value '%ls', found value '%ls'", wzValue, wzValueFromEnum);
             }
 
             hr = CfgEnumReadSystemTime(cehHandle, dwIndex, ENUM_DATA_WHEN, &st);
-            ExitOnFailure1(hr, "Failed to read when value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read when value: %u", dwIndex);
             if (0 == st.wYear || 0 == st.wMonth)
             {
                 hr = E_FAIL;
@@ -55,7 +55,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_BY, &wzByFromEnum);
-            ExitOnFailure1(hr, "Failed to read by value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read by value: %u", dwIndex);
             if (0 == lstrlenW(wzByFromEnum))
             {
                 hr = E_FAIL;
@@ -75,24 +75,24 @@ namespace CfgTests
             SYSTEMTIME st;
 
             hr = CfgEnumReadDataType(cehHandle, dwIndex, ENUM_DATA_VALUETYPE, &cvType);
-            ExitOnFailure1(hr, "Failed to get value type: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to get value type: %u", dwIndex);
 
             if (VALUE_DWORD != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find dword value, found type: %d", cvType);
+                ExitOnFailure(hr, "Expected to find dword value, found type: %d", cvType);
             }
 
             hr = CfgEnumReadDword(cehHandle, dwIndex, ENUM_DATA_VALUEDWORD, &dwValue);
-            ExitOnFailure1(hr, "Failed to enumerate dword value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to enumerate dword value: %u", dwIndex);
             if (dwValue != dwInValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected value %u, found value %u", dwInValue, dwValue);
+                ExitOnFailure(hr, "Expected value %u, found value %u", dwInValue, dwValue);
             }
 
             hr = CfgEnumReadSystemTime(cehHandle, dwIndex, ENUM_DATA_WHEN, &st);
-            ExitOnFailure1(hr, "Failed to read when value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read when value: %u", dwIndex);
             if (0 == st.wYear || 0 == st.wMonth)
             {
                 hr = E_FAIL;
@@ -100,7 +100,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_BY, &wzBy);
-            ExitOnFailure1(hr, "Failed to read by value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read by value: %u", dwIndex);
             if (0 == lstrlenW(wzBy))
             {
                 hr = E_FAIL;
@@ -120,24 +120,24 @@ namespace CfgTests
             SYSTEMTIME st;
 
             hr = CfgEnumReadDataType(cehHandle, dwIndex, ENUM_DATA_VALUETYPE, &cvType);
-            ExitOnFailure1(hr, "Failed to get value type: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to get value type: %u", dwIndex);
 
             if (VALUE_BOOL != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find bool value, found type: %d", cvType);
+                ExitOnFailure(hr, "Expected to find bool value, found type: %d", cvType);
             }
 
             hr = CfgEnumReadBool(cehHandle, dwIndex, ENUM_DATA_VALUEBOOL, &fValue);
-            ExitOnFailure1(hr, "Failed to enumerate bool value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to enumerate bool value: %u", dwIndex);
             if (fValue != fInValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected value %ls, found value %ls", fInValue ? L"TRUE" : L"FALSE", fValue ? L"TRUE" : L"FALSE");
+                ExitOnFailure(hr, "Expected value %ls, found value %ls", fInValue ? L"TRUE" : L"FALSE", fValue ? L"TRUE" : L"FALSE");
             }
 
             hr = CfgEnumReadSystemTime(cehHandle, dwIndex, ENUM_DATA_WHEN, &st);
-            ExitOnFailure1(hr, "Failed to read when value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read when value: %u", dwIndex);
             if (0 == st.wYear || 0 == st.wMonth)
             {
                 hr = E_FAIL;
@@ -145,7 +145,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_BY, &wzBy);
-            ExitOnFailure1(hr, "Failed to read by value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read by value: %u", dwIndex);
             if (0 == lstrlenW(wzBy))
             {
                 hr = E_FAIL;
@@ -166,20 +166,20 @@ namespace CfgTests
             SYSTEMTIME st;
 
             hr = CfgEnumReadDataType(cehHandle, dwIndex, ENUM_DATA_VALUETYPE, &cvType);
-            ExitOnFailure1(hr, "Failed to get value type: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to get value type: %u", dwIndex);
 
             if (VALUE_BLOB != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find blob value, found type: %d", cvType);
+                ExitOnFailure(hr, "Expected to find blob value, found type: %d", cvType);
             }
 
             hr = CfgEnumReadBinary(cdhLocal, cehHandle, dwIndex, ENUM_DATA_BLOBCONTENT, &pbValue, &cbValue);
-            ExitOnFailure1(hr, "Failed to enumerate blob value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to enumerate blob value: %u", dwIndex);
             if (cbValue != cbExpected)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected blob of size %u, found blob of size %u", cbExpected, cbValue);
+                ExitOnFailure(hr, "Expected blob of size %u, found blob of size %u", cbExpected, cbValue);
             }
             if (0 != memcmp(pbValue, pbExpected, cbExpected))
             {
@@ -188,7 +188,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadSystemTime(cehHandle, dwIndex, ENUM_DATA_WHEN, &st);
-            ExitOnFailure1(hr, "Failed to read when value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read when value: %u", dwIndex);
             if (0 == st.wYear || 0 == st.wMonth)
             {
                 hr = E_FAIL;
@@ -196,7 +196,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_BY, &wzBy);
-            ExitOnFailure1(hr, "Failed to read by value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read by value: %u", dwIndex);
             if (0 == lstrlenW(wzBy))
             {
                 hr = E_FAIL;
@@ -217,7 +217,7 @@ namespace CfgTests
             SYSTEMTIME st;
 
             hr = CfgEnumReadDataType(cehHandle, dwIndex, ENUM_DATA_VALUETYPE, &cvType);
-            ExitOnFailure1(hr, "Failed to read deleted value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read deleted value: %u", dwIndex);
             if (VALUE_DELETED != cvType)
             {
                 hr = E_FAIL;
@@ -225,7 +225,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadSystemTime(cehHandle, dwIndex, ENUM_DATA_WHEN, &st);
-            ExitOnFailure1(hr, "Failed to read when value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read when value: %u", dwIndex);
             if (0 == st.wYear || 0 == st.wMonth)
             {
                 hr = E_FAIL;
@@ -233,7 +233,7 @@ namespace CfgTests
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_BY, &wzBy);
-            ExitOnFailure1(hr, "Failed to read by value: %u", dwIndex);
+            ExitOnFailure(hr, "Failed to read by value: %u", dwIndex);
             if (0 == lstrlenW(wzBy))
             {
                 hr = E_FAIL;
@@ -308,7 +308,7 @@ namespace CfgTests
             if (dwCount < 9)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "There should be at least 9 values in Test1's history - there were only %u found", dwCount);
+                ExitOnFailure(hr, "There should be at least 9 values in Test1's history - there were only %u found", dwCount);
             }
 
             VerifyHistoryString(cehHandle, dwCount - 1, L"LatestValue");

--- a/test/src/SettingsEngineTests/EnumValuesTest.cpp
+++ b/test/src/SettingsEngineTests/EnumValuesTest.cpp
@@ -125,7 +125,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"File1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 'File1', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Value should have been 'File1', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadString(cehHandle, 1, ENUM_DATA_VALUENAME, &wzName);
@@ -134,7 +134,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"File2"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 'File2', found '%ls' instead", wzValue);
+                ExitOnFailure(hr, "Value should have been 'File2', found '%ls' instead", wzValue);
             }
 
             hr = CfgEnumReadDword(cehHandle, 0, ENUM_DATA_BLOBSIZE, &dwValue);
@@ -143,7 +143,7 @@ namespace CfgTests
             if (1000 != dwValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Size for file 1 should have been 1000, found %u instead", dwValue);
+                ExitOnFailure(hr, "Size for file 1 should have been 1000, found %u instead", dwValue);
             }
 
             hr = CfgEnumReadDword(cehHandle, 1, ENUM_DATA_BLOBSIZE, &dwValue);
@@ -152,7 +152,7 @@ namespace CfgTests
             if (500 != dwValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Size for file 1 should have been 500, found %u instead", dwValue);
+                ExitOnFailure(hr, "Size for file 1 should have been 500, found %u instead", dwValue);
             }
 
             CfgReleaseEnumeration(cehHandle);
@@ -173,7 +173,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 0, ENUM_DATA_VALUETYPE, &cvType);
@@ -181,7 +181,7 @@ namespace CfgTests
             if (VALUE_STRING != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
             }
 
             hr = CfgEnumReadString(cehHandle, 0, ENUM_DATA_VALUESTRING, &wzValue);
@@ -190,7 +190,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzValue, L"Value1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
+                ExitOnFailure(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
             }
 
             hr = CfgSetDword(cdhLocal, L"Test2", 200);
@@ -203,7 +203,7 @@ namespace CfgTests
             if (2 != dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected 2 values in enumeration, found: %u values", dwCount);
+                ExitOnFailure(hr, "Expected 2 values in enumeration, found: %u values", dwCount);
             }
 
             hr = CfgEnumReadString(cehHandle, 0, ENUM_DATA_VALUENAME, &wzName);
@@ -211,7 +211,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 0, ENUM_DATA_VALUETYPE, &cvType);
@@ -219,7 +219,7 @@ namespace CfgTests
             if (VALUE_STRING != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
             }
 
             hr = CfgEnumReadString(cehHandle, 0, ENUM_DATA_VALUESTRING, &wzValue);
@@ -228,7 +228,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzValue, L"Value1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
+                ExitOnFailure(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
             }
 
             hr = CfgEnumReadString(cehHandle, 1, ENUM_DATA_VALUENAME, &wzName);
@@ -236,7 +236,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test2"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test2', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test2', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 1, ENUM_DATA_VALUETYPE, &cvType);
@@ -244,7 +244,7 @@ namespace CfgTests
             if (VALUE_DWORD != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_DWORD, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_DWORD, was %d instead", cvType);
             }
 
             hr = CfgEnumReadDword(cehHandle, 1, ENUM_DATA_VALUEDWORD, &dwValue);
@@ -253,7 +253,7 @@ namespace CfgTests
             if (200 != dwValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 200, found %u instead", dwValue);
+                ExitOnFailure(hr, "Value should have been 200, found %u instead", dwValue);
             }
 
             hr = CfgSetBool(cdhLocal, L"Test3", TRUE);
@@ -266,7 +266,7 @@ namespace CfgTests
             if (3 != dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected 3 values in enumeration, found: %u values", dwCount);
+                ExitOnFailure(hr, "Expected 3 values in enumeration, found: %u values", dwCount);
             }
 
             hr = CfgEnumReadString(cehHandle, 0, ENUM_DATA_VALUENAME, &wzName);
@@ -274,7 +274,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test1', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 0, ENUM_DATA_VALUETYPE, &cvType);
@@ -282,7 +282,7 @@ namespace CfgTests
             if (VALUE_STRING != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_STRING, was %d instead", cvType);
             }
 
             hr = CfgEnumReadString(cehHandle, 0, ENUM_DATA_VALUESTRING, &wzValue);
@@ -291,7 +291,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzValue, L"Value1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
+                ExitOnFailure(hr, "Value should have been 'Test1', found '%ls' instead", wzValue);
             }
 
             hr = CfgEnumReadString(cehHandle, 1, ENUM_DATA_VALUENAME, &wzName);
@@ -299,7 +299,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test2"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test2', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test2', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 1, ENUM_DATA_VALUETYPE, &cvType);
@@ -307,7 +307,7 @@ namespace CfgTests
             if (VALUE_DWORD != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_DWORD, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_DWORD, was %d instead", cvType);
             }
 
             hr = CfgEnumReadDword(cehHandle, 1, ENUM_DATA_VALUEDWORD, &dwValue);
@@ -316,7 +316,7 @@ namespace CfgTests
             if (200 != dwValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been 200, found %u instead", dwValue);
+                ExitOnFailure(hr, "Value should have been 200, found %u instead", dwValue);
             }
 
             hr = CfgEnumReadString(cehHandle, 2, ENUM_DATA_VALUENAME, &wzName);
@@ -324,7 +324,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzName, L"Test3"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuename should have been 'Test3', found '%ls' instead", wzName);
+                ExitOnFailure(hr, "Valuename should have been 'Test3', found '%ls' instead", wzName);
             }
 
             hr = CfgEnumReadDataType(cehHandle, 2, ENUM_DATA_VALUETYPE, &cvType);
@@ -332,7 +332,7 @@ namespace CfgTests
             if (VALUE_BOOL != cvType)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Valuetype should have been VALUE_BOOL, was %d instead", cvType);
+                ExitOnFailure(hr, "Valuetype should have been VALUE_BOOL, was %d instead", cvType);
             }
 
             hr = CfgEnumReadBool(cehHandle, 2, ENUM_DATA_VALUEBOOL, &fValue);
@@ -341,7 +341,7 @@ namespace CfgTests
             if (TRUE != fValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Value should have been TRUE, found %ls instead", fValue ? L"TRUE" : L"FALSE");
+                ExitOnFailure(hr, "Value should have been TRUE, found %ls instead", fValue ? L"TRUE" : L"FALSE");
             }
 
             ::Sleep(5);

--- a/test/src/SettingsEngineTests/LegacyRegistrySpecialsTest.cpp
+++ b/test/src/SettingsEngineTests/LegacyRegistrySpecialsTest.cpp
@@ -40,7 +40,7 @@ namespace CfgTests
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to cleanup before main portion of test by deleting regkey:%ls", wzRegKey);
+            ExitOnFailure(hr, "Failed to cleanup before main portion of test by deleting regkey:%ls", wzRegKey);
 
             hr = CfgInitialize(&cdhLocal, BackgroundStatusCallback, BackgroundConflictsFoundCallback, reinterpret_cast<LPVOID>(m_pContext));
             ExitOnFailure(hr, "Failed to initialize user settings engine");
@@ -201,7 +201,7 @@ namespace CfgTests
 
             // Only cleanup the key if the test succeeded
             hr = RegDelete(HKEY_CURRENT_USER, wzRegKey, REG_KEY_32BIT, TRUE);
-            ExitOnFailure1(hr, "Failed to cleanup after test by deleting key: %ls", wzRegKey);
+            ExitOnFailure(hr, "Failed to cleanup after test by deleting key: %ls", wzRegKey);
 
 LExit:
             ReleaseRegKey(hk);

--- a/test/src/SettingsEngineTests/LegacySyncTest.cpp
+++ b/test/src/SettingsEngineTests/LegacySyncTest.cpp
@@ -25,7 +25,7 @@ namespace CfgTests
             ExitOnFailure(hr, "Failed to concat CfgFileTest to my documents path");
 
             hr = DirEnsureExists(*psczFileSettingsDir, NULL);
-            ExitOnFailure1(hr, "Failed to ensure directory exists: %ls", *psczFileSettingsDir);
+            ExitOnFailure(hr, "Failed to ensure directory exists: %ls", *psczFileSettingsDir);
 
             hr = PathConcat(*psczFileSettingsDir, L"FileA.tst", psczFileA);
             ExitOnFailure(hr, "Failed to create path to file A");
@@ -34,7 +34,7 @@ namespace CfgTests
             ExitOnFailure(hr, "Failed to get path to subdir");
 
             hr = DirEnsureExists(sczSubDir, NULL);
-            ExitOnFailure1(hr, "Failed to ensure subdirectory exists: %ls", sczSubDir);
+            ExitOnFailure(hr, "Failed to ensure subdirectory exists: %ls", sczSubDir);
 
             hr = PathConcat(*psczFileSettingsDir, L"SubDir\\FileB.del", psczFileB);
             ExitOnFailure(hr, "Failed to create path to file B");
@@ -84,7 +84,7 @@ namespace CfgTests
             {
                 hr = S_OK;
             }
-            ExitOnFailure1(hr, "Failed to cleanup before main portion of test by deleting regkey:%ls", wzRegKey);
+            ExitOnFailure(hr, "Failed to cleanup before main portion of test by deleting regkey:%ls", wzRegKey);
 
             hr = GetFilePaths(&sczFileSettingsDir, &sczFileA, &sczFileB);
             ExitOnFailure(hr, "Failed to get file paths for test");
@@ -244,7 +244,7 @@ namespace CfgTests
             ExitOnFailure(hr, "Failed to set dword 2 from cfg db");
 
             hr = RegOpen(HKEY_CURRENT_USER, wzRegKey, KEY_SET_VALUE | KEY_QUERY_VALUE | KEY_WOW64_32KEY, &hk);
-            ExitOnFailure1(hr, "Failed to open registry key: %ls", wzRegKey);
+            ExitOnFailure(hr, "Failed to open registry key: %ls", wzRegKey);
             CheckCfgAndRegValueString(cdhLocal, hk, wzString2CfgName, wzString2RegValueName, L"ResurrectedbyCfg");
             CheckCfgAndRegValueDword(cdhLocal, hk, wzDword1CfgName, wzDword1RegValueName, 50);
             CheckCfgAndRegValueDword(cdhLocal, hk, wzDword2CfgName, wzDword2RegValueName, 0);
@@ -276,7 +276,7 @@ namespace CfgTests
             hr = RegDelete(HKEY_CURRENT_USER, wzRegKey, REG_KEY_32BIT, TRUE);
             if (E_FILENOTFOUND != hr)
             {
-                ExitOnFailure1(hr, "Failed to cleanup after test by deleting key: %ls", wzRegKey);
+                ExitOnFailure(hr, "Failed to cleanup after test by deleting key: %ls", wzRegKey);
             }
 
         LExit:

--- a/test/src/SettingsEngineTests/PerUserProductTest.cpp
+++ b/test/src/SettingsEngineTests/PerUserProductTest.cpp
@@ -35,7 +35,7 @@ namespace CfgTests
             if (dwIndex >= dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Planned to check product at index %u, but only %u products exist in the data store!", dwIndex, dwCount);
+                ExitOnFailure(hr, "Planned to check product at index %u, but only %u products exist in the data store!", dwIndex, dwCount);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_PRODUCTNAME, &wzString);
@@ -44,7 +44,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzString, wzProductName))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected product name: %ls, found product name:%ls", wzProductName, wzString);
+                ExitOnFailure(hr, "Expected product name: %ls, found product name:%ls", wzProductName, wzString);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_VERSION, &wzString);
@@ -53,7 +53,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzString, wzVersion))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected version: %ls, found version:%ls", wzVersion, wzString);
+                ExitOnFailure(hr, "Expected version: %ls, found version:%ls", wzVersion, wzString);
             }
 
             hr = CfgEnumReadString(cehHandle, dwIndex, ENUM_DATA_PUBLICKEY, &wzString);
@@ -62,7 +62,7 @@ namespace CfgTests
             if (0 != lstrcmpW(wzString, wzPublicKey))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected public key: %ls, found public key:%ls", wzPublicKey, wzString);
+                ExitOnFailure(hr, "Expected public key: %ls, found public key:%ls", wzPublicKey, wzString);
             }
 
             hr = CfgEnumReadBool(cehHandle, dwIndex, ENUM_DATA_REGISTERED, &fBool);
@@ -71,7 +71,7 @@ namespace CfgTests
             if (fRegistered != fBool)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected registered flag to be %ls, but it was %ls!", fRegistered ? L"TRUE" : L"FALSE", fBool ? L"TRUE" : L"FALSE");
+                ExitOnFailure(hr, "Expected registered flag to be %ls, but it was %ls!", fRegistered ? L"TRUE" : L"FALSE", fBool ? L"TRUE" : L"FALSE");
             }
 
         LExit:
@@ -90,7 +90,7 @@ namespace CfgTests
             if (dwExpectedNumber != dwCount)
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Expected %u products registered, but found %u products!", dwExpectedNumber, dwCount);
+                ExitOnFailure(hr, "Expected %u products registered, but found %u products!", dwExpectedNumber, dwCount);
             }
 
         LExit:

--- a/test/src/SettingsEngineTests/RemoteSyncResolveTest.cpp
+++ b/test/src/SettingsEngineTests/RemoteSyncResolveTest.cpp
@@ -127,7 +127,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValue1"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "String1's value in Remote1 is incorrect - should be: StringValue1, instead is: %ls", sczValue);
+                ExitOnFailure(hr, "String1's value in Remote1 is incorrect - should be: StringValue1, instead is: %ls", sczValue);
             }
 
             hr = CfgSetProduct(cdhRemote1, L"TestRemoteSyncNoResolve", L"1.0.0.0", L"abcdabcdabcdabcd");
@@ -139,7 +139,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValue2"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "String2's value in Remote2 is incorrect - should be: StringValue2, instead is: %ls", sczValue);
+                ExitOnFailure(hr, "String2's value in Remote2 is incorrect - should be: StringValue2, instead is: %ls", sczValue);
             }
 
             hr = CfgGetDword(cdhRemote1, L"Dword1", &dwValue);
@@ -148,7 +148,7 @@ namespace CfgTests
             if (100 != dwValue)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Dword1's value in Remote1 is incorrect - should be: 100, instead is: %u", dwValue);
+                ExitOnFailure(hr, "Dword1's value in Remote1 is incorrect - should be: 100, instead is: %u", dwValue);
             }
 
             hr = CfgGetBool(cdhRemote2, L"Bool1", &fValue);
@@ -216,7 +216,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValueLocal"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Local db's string1 value should be StringValueLocal, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Local db's string1 value should be StringValueLocal, was instead: %ls", sczValue);
             }
 
             hr = CfgGetString(cdhRemote2, L"String1", &sczValue);
@@ -225,7 +225,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValueLocal"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Remote db 2's string1 value should be StringValueLocal, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Remote db 2's string1 value should be StringValueLocal, was instead: %ls", sczValue);
             }
 
             hr = CfgSetString(cdhLocal, L"String1", L"StringValueLocalNew");
@@ -242,7 +242,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValueRemote3"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Remote db 2's string1 value should be StringValueRemote3, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Remote db 2's string1 value should be StringValueRemote3, was instead: %ls", sczValue);
             }
 
             hr = CfgGetString(cdhLocal, L"String1", &sczValue);
@@ -251,7 +251,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"StringValueRemote3"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Local db's string1 value should be StringValueRemote3, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Local db's string1 value should be StringValueRemote3, was instead: %ls", sczValue);
             }
 
             hr = CfgDeleteValue(cdhLocal, L"String1");
@@ -268,7 +268,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"Resurrected"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Remote db 2's string1 value should be Resurrected, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Remote db 2's string1 value should be Resurrected, was instead: %ls", sczValue);
             }
 
             hr = CfgGetString(cdhLocal, L"String1", &sczValue);
@@ -277,7 +277,7 @@ namespace CfgTests
             if (0 != lstrcmpW(sczValue, L"Resurrected"))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Local db's string1 value should be Resurrected, was instead: %ls", sczValue);
+                ExitOnFailure(hr, "Local db's string1 value should be Resurrected, was instead: %ls", sczValue);
             }
 
             hr = CfgDeleteValue(cdhLocal, L"String1");

--- a/test/src/SettingsEngineTests/SettingsEngineTest.cpp
+++ b/test/src/SettingsEngineTests/SettingsEngineTest.cpp
@@ -99,10 +99,10 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete fake ARP regkey: %ls", ARP_REG_KEY);
+        ExitOnFailure(hr, "Failed to delete fake ARP regkey: %ls", ARP_REG_KEY);
 
         hr = RegCreate(HKEY_CURRENT_USER, ARP_REG_KEY, REG_KEY_32BIT, &hk);
-        ExitOnFailure1(hr, "Failed to create fake ARP regkey: %ls", ARP_REG_KEY);
+        ExitOnFailure(hr, "Failed to create fake ARP regkey: %ls", ARP_REG_KEY);
 
         hr = TestHookOverrideArpPath(ARP_REG_KEY);
         ExitOnFailure(hr, "Failed to override ARP path for test");
@@ -113,10 +113,10 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
+        ExitOnFailure(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
 
         hr = RegCreate(HKEY_CURRENT_USER, APPLICATIONS_REG_KEY, REG_KEY_32BIT, &hk);
-        ExitOnFailure1(hr, "Failed to create fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
+        ExitOnFailure(hr, "Failed to create fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
 
         hr = TestHookOverrideApplicationsPath(APPLICATIONS_REG_KEY);
         ExitOnFailure(hr, "Failed to override Applications path for test");
@@ -136,14 +136,14 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete fake ARP regkey: %ls", ARP_REG_KEY);
+        ExitOnFailure(hr, "Failed to delete fake ARP regkey: %ls", ARP_REG_KEY);
 
         hr = RegDelete(HKEY_CURRENT_USER, APPLICATIONS_REG_KEY, REG_KEY_32BIT, TRUE);
         if (E_FILENOTFOUND == hr)
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
+        ExitOnFailure(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
 
     LExit:
         return;
@@ -165,7 +165,7 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to ensure directory %ls is deleted", sczPathUser);
+        ExitOnFailure(hr, "Failed to ensure directory %ls is deleted", sczPathUser);
 
         TestHookOverrideUserDatabasePath(L"%TEMP%\\TestUserDb\\");
 
@@ -178,7 +178,7 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to ensure directory %ls is deleted", sczPathAdmin);
+        ExitOnFailure(hr, "Failed to ensure directory %ls is deleted", sczPathAdmin);
 
         TestHookOverrideAdminDatabasePath(L"%TEMP%\\TestAdminDb\\");
 
@@ -195,19 +195,19 @@ namespace CfgTests
         HKEY hkNew = NULL;
 
         hr = RegOpen(HKEY_CURRENT_USER, ARP_REG_KEY, KEY_WOW64_32KEY | KEY_ALL_ACCESS, &hkArp);
-        ExitOnFailure1(hr, "Failed to open fake ARP regkey: %ls", ARP_REG_KEY);
+        ExitOnFailure(hr, "Failed to open fake ARP regkey: %ls", ARP_REG_KEY);
 
         hr = RegDelete(hkArp, wzKeyName, REG_KEY_32BIT, TRUE);
         if (E_FILENOTFOUND == hr)
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete subkey: %ls", wzKeyName);
+        ExitOnFailure(hr, "Failed to delete subkey: %ls", wzKeyName);
 
         if (NULL != wzDisplayName)
         {
             hr = RegCreate(hkArp, wzKeyName, KEY_WOW64_32KEY | KEY_ALL_ACCESS, &hkNew);
-            ExitOnFailure1(hr, "Failed to create subkey: %ls", wzKeyName);
+            ExitOnFailure(hr, "Failed to create subkey: %ls", wzKeyName);
 
             hr = RegWriteString(hkNew, L"DisplayName", wzDisplayName);
             ExitOnFailure(hr, "Failed to write DisplayName to registry");
@@ -235,7 +235,7 @@ namespace CfgTests
         ExitOnFailure(hr, "Failed to format string to full shell\\open\\command path");
 
         hr = RegCreate(HKEY_CURRENT_USER, sczFullPath, KEY_WOW64_32KEY | KEY_ALL_ACCESS, &hk);
-        ExitOnFailure1(hr, "Failed to create key: %ls", sczFullPath);
+        ExitOnFailure(hr, "Failed to create key: %ls", sczFullPath);
 
         hr = StrAllocFormatted(&sczQuotedCommand, L"\"%ls\" \"%%1\"", wzFilePath);
         ExitOnFailure(hr, "Failed to format quoted command string");
@@ -258,7 +258,7 @@ namespace CfgTests
         {
             hr = S_OK;
         }
-        ExitOnFailure1(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
+        ExitOnFailure(hr, "Failed to delete fake Applications regkey: %ls", APPLICATIONS_REG_KEY);
 
     LExit:
         return;
@@ -344,12 +344,12 @@ namespace CfgTests
         BOOL fRegistered = FALSE;
 
         hr = CfgIsProductRegistered(cdhUserDb, wzProductName, wzVersion, wzPublicKey, &fRegistered);
-        ExitOnFailure3(hr, "Failed to check if product is registered (per-user): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+        ExitOnFailure(hr, "Failed to check if product is registered (per-user): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
 
         if (!fRegistered)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "Product should be registered (per-user), but it isn't!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+            ExitOnFailure(hr, "Product should be registered (per-user), but it isn't!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
         }
 
     LExit:
@@ -362,12 +362,12 @@ namespace CfgTests
         BOOL fRegistered = FALSE;
 
         hr = CfgIsProductRegistered(cdhUserDb, wzProductName, wzVersion, wzPublicKey, &fRegistered);
-        ExitOnFailure3(hr, "Failed to check if product is registered (per-user): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+        ExitOnFailure(hr, "Failed to check if product is registered (per-user): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
 
         if (fRegistered)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "Product shouldn't be registered (per-user), but it is!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+            ExitOnFailure(hr, "Product shouldn't be registered (per-user), but it is!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
         }
 
     LExit:
@@ -380,12 +380,12 @@ namespace CfgTests
         BOOL fRegistered = FALSE;
 
         hr = CfgAdminIsProductRegistered(cdhAdminDb, wzProductName, wzVersion, wzPublicKey, &fRegistered);
-        ExitOnFailure3(hr, "Failed to check if product is registered (per-machine): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+        ExitOnFailure(hr, "Failed to check if product is registered (per-machine): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
 
         if (!fRegistered)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "Product should be registered (per-machine), but it isn't!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+            ExitOnFailure(hr, "Product should be registered (per-machine), but it isn't!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
         }
 
     LExit:
@@ -398,12 +398,12 @@ namespace CfgTests
         BOOL fRegistered = FALSE;
 
         hr = CfgAdminIsProductRegistered(cdhAdminDb, wzProductName, wzVersion, wzPublicKey, &fRegistered);
-        ExitOnFailure3(hr, "Failed to check if product is registered (per-machine): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+        ExitOnFailure(hr, "Failed to check if product is registered (per-machine): %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
 
         if (fRegistered)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "Product shouldn't be registered (per-machine), but it is!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
+            ExitOnFailure(hr, "Product shouldn't be registered (per-machine), but it is!: %ls, %ls, %ls", wzProductName, wzVersion, wzPublicKey);
         }
 
     LExit:
@@ -419,12 +419,12 @@ namespace CfgTests
         BOOL fCfgFoundValue = FALSE;
 
         hr = RegReadBinary(hk, wzName, &pbBytes, &cbBytes);
-        ExitOnFailure1(hr, "Failed to read binary value from registry named %ls", wzName);
+        ExitOnFailure(hr, "Failed to read binary value from registry named %ls", wzName);
 
         if (dwOffset >= cbBytes * 8)
         {
             hr = E_INVALIDARG;
-            ExitOnFailure2(hr, "Not enough bytes found in registry value %ls to check offset %u", wzName, dwOffset);
+            ExitOnFailure(hr, "Not enough bytes found in registry value %ls to check offset %u", wzName, dwOffset);
         }
 
         fRegFoundValue = (pbBytes[dwOffset / 8] & (0x1 << (dwOffset % 8))) == 0 ? FALSE : TRUE;
@@ -432,16 +432,16 @@ namespace CfgTests
         if (fRegFoundValue != fExpectedValue)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "Boolean flag value in registry didn't match expected! RegName: %ls, Offset: %ls, Expected: %ls", wzName, dwOffset, fExpectedValue ? L"TRUE" : L"FALSE");
+            ExitOnFailure(hr, "Boolean flag value in registry didn't match expected! RegName: %ls, Offset: %ls, Expected: %ls", wzName, dwOffset, fExpectedValue ? L"TRUE" : L"FALSE");
         }
 
         hr = CfgGetBool(cdhDb, wzCfgName, &fCfgFoundValue);
-        ExitOnFailure1(hr, "Failed to read boolean from cfg db named %ls", wzCfgName);
+        ExitOnFailure(hr, "Failed to read boolean from cfg db named %ls", wzCfgName);
 
         if (fCfgFoundValue != fExpectedValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Boolean flag value in cfg db didn't match expected! CfgName: %ls, Expected: %ls", wzCfgName, fExpectedValue ? L"TRUE" : L"FALSE");
+            ExitOnFailure(hr, "Boolean flag value in cfg db didn't match expected! CfgName: %ls, Expected: %ls", wzCfgName, fExpectedValue ? L"TRUE" : L"FALSE");
         }
     LExit:
         ReleaseMem(pbBytes);
@@ -453,21 +453,21 @@ namespace CfgTests
         LPWSTR sczValue = NULL;
 
         hr = RegReadString(hk, wzName, &sczValue);
-        ExitOnFailure1(hr, "Failed to read registry string:%ls", wzName);
+        ExitOnFailure(hr, "Failed to read registry string:%ls", wzName);
 
         if (0 != lstrcmpW(sczValue, wzExpectedValue))
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in registry! Expected value '%ls', found value '%ls'", wzExpectedValue, sczValue);
+            ExitOnFailure(hr, "Wrong value in registry! Expected value '%ls', found value '%ls'", wzExpectedValue, sczValue);
         }
 
         hr = CfgGetString(cdhDb, wzCfgName, &sczValue);
-        ExitOnFailure1(hr, "Failed to read cfg db string:%ls", wzCfgName);
+        ExitOnFailure(hr, "Failed to read cfg db string:%ls", wzCfgName);
 
         if (0 != lstrcmpW(sczValue, wzExpectedValue))
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in cfg db! Expected value '%ls', found value '%ls'", wzExpectedValue, sczValue);
+            ExitOnFailure(hr, "Wrong value in cfg db! Expected value '%ls', found value '%ls'", wzExpectedValue, sczValue);
         }
 
     LExit:
@@ -480,21 +480,21 @@ namespace CfgTests
         DWORD dwValue = 0;
 
         hr = RegReadNumber(hk, wzName, &dwValue);
-        ExitOnFailure1(hr, "Failed to read registry dword:%ls", wzName);
+        ExitOnFailure(hr, "Failed to read registry dword:%ls", wzName);
 
         if (dwExpectedValue != dwValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in registry! Expected value %u, found value %u", dwExpectedValue, dwValue);
+            ExitOnFailure(hr, "Wrong value in registry! Expected value %u, found value %u", dwExpectedValue, dwValue);
         }
 
         hr = CfgGetDword(cdhDb, wzCfgName, &dwValue);
-        ExitOnFailure1(hr, "Failed to read cfg db dword:%ls", wzCfgName);
+        ExitOnFailure(hr, "Failed to read cfg db dword:%ls", wzCfgName);
 
         if (dwValue != dwExpectedValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in cfg db! Expected dword value %u, found dword value %u", dwExpectedValue, dwValue);
+            ExitOnFailure(hr, "Wrong value in cfg db! Expected dword value %u, found dword value %u", dwExpectedValue, dwValue);
         }
 
     LExit:
@@ -507,21 +507,21 @@ namespace CfgTests
         DWORD64 qwValue = 0;
 
         hr = RegReadQword(hk, wzName, &qwValue);
-        ExitOnFailure1(hr, "Failed to read registry qword:%ls", wzName);
+        ExitOnFailure(hr, "Failed to read registry qword:%ls", wzName);
 
         if (qwExpectedValue != qwValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in registry! Expected value %I64u, found value %I64u", qwExpectedValue, qwValue);
+            ExitOnFailure(hr, "Wrong value in registry! Expected value %I64u, found value %I64u", qwExpectedValue, qwValue);
         }
 
         hr = CfgGetQword(cdhDb, wzCfgName, &qwValue);
-        ExitOnFailure1(hr, "Failed to read cfg db qword:%ls", wzCfgName);
+        ExitOnFailure(hr, "Failed to read cfg db qword:%ls", wzCfgName);
 
         if (qwValue != qwExpectedValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Wrong value in cfg db! Expected qword value %I64u, found qword value %I64u", qwExpectedValue, qwValue);
+            ExitOnFailure(hr, "Wrong value in cfg db! Expected qword value %I64u, found qword value %I64u", qwExpectedValue, qwValue);
         }
 
     LExit:
@@ -542,7 +542,7 @@ namespace CfgTests
         {
             hr = E_FAIL;
         }
-        ExitOnFailure1(hr, "Registry string should not exist:%ls", wzName);
+        ExitOnFailure(hr, "Registry string should not exist:%ls", wzName);
 
         hr = CfgGetString(cdhDb, wzCfgName, &sczValue);
         if (E_NOTFOUND == hr)
@@ -553,7 +553,7 @@ namespace CfgTests
         {
             hr = E_FAIL;
         }
-        ExitOnFailure1(hr, "Cfg db value should not exist:%ls", wzName);
+        ExitOnFailure(hr, "Cfg db value should not exist:%ls", wzName);
 
     LExit:
         ReleaseStr(sczValue);
@@ -568,18 +568,18 @@ namespace CfgTests
         ExpectFile(cdhDb, wzFileName, pbBuffer, cbBuffer);
 
         hr = FileRead(&pbDataReadFromFile, &cbDataReadFromFile, wzFilePath);
-        ExitOnFailure1(hr, "Failed to read file: %ls", wzFilePath);
+        ExitOnFailure(hr, "Failed to read file: %ls", wzFilePath);
 
         if (cbBuffer != cbDataReadFromFile)
         {
             hr = E_FAIL;
-            ExitOnFailure3(hr, "File %ls should be size %u, but was size %u instead", wzFilePath, cbBuffer, cbDataReadFromFile);
+            ExitOnFailure(hr, "File %ls should be size %u, but was size %u instead", wzFilePath, cbBuffer, cbDataReadFromFile);
         }
 
         if (0 != memcmp(pbBuffer, pbDataReadFromFile, cbBuffer))
         {
             hr = E_FAIL;
-            ExitOnFailure1(hr, "File contents don't match for file of name: %ls", wzFilePath);
+            ExitOnFailure(hr, "File contents don't match for file of name: %ls", wzFilePath);
         }
     LExit:
         ReleaseMem(pbDataReadFromFile);
@@ -596,7 +596,7 @@ namespace CfgTests
         hr = FileRead(&pbDataReadFromFile, &cbDataReadFromFile, wzFilePath);
         if (E_FILENOTFOUND != hr && E_PATHNOTFOUND != hr)
         {
-            ExitOnFailure1(hr, "Shouldn't have found file: %ls", wzFilePath);
+            ExitOnFailure(hr, "Shouldn't have found file: %ls", wzFilePath);
         }
     LExit:
         ReleaseMem(pbDataReadFromFile);
@@ -624,12 +624,12 @@ namespace CfgTests
         LPWSTR sczValue = NULL;
 
         hr = CfgGetString(cdhDb, wzValueName, &sczValue);
-        ExitOnFailure1(hr, "Couldn't read string: %ls", wzValueName);
+        ExitOnFailure(hr, "Couldn't read string: %ls", wzValueName);
 
         if (0 != lstrcmpW(sczValue, wzExpectedValue))
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Value should have been '%ls', but was '%ls' instead", wzExpectedValue, sczValue);
+            ExitOnFailure(hr, "Value should have been '%ls', but was '%ls' instead", wzExpectedValue, sczValue);
         }
 
     LExit:
@@ -642,12 +642,12 @@ namespace CfgTests
         DWORD dwValue = 0;
 
         hr = CfgGetDword(cdhDb, wzValueName, &dwValue);
-        ExitOnFailure1(hr, "Couldn't read string: %ls", wzValueName);
+        ExitOnFailure(hr, "Couldn't read string: %ls", wzValueName);
 
         if (dwExpectedValue != dwValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Value should have been '%u', but was '%u' instead", dwExpectedValue, dwValue);
+            ExitOnFailure(hr, "Value should have been '%u', but was '%u' instead", dwExpectedValue, dwValue);
         }
 
     LExit:
@@ -660,12 +660,12 @@ namespace CfgTests
         BOOL fValue = 0;
 
         hr = CfgGetBool(cdhDb, wzValueName, &fValue);
-        ExitOnFailure1(hr, "Couldn't read string: %ls", wzValueName);
+        ExitOnFailure(hr, "Couldn't read string: %ls", wzValueName);
 
         if (fExpectedValue != fValue)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "Value should have been '%u', but was '%u' instead", fExpectedValue, fValue);
+            ExitOnFailure(hr, "Value should have been '%u', but was '%u' instead", fExpectedValue, fValue);
         }
 
     LExit:
@@ -679,18 +679,18 @@ namespace CfgTests
         SIZE_T cbLocalBuffer = 0;
 
         hr = CfgGetBlob(cdhDb, wzFileName, &pbLocalBuffer, &cbLocalBuffer);
-        ExitOnFailure1(hr, "Failed to get file: %ls", wzFileName);
+        ExitOnFailure(hr, "Failed to get file: %ls", wzFileName);
 
         if (cbBuffer != cbLocalBuffer)
         {
             hr = E_FAIL;
-            ExitOnFailure2(hr, "File should be size %u, but was size %u instead", cbBuffer, cbLocalBuffer);
+            ExitOnFailure(hr, "File should be size %u, but was size %u instead", cbBuffer, cbLocalBuffer);
         }
 
         if (0 != memcmp(pbBuffer, pbLocalBuffer, cbBuffer))
         {
             hr = E_FAIL;
-            ExitOnFailure1(hr, "File contents don't match for file of name: %ls", wzFileName);
+            ExitOnFailure(hr, "File contents don't match for file of name: %ls", wzFileName);
         }
 
     LExit:
@@ -723,7 +723,7 @@ namespace CfgTests
         if (E_FILENOTFOUND != hr)
         {
             hr = E_FAIL;
-            ExitOnFailure1(hr, "Regkey should not exist, but it does: %ls", wzKeyName);
+            ExitOnFailure(hr, "Regkey should not exist, but it does: %ls", wzKeyName);
         }
 
     LExit:
@@ -750,13 +750,13 @@ namespace CfgTests
                 else
                 {
                     hr = E_FAIL;
-                    ExitOnFailure3(hr, "Found ini value %ls, but we expected to find value %ls, and found value %ls instead", wzValueName, wzExpectedValue, rgivValues[i].wzValue);
+                    ExitOnFailure(hr, "Found ini value %ls, but we expected to find value %ls, and found value %ls instead", wzValueName, wzExpectedValue, rgivValues[i].wzValue);
                 }
             }
         }
 
         hr = E_NOTFOUND;
-        ExitOnFailure1(hr, "Failed to find value %ls in INI", wzValueName);
+        ExitOnFailure(hr, "Failed to find value %ls in INI", wzValueName);
 
     LExit:
         return;
@@ -799,13 +799,13 @@ namespace CfgTests
         for (DWORD i = 0; i < dwCount; ++i)
         {
             hr = CfgEnumReadString(cehHandle, i, ENUM_DATA_FRIENDLY_NAME, &wzFriendlyName);
-            ExitOnFailure1(hr, "Failed to read friendly name from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read friendly name from database list enum at index %u", i);
 
             hr = CfgEnumReadBool(cehHandle, i, ENUM_DATA_SYNC_BY_DEFAULT, &fSyncByDefault);
-            ExitOnFailure1(hr, "Failed to read path from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read path from database list enum at index %u", i);
 
             hr = CfgEnumReadString(cehHandle, i, ENUM_DATA_PATH, &wzPath);
-            ExitOnFailure1(hr, "Failed to read path from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read path from database list enum at index %u", i);
 
             // If it isn't the right friendly name, skip to the next database in the enumeration
             if (0 != lstrcmpW(wzExpectedFriendlyName, wzFriendlyName))
@@ -816,13 +816,13 @@ namespace CfgTests
             if (0 != lstrcmpW(wzExpectedPath, wzPath))
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "Database list friendly name '%ls' has incorrect path (expected '%ls', found '%ls')", wzExpectedFriendlyName, wzExpectedPath, wzPath);
+                ExitOnFailure(hr, "Database list friendly name '%ls' has incorrect path (expected '%ls', found '%ls')", wzExpectedFriendlyName, wzExpectedPath, wzPath);
             }
 
             if (fSyncByDefault != fExpectedSyncByDefault)
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "Database list friendly name '%ls' has incorrect 'sync by default' flag (expected %u, found %u)", wzExpectedFriendlyName, fExpectedSyncByDefault, fSyncByDefault);
+                ExitOnFailure(hr, "Database list friendly name '%ls' has incorrect 'sync by default' flag (expected %u, found %u)", wzExpectedFriendlyName, fExpectedSyncByDefault, fSyncByDefault);
             }
 
             // We found the right one, so return successfully now
@@ -830,7 +830,7 @@ namespace CfgTests
         }
 
         hr = E_FAIL;
-        ExitOnFailure2(hr, "Expected to find database in list, but didn't find it: %ls, %ls", wzFriendlyName, wzPath);
+        ExitOnFailure(hr, "Expected to find database in list, but didn't find it: %ls, %ls", wzFriendlyName, wzPath);
 
     LExit:
         return;
@@ -850,19 +850,19 @@ namespace CfgTests
         for (DWORD i = 0; i < dwCount; ++i)
         {
             hr = CfgEnumReadString(cehHandle, i, ENUM_DATA_FRIENDLY_NAME, &wzFriendlyName);
-            ExitOnFailure1(hr, "Failed to read friendly name from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read friendly name from database list enum at index %u", i);
 
             hr = CfgEnumReadBool(cehHandle, i, ENUM_DATA_SYNC_BY_DEFAULT, &fSyncByDefault);
-            ExitOnFailure1(hr, "Failed to read path from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read path from database list enum at index %u", i);
 
             hr = CfgEnumReadString(cehHandle, i, ENUM_DATA_PATH, &wzPath);
-            ExitOnFailure1(hr, "Failed to read path from database list enum at index %u", i);
+            ExitOnFailure(hr, "Failed to read path from database list enum at index %u", i);
 
             // If it isn't the right friendly name, skip to the next database in the enumeration
             if (0 == lstrcmpW(wzExpectedFriendlyName, wzFriendlyName))
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Should not have found friendly name '%ls' in database list, but it was found!", wzExpectedFriendlyName);
+                ExitOnFailure(hr, "Should not have found friendly name '%ls' in database list, but it was found!", wzExpectedFriendlyName);
             }
         }
 

--- a/test/src/SettingsEngineTests/error.h
+++ b/test/src/SettingsEngineTests/error.h
@@ -17,7 +17,7 @@ static char szMsg[ERROR_STRING_BUFFER];
 static WCHAR wzMsg[ERROR_STRING_BUFFER];
 
 #define ExitTrace(x, s) { HRESULT hrTemp = x; throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(s))); }
-#define ExitTrace1(x, f, s) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
-#define ExitTrace2(x, f, s, t) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
-#define ExitTrace3(x, f, s, t, u) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t, u); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
+#define ExitTrace(x, f, s) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
+#define ExitTrace(x, f, s, t) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
+#define ExitTrace(x, f, s, t, u) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t, u); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
 

--- a/test/src/UnitTests/Burn/ElevationTest.cpp
+++ b/test/src/UnitTests/Burn/ElevationTest.cpp
@@ -189,7 +189,7 @@ static HRESULT ProcessParentMessages(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unexpected elevated message sent to parent process, msg: %u", pMsg->dwMessage);
+        ExitOnRootFailure(hr, "Unexpected elevated message sent to parent process, msg: %u", pMsg->dwMessage);
     }
 
     *pdwResult = static_cast<DWORD>(hrResult);
@@ -219,7 +219,7 @@ static HRESULT ProcessChildMessages(
 
     default:
         hr = E_INVALIDARG;
-        ExitOnRootFailure1(hr, "Unexpected elevated message sent to child process, msg: %u", pMsg->dwMessage);
+        ExitOnRootFailure(hr, "Unexpected elevated message sent to child process, msg: %u", pMsg->dwMessage);
     }
 
     *pdwResult = dwResult;

--- a/test/src/UnitTests/dutil/DictUtilTest.cpp
+++ b/test/src/UnitTests/dutil/DictUtilTest.cpp
@@ -60,7 +60,7 @@ namespace DutilTests
                 ExitOnFailure(hr, "Failed to grow value array");
 
                 hr = StrAllocFormatted(&rgValues[i].sczKey, L"%u_a_%u", i, i);
-                ExitOnFailure2(hr, "Failed to allocate key for value %u", i, i);
+                ExitOnFailure(hr, "Failed to allocate key for value %u", i, i);
 
                 hr = DictAddValue(sdValues, rgValues + i);
                 ExitOnFailure(hr, "Failed to add item to dict");
@@ -72,7 +72,7 @@ namespace DutilTests
                 ExitOnFailure(hr, "Failed to alloc expected key");
 
                 hr = DictGetValue(sdValues, sczExpectedKey, (void **)&valueFound);
-                ExitOnFailure1(hr, "Failed to find value %ls", sczExpectedKey);
+                ExitOnFailure(hr, "Failed to find value %ls", sczExpectedKey);
 
                 if (0 != wcscmp(sczExpectedKey, valueFound->sczKey))
                 {
@@ -86,7 +86,7 @@ namespace DutilTests
 
                 if (dfFlags & DICT_FLAG_CASEINSENSITIVE)
                 {
-                    ExitOnFailure1(hr, "Failed to find value %ls", sczExpectedKey);
+                    ExitOnFailure(hr, "Failed to find value %ls", sczExpectedKey);
 
                     if (0 != _wcsicmp(sczExpectedKey, valueFound->sczKey))
                     {
@@ -99,7 +99,7 @@ namespace DutilTests
                     if (E_NOTFOUND != hr)
                     {
                         hr = E_FAIL;
-                        ExitOnFailure1(hr, "This embedded key is case sensitive, but it seemed to have found something case using case insensitivity!: %ls", sczExpectedKey);
+                        ExitOnFailure(hr, "This embedded key is case sensitive, but it seemed to have found something case using case insensitivity!: %ls", sczExpectedKey);
                     }
                 }
 
@@ -110,7 +110,7 @@ namespace DutilTests
                 if (E_NOTFOUND != hr)
                 {
                     hr = E_FAIL;
-                    ExitOnFailure1(hr, "Item shouldn't have been found in dictionary: %ls", sczExpectedKey);
+                    ExitOnFailure(hr, "Item shouldn't have been found in dictionary: %ls", sczExpectedKey);
                 }
             }
 
@@ -137,7 +137,7 @@ namespace DutilTests
             for (DWORD i = 0; i < dwNumIterations; ++i)
             {
                 hr = StrAllocFormatted(&sczKey, L"%u_a_%u", i, i);
-                ExitOnFailure2(hr, "Failed to allocate key for value %u", i, i);
+                ExitOnFailure(hr, "Failed to allocate key for value %u", i, i);
 
                 hr = DictAddKey(sdValues, sczKey);
                 ExitOnFailure(hr, "Failed to add key to dict");
@@ -149,7 +149,7 @@ namespace DutilTests
                 ExitOnFailure(hr, "Failed to alloc expected key");
 
                 hr = DictKeyExists(sdValues, sczExpectedKey);
-                ExitOnFailure1(hr, "Failed to find value %ls", sczExpectedKey);
+                ExitOnFailure(hr, "Failed to find value %ls", sczExpectedKey);
 
                 hr = StrAllocFormatted(&sczExpectedKey, L"%u_A_%u", i, i);
                 ExitOnFailure(hr, "Failed to alloc expected key");
@@ -157,14 +157,14 @@ namespace DutilTests
                 hr = DictKeyExists(sdValues, sczExpectedKey);
                 if (dfFlags & DICT_FLAG_CASEINSENSITIVE)
                 {
-                    ExitOnFailure1(hr, "Failed to find value %ls", sczExpectedKey);
+                    ExitOnFailure(hr, "Failed to find value %ls", sczExpectedKey);
                 }
                 else
                 {
                     if (E_NOTFOUND != hr)
                     {
                         hr = E_FAIL;
-                        ExitOnFailure1(hr, "This stringlist dict is case sensitive, but it seemed to have found something case using case insensitivity!: %ls", sczExpectedKey);
+                        ExitOnFailure(hr, "This stringlist dict is case sensitive, but it seemed to have found something case using case insensitivity!: %ls", sczExpectedKey);
                     }
                 }
 
@@ -175,7 +175,7 @@ namespace DutilTests
                 if (E_NOTFOUND != hr)
                 {
                     hr = E_FAIL;
-                    ExitOnFailure1(hr, "Item shouldn't have been found in dictionary: %ls", sczExpectedKey);
+                    ExitOnFailure(hr, "Item shouldn't have been found in dictionary: %ls", sczExpectedKey);
                 }
             }
 

--- a/test/src/UnitTests/dutil/DirUtilTests.cpp
+++ b/test/src/UnitTests/dutil/DirUtilTests.cpp
@@ -36,30 +36,30 @@ namespace DutilTests
                 ExitOnFailure(hr, "Failed to get current directory.");
 
                 hr = PathConcat(sczCurrentDir, sczGuid, &sczFolder);
-                ExitOnFailure2(hr, "Failed to combine current directory: '%ls' with Guid: '%ls'", sczCurrentDir, sczGuid);
+                ExitOnFailure(hr, "Failed to combine current directory: '%ls' with Guid: '%ls'", sczCurrentDir, sczGuid);
 
                 BOOL fExists = DirExists(sczFolder, NULL);
                 Assert::False(fExists);
 
                 hr = PathConcat(sczFolder, L"foo", &sczSubFolder);
-                ExitOnFailure1(hr, "Failed to combine folder: '%ls' with subfolder: 'foo'", sczFolder);
+                ExitOnFailure(hr, "Failed to combine folder: '%ls' with subfolder: 'foo'", sczFolder);
 
                 hr = DirEnsureExists(sczSubFolder, NULL);
-                ExitOnFailure1(hr, "Failed to create multiple directories: %ls", sczSubFolder);
+                ExitOnFailure(hr, "Failed to create multiple directories: %ls", sczSubFolder);
 
                 // Test failure to delete non-empty folder.
                 hr = DirEnsureDelete(sczFolder, FALSE, FALSE);
                 Assert::Equal<HRESULT>(0x80070091, hr);
 
                 hr = DirEnsureDelete(sczSubFolder, FALSE, FALSE);
-                ExitOnFailure1(hr, "Failed to delete single directory: %ls", sczSubFolder);
+                ExitOnFailure(hr, "Failed to delete single directory: %ls", sczSubFolder);
 
                 // Put the directory back and we'll test deleting tree.
                 hr = DirEnsureExists(sczSubFolder, NULL);
-                ExitOnFailure1(hr, "Failed to create single directory: %ls", sczSubFolder);
+                ExitOnFailure(hr, "Failed to create single directory: %ls", sczSubFolder);
 
                 hr = DirEnsureDelete(sczFolder, FALSE, TRUE);
-                ExitOnFailure1(hr, "Failed to delete directory tree: %ls", sczFolder);
+                ExitOnFailure(hr, "Failed to delete directory tree: %ls", sczFolder);
 
                 // Finally, try to create "C:\" which would normally fail, but we want success
                 hr = DirEnsureExists(L"C:\\", NULL);

--- a/test/src/UnitTests/dutil/FileUtilTest.cpp
+++ b/test/src/UnitTests/dutil/FileUtilTest.cpp
@@ -33,7 +33,7 @@ namespace DutilTests
             ExitOnFailure(hr, "Failed to get path to encodings file dir");
 
             hr = DirEnsureExists(sczTempDir, NULL);
-            ExitOnFailure1(hr, "Failed to ensure directory exists: %ls", sczTempDir);
+            ExitOnFailure(hr, "Failed to ensure directory exists: %ls", sczTempDir);
 
             TestFile(sczFileDir, sczTempDir, L"ANSI.txt", 32, FILE_ENCODING_UTF8);
             // Big endian not supported today!
@@ -66,27 +66,27 @@ namespace DutilTests
             DWORD cbFile2 = 0;
 
             hr = PathConcat(wzDir, wzFileName, &sczFullPath);
-            ExitOnFailure1(hr, "Failed to create path to test file: %ls", sczFullPath);
+            ExitOnFailure(hr, "Failed to create path to test file: %ls", sczFullPath);
 
             hr = FileToString(sczFullPath, &sczContents, &feEncodingFound);
-            ExitOnFailure1(hr, "Failed to read text from file: %ls", sczFullPath);
+            ExitOnFailure(hr, "Failed to read text from file: %ls", sczFullPath);
 
             if (NULL == sczContents)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "FileToString() returned NULL for file: %ls", sczFullPath);
+                ExitOnFailure(hr, "FileToString() returned NULL for file: %ls", sczFullPath);
             }
 
             if ((DWORD)lstrlenW(sczContents) != dwExpectedStringLength)
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "FileToString() returned wrong size for file: %ls (expected size %u, found size %u)", sczFullPath, dwExpectedStringLength, lstrlenW(sczContents));
+                ExitOnFailure(hr, "FileToString() returned wrong size for file: %ls (expected size %u, found size %u)", sczFullPath, dwExpectedStringLength, lstrlenW(sczContents));
             }
 
             if (feEncodingFound != feExpectedEncoding)
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "FileToString() returned unexpected encoding type for file: %ls (expected type %u, found type %u)", sczFullPath, feExpectedEncoding, feEncodingFound);
+                ExitOnFailure(hr, "FileToString() returned unexpected encoding type for file: %ls (expected type %u, found type %u)", sczFullPath, feExpectedEncoding, feEncodingFound);
             }
 
             hr = PathConcat(wzTempDir, wzFileName, &sczOutputPath);
@@ -104,7 +104,7 @@ namespace DutilTests
             if (cbFile1 != cbFile2 || 0 != memcmp(pbFile1, pbFile2, cbFile1))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "Outputted file doesn't match input file: \"%ls\" and \"%ls\"", sczFullPath, sczOutputPath);
+                ExitOnFailure(hr, "Outputted file doesn't match input file: \"%ls\" and \"%ls\"", sczFullPath, sczOutputPath);
             }
 
         LExit:

--- a/test/src/UnitTests/dutil/IniUtilTest.cpp
+++ b/test/src/UnitTests/dutil/IniUtilTest.cpp
@@ -74,12 +74,12 @@ namespace DutilTests
             LPWSTR sczValue = NULL;
 
             hr = IniGetValue(iniHandle, wzValueName, &sczValue);
-            ExitOnFailure1(hr, "Failed to get ini value: %ls", wzValueName);
+            ExitOnFailure(hr, "Failed to get ini value: %ls", wzValueName);
 
             if (0 != wcscmp(sczValue, wzValue))
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "Expected to find value in INI: '%ls'='%ls' - but found value '%ls' instead", wzValueName, wzValue, sczValue);
+                ExitOnFailure(hr, "Expected to find value in INI: '%ls'='%ls' - but found value '%ls' instead", wzValueName, wzValue, sczValue);
             }
 
         LExit:
@@ -98,7 +98,7 @@ namespace DutilTests
                 {
                     hr = E_FAIL;
                 }
-                ExitOnFailure1(hr, "INI value shouldn't have been found: %ls", wzValueName);
+                ExitOnFailure(hr, "INI value shouldn't have been found: %ls", wzValueName);
             }
         LExit:
             ReleaseStr(sczValue);
@@ -158,7 +158,7 @@ namespace DutilTests
             if (cValues != 5)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 5 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 5 values in INI file, but found %u instead!", cValues);
             }
 
             AssertValue(iniHandle, L"PlainValue", L"Blah");
@@ -184,7 +184,7 @@ namespace DutilTests
             if (cValues != 7)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 7 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 7 values in INI file, but found %u instead!", cValues);
             }
 
             AssertValue(iniHandle, L"PlainValue", L"Blah");
@@ -220,7 +220,7 @@ namespace DutilTests
             if (cValues != 6)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 6 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 6 values in INI file, but found %u instead!", cValues);
             }
 
             AssertValue(iniHandle2, L"PlainValue", L"Blah");
@@ -260,7 +260,7 @@ namespace DutilTests
             if (cValues != 0)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 0 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 0 values in INI file, but found %u instead!", cValues);
             }
 
             hr = IniSetValue(iniHandle, L"Value1", L"BlahTypo");
@@ -299,7 +299,7 @@ namespace DutilTests
             if (cValues != 8)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 8 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 8 values in INI file, but found %u instead!", cValues);
             }
 
             AssertValue(iniHandle, L"Value1", L"Blah1");
@@ -331,7 +331,7 @@ namespace DutilTests
             if (cValues != 7)
             {
                 hr = E_FAIL;
-                ExitOnFailure1(hr, "Expected to find 7 values in INI file, but found %u instead!", cValues);
+                ExitOnFailure(hr, "Expected to find 7 values in INI file, but found %u instead!", cValues);
             }
 
             AssertValue(iniHandle2, L"Value1", L"Blah1");

--- a/test/src/UnitTests/dutil/StrUtilTest.cpp
+++ b/test/src/UnitTests/dutil/StrUtilTest.cpp
@@ -91,12 +91,12 @@ namespace DutilTests
             LPWSTR sczOutput = NULL;
 
             hr = StrTrimWhitespace(&sczOutput, wzInput);
-            ExitOnFailure1(hr, "Failed to trim whitespace from string: %ls", wzInput);
+            ExitOnFailure(hr, "Failed to trim whitespace from string: %ls", wzInput);
 
             if (0 != wcscmp(wzExpectedResult, sczOutput))
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "Trimmed string \"%ls\", expected result \"%ls\", actual result \"%ls\"", wzInput, wzExpectedResult, sczOutput);
+                ExitOnFailure(hr, "Trimmed string \"%ls\", expected result \"%ls\", actual result \"%ls\"", wzInput, wzExpectedResult, sczOutput);
             }
 
         LExit:
@@ -109,12 +109,12 @@ namespace DutilTests
             LPSTR sczOutput = NULL;
 
             hr = StrAnsiTrimWhitespace(&sczOutput, szInput);
-            ExitOnFailure1(hr, "Failed to trim whitespace from string: \"%hs\"", szInput);
+            ExitOnFailure(hr, "Failed to trim whitespace from string: \"%hs\"", szInput);
 
             if (0 != strcmp(szExpectedResult, sczOutput))
             {
                 hr = E_FAIL;
-                ExitOnFailure3(hr, "Trimmed string \"%hs\", expected result \"%hs\", actual result \"%ls\"", szInput, szExpectedResult, sczOutput);
+                ExitOnFailure(hr, "Trimmed string \"%hs\", expected result \"%hs\", actual result \"%ls\"", szInput, szExpectedResult, sczOutput);
             }
 
         LExit:
@@ -127,12 +127,12 @@ namespace DutilTests
             LPWSTR sczOutput = NULL;
 
             hr = StrAllocStringAnsi(&sczOutput, szSource, cchSource, CP_UTF8);
-            ExitOnFailure1(hr, "Failed to call StrAllocStringAnsi on string: \"%hs\"", szSource);
+            ExitOnFailure(hr, "Failed to call StrAllocStringAnsi on string: \"%hs\"", szSource);
 
             if (0 != wcscmp(sczOutput, wzExpectedResult))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "String doesn't match, expected result \"%ls\", actual result \"%ls\"", wzExpectedResult, sczOutput);
+                ExitOnFailure(hr, "String doesn't match, expected result \"%ls\", actual result \"%ls\"", wzExpectedResult, sczOutput);
             }
 
         LExit:
@@ -145,12 +145,12 @@ namespace DutilTests
             LPSTR sczOutput = NULL;
 
             hr = StrAnsiAllocString(&sczOutput, wzSource, cchSource, CP_UTF8);
-            ExitOnFailure1(hr, "Failed to call StrAllocStringAnsi on string: \"%ls\"", wzSource);
+            ExitOnFailure(hr, "Failed to call StrAllocStringAnsi on string: \"%ls\"", wzSource);
 
             if (0 != strcmp(sczOutput, szExpectedResult))
             {
                 hr = E_FAIL;
-                ExitOnFailure2(hr, "String doesn't match, expected result \"%hs\", actual result \"%hs\"", szExpectedResult, sczOutput);
+                ExitOnFailure(hr, "String doesn't match, expected result \"%hs\", actual result \"%hs\"", szExpectedResult, sczOutput);
             }
 
         LExit:

--- a/test/src/UnitTests/dutil/error.h
+++ b/test/src/UnitTests/dutil/error.h
@@ -16,8 +16,7 @@ const int ERROR_STRING_BUFFER = 1024;
 static char szMsg[ERROR_STRING_BUFFER];
 static WCHAR wzMsg[ERROR_STRING_BUFFER];
 
-#define ExitTrace(x, s) { HRESULT hrTemp = x; throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(s))); }
-#define ExitTrace1(x, f, s) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
-#define ExitTrace2(x, f, s, t) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
-#define ExitTrace3(x, f, s, t, u) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, s, t, u); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
-
+#define ExitTrace(x, f, ...) { HRESULT hrTemp = x; hr = ::StringCchPrintfA(szMsg, countof(szMsg), f, __VA_ARGS__); MultiByteToWideChar(CP_ACP, 0, szMsg, -1, wzMsg, countof(wzMsg)); throw gcnew System::Exception(System::String::Format("hr = 0x{0:X8}, message = {1}", hrTemp, gcnew System::String(wzMsg))); }
+#define ExitTrace1 ExitTrace
+#define ExitTrace2 ExitTrace
+#define ExitTrace3 ExitTrace


### PR DESCRIPTION
Variadic macros can be a productivity boost by not having to think about which macro to use only to change it later when you realize you want an extra string argument...if you remember. And it's not always easy to catch when you don't remember.

This also includes a few supporting changes to libs like wcautil, where I copy the `va_list` and iterate through a copy to determine the number of arguments automatically while maintaining backward compatibility.
