### PR TITLE
Fix BA manifest parsing when DisplayInternalUI is absent.

### DIFF
--- a/src/ext/BalExtension/mba/core/PackageInfo.cs
+++ b/src/ext/BalExtension/mba/core/PackageInfo.cs
@@ -93,11 +93,7 @@ namespace WixToolset.Bootstrapper
                 package.Vital = vital.Value;
 
                 bool? displayInternalUI = BootstrapperApplicationData.GetYesNoAttribute(node, "DisplayInternalUI");
-                if (!displayInternalUI.HasValue)
-                {
-                    throw new Exception("Failed to get DisplayInternalUI setting for package.");
-                }
-                package.DisplayInternalUI = displayInternalUI.Value;
+                package.DisplayInternalUI = displayInternalUI.HasValue && displayInternalUI.Value;
 
                 package.ProductCode = BootstrapperApplicationData.GetAttribute(node, "ProductCode");
 


### PR DESCRIPTION
DisplayInternalUI is only present on MSI and MSP packages. The code
assumed it was always present (which it may have been but should not
have been).
