### PR TITLE
VS2015 support

### DIFF
--- a/src/DTF/Libraries/WindowsInstaller/RemotableNativeMethods.cs
+++ b/src/DTF/Libraries/WindowsInstaller/RemotableNativeMethods.cs
@@ -243,7 +243,7 @@ namespace WixToolset.Dtf.WindowsInstaller
         private static void FreeString(IntPtr buf, int field)
         {
             IntPtr stringPtr = Marshal.ReadIntPtr(buf, (field * requestFieldSize) + requestFieldDataOffset);
-            if (stringPtr != null)
+            if (stringPtr != IntPtr.Zero)
             {
                 Marshal.FreeHGlobal(stringPtr);
             }

--- a/src/DTF/Tools/SfxCA/SfxCA.cpp
+++ b/src/DTF/Tools/SfxCA/SfxCA.cpp
@@ -352,7 +352,11 @@ bool InvokeManagedCustomAction(MSIHANDLE hSession, _AppDomain* pAppDomain,
         else
         {
                 vRemotingFunctionPtr.vt =  VT_I4;
+#pragma warning(push)
+#pragma warning(disable:4302) // truncation
+#pragma warning(disable:4311) // pointer truncation
                 vRemotingFunctionPtr.lVal = (LONG) (g_fRunningOutOfProc ? MsiRemoteInvoke : NULL);
+#pragma warning(pop)
         }
         index = 2;
         hr = SafeArrayPutElement(saArgs, &index, &vRemotingFunctionPtr);

--- a/src/Setup/Bundle/Bundle.wixproj
+++ b/src/Setup/Bundle/Bundle.wixproj
@@ -44,6 +44,9 @@
     <ProjectReference Include="..\NativeSdkMsi\NativeSdkMsi2013.wixproj" Condition="$(VS2013Available)">
         <Properties>VisualStudioTargetVersion=2013</Properties>
     </ProjectReference>
+    <ProjectReference Include="..\NativeSdkMsi\NativeSdkMsi2015.wixproj" Condition="$(VS2015Available)">
+        <Properties>VisualStudioTargetVersion=2015</Properties>
+    </ProjectReference>
     <ProjectReference Include="..\VotiveMsi\VotiveMsi.wixproj" />
     <ProjectReference Include="..\WixBA\WixBA.csproj" />
   </ItemGroup>

--- a/src/Setup/Bundle/Bundle.wxs
+++ b/src/Setup/Bundle/Bundle.wxs
@@ -38,6 +38,7 @@
         <util:RegistrySearch Root='HKLM' Key='SOFTWARE\Microsoft\VisualStudio\10.0' Value='InstallDir' Variable='VS2010InstallFolder' />
         <util:RegistrySearch Root='HKLM' Key='SOFTWARE\Microsoft\VisualStudio\11.0' Value='InstallDir' Variable='VS2012InstallFolder' />
         <util:RegistrySearch Root='HKLM' Key='SOFTWARE\Microsoft\VisualStudio\12.0' Value='InstallDir' Variable='VS2013InstallFolder' />
+        <util:RegistrySearch Root='HKLM' Key='SOFTWARE\Microsoft\VisualStudio\14.0' Value='InstallDir' Variable='VS2015InstallFolder' />
         
         <util:ComponentSearch Guid="{B455E8D3-90CB-47F6-AB7B-9B31E5DE6266}" Variable="VS2010VCExpressInstalled" />
         <util:ComponentSearch Guid="{55C6B9D6-A824-4AFC-8D08-20E581B6F42C}" Variable="VS2012WDExpressInstalled" />
@@ -69,7 +70,7 @@
 
             <!-- Votive needs to be last as it runs devenv /setup -->
             <MsiPackage Vital='yes' Name='data\votive.msi' SourceFile='data\votive.msi'
-                        InstallCondition='VS2010InstallFolder OR VS2012InstallFolder OR VS2013InstallFolder'
+                        InstallCondition='VS2010InstallFolder OR VS2012InstallFolder OR VS2013InstallFolder OR VS2015InstallFolder'
                         DownloadUrl='http://wixtoolset.org/releases/$(var.WixVersion)/{2}'
                         >
                 <MsiProperty Name='INSTALLFOLDER' Value='[InstallFolder]' />
@@ -101,6 +102,14 @@
             <MsiPackage Vital='yes' Name='data\nsdk2013.msi' SourceFile='data\nsdk2013.msi'
                         InstallCondition='VS2013InstallFolder OR VS2013WDExpressInstalled'
                         DownloadUrl='http://wixtoolset.org/releases/$(var.WixVersion)/{2}'
+                        >
+                <MsiProperty Name='INSTALLFOLDER' Value='[InstallFolder]' />
+            </MsiPackage>
+            <?endif?>
+
+            <?ifdef VS2015Available ?>
+            <MsiPackage Vital='yes' Name='data\nsdk2015.msi' SourceFile='data\nsdk2015.msi'
+                        InstallCondition='VS2015InstallFolder'
                         >
                 <MsiProperty Name='INSTALLFOLDER' Value='[InstallFolder]' />
             </MsiPackage>

--- a/src/Setup/CommonLib/Folders.wxs
+++ b/src/Setup/CommonLib/Folders.wxs
@@ -190,4 +190,41 @@
             <Directory Id="VS2013_SCHEMAS_DIR" Name="Schemas" />
         </DirectoryRef>
     </Fragment>
+
+    <!--
+        VS2015
+    -->
+    <Fragment>
+        <DirectoryRef Id="ProgramFilesFolder">
+            <Directory Id="VisualStudio2014Folder" Name="Microsoft Visual Studio 14.0">
+                <Directory Id="Common7Vs2015" Name="Common7">
+                    <Directory Id="IDEVs2015" Name="IDE"/>
+                </Directory>
+                <Directory Id="XmlVs2015" Name="Xml"/>
+            </Directory>
+        </DirectoryRef>
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS14_EXTENSIONS_DIR" />
+
+        <DirectoryRef Id="IDEVs2015">
+            <Directory Id="VS14_EXTENSIONS_DIR" Name="Extensions">
+                <Directory Id="VsExtensions2015Microsoft" Name="Microsoft">
+                    <Directory Id="VsExtensions2015MicrosoftWix" Name="WiX">
+                        <Directory Id="VsItemTemplatesWix2015Folder" Name="ItemTemplates" />
+                        <Directory Id="VsProjectTemplatesWix2015Folder" Name="ProjectTemplates" />
+                    </Directory>
+                </Directory>
+            </Directory>
+        </DirectoryRef>
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS14_SCHEMAS_DIR" />
+
+        <DirectoryRef Id="XmlVs2015">
+            <Directory Id="VS14_SCHEMAS_DIR" Name="Schemas" />
+        </DirectoryRef>
+    </Fragment>
 </Wix>

--- a/src/Setup/NativeSdkMsi/NativeSdkMsi2015.wixproj
+++ b/src/Setup/NativeSdkMsi/NativeSdkMsi2015.wixproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="NativeSdkMsi2013.wixproj" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioTargetVersion>2015</VisualStudioTargetVersion>
+    <NativeTemplatesFromVersion>2015</NativeTemplatesFromVersion>
+  </PropertyGroup>
+
+  <Import Project="NativeSdkMsi.targets" />
+
+  <PropertyGroup>
+    <VS2010SDKAndVS2015SDK>false</VS2010SDKAndVS2015SDK>
+    <VS2010SDKAndVS2015SDK Condition=" $(VS2010SdkAvailable) and $(VS2015SdkAvailable) ">true</VS2010SDKAndVS2015SDK>
+    <DefineConstants>$(DefineConstants);VSSdkAvailable=$(VS2010SDKAndVS2015SDK)</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/Setup/NativeSdkMsi/ProjectTemplates.wxs
+++ b/src/Setup/NativeSdkMsi/ProjectTemplates.wxs
@@ -10,7 +10,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <ComponentGroup Id="ProjectTemplates" Directory="VsProjectTemplatesWix$(var.VisualStudioTargetVersion)Folder">
-<?ifdef VS2010SdkAvailable ?>
+<?if $(var.VSSdkAvailable)=true ?>
           <Component>
             <File Source="votive$(var.NativeTemplatesFromVersion)\CustomActionCPP.zip" />
           </Component>

--- a/src/Setup/VotiveMsi/2010.wxs
+++ b/src/Setup/VotiveMsi/2010.wxs
@@ -35,6 +35,9 @@
             <Component>
                 <File Source="votive2010.dll" />
                 <util:RestartResource Path="[VS2010DEVENV]" />
+                <util:RestartResource Path="[VS2012DEVENV]" />
+                <util:RestartResource Path="[VS2013DEVENV]" />
+                <util:RestartResource Path="[VS14DEVENV]" />
             </Component>
 
           <Component>
@@ -89,7 +92,9 @@
                 <File Id="WixProject$(var.VsVersion).zip" Source="templates\WixProject.zip" />
             </Component>
         </ComponentGroup>
+    </Fragment>
 
+    <Fragment>
         <ComponentGroup Id="Votive$(var.VsVersion)SchemaComponents" Directory="VS2010_SCHEMAS_DIR">
             <Component>
                 <File Id="LuxSchema$(var.VsVersion)" Source="lux\wixext\Xsd\lux.xsd" />

--- a/src/Setup/VotiveMsi/2013.wxs
+++ b/src/Setup/VotiveMsi/2013.wxs
@@ -77,7 +77,9 @@
                 <File Id="WixProject$(var.VsVersion).zip" Source="templates\WixProject.zip" />
             </Component>
         </ComponentGroup>
+    </Fragment>
 
+    <Fragment>
         <ComponentGroup Id="Votive$(var.VsVersion)SchemaComponents" Directory="VS2013_SCHEMAS_DIR">
             <Component>
                 <File Id="LuxSchema$(var.VsVersion)" Source="lux\wixext\Xsd\lux.xsd" />
@@ -98,6 +100,9 @@
                 <File Id="ExtensionXsdDependency$(var.VsVersion)" Source="ext\DependencyExtension\wixext\Xsd\Dependency.xsd" />
             </Component>
             <Component>
+                <File Id="ExtensionXsdComplus$(var.VsVersion)" Source="ext\ComPlusExtension\wixext\xsd\complus.xsd" />
+            </Component>
+            <Component>
                 <File Id="ExtensionXsdDifxApp$(var.VsVersion)" Source="ext\DifxAppExtension\wixext\Xsd\difxapp.xsd" />
             </Component>
             <Component>
@@ -108,6 +113,9 @@
             </Component>
             <Component>
                 <File Id="ExtensionXsdIis$(var.VsVersion)" Source="ext\IIsExtension\wixext\xsd\iis.xsd" />
+            </Component>
+            <Component>
+                <File Id="ExtensionXsdMsmq$(var.VsVersion)" Source="ext\MsmqExtension\wixext\xsd\msmq.xsd" />
             </Component>
             <Component>
                 <File Id="ExtensionXsdNetFx$(var.VsVersion)" Source="ext\NetFxExtension\wixext\Xsd\netfx.xsd" />

--- a/src/Setup/VotiveMsi/2015.wxs
+++ b/src/Setup/VotiveMsi/2015.wxs
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  <copyright file="2012.wxs" company="Outercurve Foundation">
+  <copyright file="2015.wxs" company="Outercurve Foundation">
     Copyright (c) 2004, Outercurve Foundation.
     This software is released under Microsoft Reciprocal License (MS-RL).
     The license and further copyright text can be found in the file
@@ -11,39 +11,36 @@
 <?include WixVer.wxi ?>
 
 <!-- Preprocessor definitions -->
-<?define VsVersion = "2012"?>
-<?define VsRegPath = "SOFTWARE\Microsoft\VisualStudio\11.0" ?>
+<?define VsVersion = "2015"?>
+<?define VsRegPath = "SOFTWARE\Microsoft\VisualStudio\14.0" ?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
     <Fragment>
-        <PropertyRef Id="VS2012DEVENV" />
-        <PropertyRef Id="VS2012_ROOT_FOLDER" />
-        <PropertyRef Id="VS2012_SCHEMAS_DIR" />
+        <PropertyRef Id="VS14DEVENV" />
+        <PropertyRef Id="VS14_ROOT_FOLDER" />
+        <PropertyRef Id="VS14_SCHEMAS_DIR" />
 
-        <CustomActionRef Id="VS2012Setup" />
+        <CustomActionRef Id="VS14Setup" />
         <UI>
-            <ProgressText Action="VS2012Setup" Template="[1]">Updating Visual Studio 2012 registration</ProgressText>
+            <ProgressText Action="VS14Setup" Template="[1]">Updating Visual Studio 2015 registration</ProgressText>
         </UI>
 
-        <ComponentGroup Id="Votive2012Components">
+        <ComponentGroup Id="Votive2015Components">
             <ComponentGroupRef Id="Votive2010BinaryComponents"/>
-            <ComponentGroupRef Id="Votive2012ExtensionComponents"/>
-            <ComponentGroupRef Id="Votive2012ItemTemplateComponents" />
-            <ComponentGroupRef Id="Votive2012ProjectTemplateComponents" />
+            <ComponentGroupRef Id="Votive2015ExtensionComponents"/>
+            <ComponentGroupRef Id="Votive2015ItemTemplateComponents" />
+            <ComponentGroupRef Id="Votive2015ProjectTemplateComponents" />
         </ComponentGroup>
     </Fragment>
 
     <Fragment>
-        <PropertyRef Id="VS2012_EXTENSIONS_DIR" />
-
-        <ComponentGroup Id="Votive$(var.VsVersion)ExtensionComponents" Directory="VsExtensions$(var.VsVersion)WixVersionFolder">
+        <ComponentGroup Id="Votive$(var.VsVersion)ExtensionComponents" Directory="VsExtensions$(var.VsVersion)MicrosoftWix">
             <Component>
                 <File Id="extension$(var.VsVersion).vsixmanifest" Source="extension.vsixmanifest"/>
             </Component>
 
             <Component>
                 <File Id="Votive$(var.VsVersion).pkgdef" Source="votive2010.pkgdef"/>
-                <util:TouchFile OnInstall="yes" OnReinstall="yes" OnUninstall="yes" Path="[VS2012_EXTENSIONS_DIR]extensions.configurationchanged" />
             </Component>
 
             <Component>
@@ -67,9 +64,7 @@
                 <File Id="TextFile$(var.VsVersion).zip" Source="templates\TextFile.zip" />
             </Component>
         </ComponentGroup>
-    </Fragment>
 
-    <Fragment>
         <ComponentGroup Id="Votive$(var.VsVersion)ProjectTemplateComponents" Directory="VsProjectTemplatesWix$(var.VsVersion)Folder">
             <Component>
                 <File Id="WixLibrary$(var.VsVersion).zip" Source="templates\WixLibrary.zip" />
@@ -87,7 +82,7 @@
     </Fragment>
 
     <Fragment>
-        <ComponentGroup Id="Votive$(var.VsVersion)SchemaComponents" Directory="VS2012_SCHEMAS_DIR">
+        <ComponentGroup Id="Votive$(var.VsVersion)SchemaComponents" Directory="VS14_SCHEMAS_DIR">
             <Component>
                 <File Id="LuxSchema$(var.VsVersion)" Source="lux\wixext\Xsd\lux.xsd" />
             </Component>
@@ -107,9 +102,6 @@
                 <File Id="ExtensionXsdDependency$(var.VsVersion)" Source="ext\DependencyExtension\wixext\Xsd\Dependency.xsd" />
             </Component>
             <Component>
-                <File Id="ExtensionXsdComplus$(var.VsVersion)" Source="ext\ComPlusExtension\wixext\xsd\complus.xsd" />
-            </Component>
-            <Component>
                 <File Id="ExtensionXsdDifxApp$(var.VsVersion)" Source="ext\DifxAppExtension\wixext\Xsd\difxapp.xsd" />
             </Component>
             <Component>
@@ -120,9 +112,6 @@
             </Component>
             <Component>
                 <File Id="ExtensionXsdIis$(var.VsVersion)" Source="ext\IIsExtension\wixext\xsd\iis.xsd" />
-            </Component>
-            <Component>
-                <File Id="ExtensionXsdMsmq$(var.VsVersion)" Source="ext\MsmqExtension\wixext\xsd\msmq.xsd" />
             </Component>
             <Component>
                 <File Id="ExtensionXsdNetFx$(var.VsVersion)" Source="ext\NetFxExtension\wixext\Xsd\netfx.xsd" />

--- a/src/Setup/VotiveMsi/FileAssociations.wxs
+++ b/src/Setup/VotiveMsi/FileAssociations.wxs
@@ -84,24 +84,29 @@
         <PropertyRef Id="VS2010DEVENV" />
         <PropertyRef Id="VS2012DEVENV" />
         <PropertyRef Id="VS2013DEVENV" />
+        <PropertyRef Id="VS14DEVENV" />
 
         <CustomAction Id="CA_SetLatestDevenv_2010" Property="LATEST_DEVENV_EXE" Value="[VS2010DEVENV]"/>
         <CustomAction Id="CA_SetLatestDevenv_2012" Property="LATEST_DEVENV_EXE" Value="[VS2012DEVENV]" />
         <CustomAction Id="CA_SetLatestDevenv_2013" Property="LATEST_DEVENV_EXE" Value="[VS2013DEVENV]" />
+        <CustomAction Id="CA_SetLatestDevenv_2015" Property="LATEST_DEVENV_EXE" Value="[VS14DEVENV]" />
 
-        <CustomAction Id="CA_SetLatestDevenvCommand_2010" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2010"/>
-        <CustomAction Id="CA_SetLatestDevenvCommand_2012" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2012"/>
-        <CustomAction Id="CA_SetLatestDevenvCommand_2013" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2013"/>
+        <CustomAction Id="CA_SetLatestDevenvCommand_2010" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2010" />
+        <CustomAction Id="CA_SetLatestDevenvCommand_2012" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2012" />
+        <CustomAction Id="CA_SetLatestDevenvCommand_2013" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2013" />
+        <CustomAction Id="CA_SetLatestDevenvCommand_2015" Property="LATEST_DEVENV_EXE_COMMAND" Value="&amp;Open in Visual Studio 2015" />
 
         <!-- Install Sequences -->
         <InstallExecuteSequence>
             <Custom Action="CA_SetLatestDevenv_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
             <Custom Action="CA_SetLatestDevenv_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenv_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenv_2013" After="CostFinalize"><![CDATA[VS2013DEVENV AND NOT VS14DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenv_2015" After="CostFinalize"><![CDATA[VS14DEVENV]]></Custom>
 
             <Custom Action="CA_SetLatestDevenvCommand_2010" After="CostFinalize"><![CDATA[VS2010DEVENV AND NOT VS2012DEVENV]]></Custom>
             <Custom Action="CA_SetLatestDevenvCommand_2012" After="CostFinalize"><![CDATA[VS2012DEVENV AND NOT VS2013DEVENV]]></Custom>
-            <Custom Action="CA_SetLatestDevenvCommand_2013" After="CostFinalize"><![CDATA[VS2013DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenvCommand_2013" After="CostFinalize"><![CDATA[VS2013DEVENV AND NOT VS14DEVENV]]></Custom>
+            <Custom Action="CA_SetLatestDevenvCommand_2015" After="CostFinalize"><![CDATA[VS14DEVENV]]></Custom>
         </InstallExecuteSequence>
     </Fragment>
 </Wix>

--- a/src/Setup/VotiveMsi/VotiveMsi.wixproj
+++ b/src/Setup/VotiveMsi/VotiveMsi.wixproj
@@ -26,6 +26,7 @@
     <Compile Include="2010.wxs" />
     <Compile Include="2012.wxs" />
     <Compile Include="2013.wxs" />
+    <Compile Include="2015.wxs" />
     <Compile Include="FileAssociations.wxs" />
   </ItemGroup>
 

--- a/src/Setup/VotiveMsi/VotiveMsi.wxs
+++ b/src/Setup/VotiveMsi/VotiveMsi.wxs
@@ -55,6 +55,17 @@
                 <ComponentGroupRef Id="Votive2013Components" />
                 <ComponentGroupRef Id="FileAssociationComponents" />
             </Feature>
+
+            <Feature Id="Intellisense2015" Title="IntelliSense 2015" Description="Schema files for IntelliSense in the Visual Studio 2015 editor" AllowAdvertise="no" Display="expand" InstallDefault="local" Level="0" TypicalDefault="install">
+                <Condition Level="1">VS14DEVENV OR VS14_ROOT_FOLDER OR REMOVE</Condition>
+                <ComponentGroupRef Id="Votive2015SchemaComponents" />
+            </Feature>
+
+            <Feature Id="Votive2015" Title="Project Templates 2015" Description="Votive Package for Visual Studio 2013" AllowAdvertise="no" Display="expand" InstallDefault="local" Level="0" TypicalDefault="install">
+                <Condition Level="1">VS14DEVENV OR REMOVE</Condition>
+                <ComponentGroupRef Id="Votive2015Components" />
+                <ComponentGroupRef Id="FileAssociationComponents" />
+            </Feature>
             <?endif?>
         </Feature>
     </Product>

--- a/src/Votive/votive2010/extension.vsixmanifest
+++ b/src/Votive/votive2010/extension.vsixmanifest
@@ -27,6 +27,12 @@
                 <Edition>Pro</Edition>
                 <Edition>Express_All</Edition>
             </VisualStudio>
+            <VisualStudio Version="14.0">
+                <Edition>Ultimate</Edition>
+                <Edition>Premium</Edition>
+                <Edition>Pro</Edition>
+                <Edition>Express_All</Edition>
+            </VisualStudio>
         </SupportedProducts>
         <SupportedFrameworkRuntimeEdition MinVersion="4.0" />
     </Identifier>

--- a/src/Votive/votive2010/vssdk/dataobject.cs
+++ b/src/Votive/votive2010/vssdk/dataobject.cs
@@ -432,7 +432,7 @@ namespace Microsoft.VisualStudio.Package
 			}
 			finally
 			{
-				if (data != null)
+				if (data != IntPtr.Zero)
 				{
 					UnsafeNativeMethods.GlobalUnLock(data);
 				}

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -231,7 +231,7 @@ extern "C" HRESULT CoreDetect(
     hr = DependencyDetectProviderKeyBundleId(&pEngineState->registration);
     if (SUCCEEDED(hr))
     {
-        HRESULT hr = DetectForwardCompatibleBundle(&pEngineState->userExperience, &pEngineState->command, &pEngineState->registration);
+        hr = DetectForwardCompatibleBundle(&pEngineState->userExperience, &pEngineState->command, &pEngineState->registration);
         ExitOnFailure(hr, "Failed to detect forward compatible bundle.");
 
         // If a forward compatible bundle was detected, skip rest of bundle detection

--- a/src/burn/engine/payload.cpp
+++ b/src/burn/engine/payload.cpp
@@ -269,7 +269,7 @@ extern "C" HRESULT PayloadExtractFromContainer(
     // locate any payloads that were not extracted
     for (DWORD i = 0; i < pPayloads->cPayloads; ++i)
     {
-        BURN_PAYLOAD* pPayload = &pPayloads->rgPayloads[i];
+        pPayload = &pPayloads->rgPayloads[i];
 
         // if the payload is part of the container
         if (!pContainer || pPayload->pContainer == pContainer)

--- a/src/ext/BalExtension/mba/core/EventArgs.cs
+++ b/src/ext/BalExtension/mba/core/EventArgs.cs
@@ -150,14 +150,10 @@ namespace WixToolset.Bootstrapper
     /// <para>To prevent shutting down or logging off, set <see cref="ResultEventArgs.Result"/> to
     /// <see cref="Result.Cancel"/>; otherwise, set it to <see cref="Result.Ok"/>.</para>
     /// <para>By default setup will prevent shutting down or logging off between
-    /// <see cref="BootstrapperApplication.ApplyBegin"/> and <see cref="BootstrapperApplication.ApplyComplete"/>.
-    /// Derivatives can change this behavior by overriding <see cref="BootstrapperApplication.OnSystemShutdown"/>
-    /// or handling <see cref="BootstrapperApplication.SystemShutdown"/>.</para>
+    /// <see cref="BootstrapperApplication.ApplyBegin"/> and <see cref="BootstrapperApplication.ApplyComplete"/>.</para>
     /// <para>If <see cref="SystemShutdownEventArgs.Reasons"/> contains <see cref="EndSessionReasons.Critical"/>
     /// the bootstrapper cannot prevent the shutdown and only has a few seconds to save state or perform any other
     /// critical operations before being closed by the operating system.</para>
-    /// <seealso cref="BootstrapperApplication.SystemShutdown"/>
-    /// <seealso cref="BootstrapperApplication.OnSystemShutdown"/>
     /// </remarks>
     [Serializable]
     public class SystemShutdownEventArgs : ResultEventArgs

--- a/src/ext/ca/inc/caSuffix.h
+++ b/src/ext/ca/inc/caSuffix.h
@@ -14,9 +14,9 @@
 //-------------------------------------------------------------------------------------------------
 
 #if defined _WIN64
-#define PLATFORM_DECORATION(f) f ## L"_64"
+#define PLATFORM_DECORATION(f) f L"_64"
 #elif defined ARM
-#define PLATFORM_DECORATION(f) f ## L"_ARM"
+#define PLATFORM_DECORATION(f) f L"_ARM"
 #else
 #define PLATFORM_DECORATION(f) f
 #endif

--- a/src/ext/ca/wixca/dll/shellexecca.cpp
+++ b/src/ext/ca/wixca/dll/shellexecca.cpp
@@ -40,7 +40,8 @@ HRESULT ShellExec(
         HINSTANCE hinst = ::ShellExecuteW(NULL, NULL, wzTarget, NULL, sczWorkingDirectory, SW_SHOWDEFAULT);
         if (hinst <= HINSTANCE(32))
         {
-            switch (int(hinst))
+            LONG64 code = reinterpret_cast<LONG64>(hinst);
+            switch (code)
             {
             case ERROR_FILE_NOT_FOUND:
                 hr = HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
@@ -73,7 +74,7 @@ HRESULT ShellExec(
                 hr = E_FAIL;
             }
 
-            ExitOnFailure(hr, "ShellExec failed with return code %d", int(hinst));
+            ExitOnFailure(hr, "ShellExec failed with return code %llu.", code);
         }
     }
 

--- a/src/libs/WixToolset.Data/Rows/WixBundleRow.cs
+++ b/src/libs/WixToolset.Data/Rows/WixBundleRow.cs
@@ -212,7 +212,7 @@ namespace WixToolset.Data.Rows
                 return new Guid((string)this.Fields[20].Data);
             }
 
-            set { this.Fields[20].Data = null == value ? null : value.ToString(); }
+            set { this.Fields[20].Data = value.ToString(); }
         }
 
         public string ProviderKey

--- a/src/libs/dutil/inc/dutil.h
+++ b/src/libs/dutil/inc/dutil.h
@@ -40,7 +40,7 @@ extern "C" {
 void DAPI Dutil_SetAssertModule(__in HMODULE hAssertModule);
 void DAPI Dutil_SetAssertDisplayFunction(__in DUTIL_ASSERTDISPLAYFUNCTION pfn);
 void DAPI Dutil_Assert(__in_z LPCSTR szFile, __in int iLine);
-void DAPI Dutil_AssertSz(__in_z LPCSTR szFile, __in int iLine, __in_z LPCSTR szMsg);
+void DAPI Dutil_AssertSz(__in_z LPCSTR szFile, __in int iLine, __in_z LPCSTR szMessage);
 
 void DAPI Dutil_TraceSetLevel(__in REPORT_LEVEL ll, __in BOOL fTraceFilenames);
 REPORT_LEVEL DAPI Dutil_TraceGetLevel();

--- a/src/libs/libs_multitarget.proj
+++ b/src/libs/libs_multitarget.proj
@@ -72,5 +72,35 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup Condition=" $(VS2015Available) and !$(StaticAnalysisEnabled) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v140_xp</Properties>
+    </ProjectReference>
+    <ProjectReference Include="wcautil\wcautil.vcxproj">
+      <Properties>PlatformToolset=v140_xp</Properties>
+    </ProjectReference>
+    <ProjectReference Include="balutil\balutil.vcxproj" Condition=" '$(Platform)'!='x64' ">
+      <Properties>PlatformToolset=v140_xp</Properties>
+    </ProjectReference>
+    <ProjectReference Include="deputil\deputil.vcxproj">
+      <Properties>PlatformToolset=v140_xp</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2015Available) and $(StaticAnalysisEnabled) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v140</Properties>
+    </ProjectReference>
+    <ProjectReference Include="wcautil\wcautil.vcxproj">
+      <Properties>PlatformToolset=v140</Properties>
+    </ProjectReference>
+    <ProjectReference Include="balutil\balutil.vcxproj" Condition=" '$(Platform)'!='x64' ">
+      <Properties>PlatformToolset=v140</Properties>
+    </ProjectReference>
+    <ProjectReference Include="deputil\deputil.vcxproj">
+      <Properties>PlatformToolset=v140</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\Traversal.targets" />
 </Project>

--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -39,6 +39,8 @@
     <Message Importance="high" Text="VS2012SdkAvailable = $(VS2012SdkAvailable)" />
     <Message Importance="high" Text="VS2013Available = $(VS2013Available)" />
     <Message Importance="high" Text="VS2013SdkAvailable = $(VS2013SdkAvailable)" />
+    <Message Importance="high" Text="VS2015Available = $(VS2015Available)" />
+    <Message Importance="high" Text="VS2015SdkAvailable = $(VS2015SdkAvailable)" />
     <Message Importance="high" Text="PlatformSdkInstallPath = $(PlatformSdkInstallPath)" />
     <Message Importance="high" Text="PlatformSdkInstallPath = $(PlatformSdkInstallPath)" />
     <Message Importance="high" Text="SqlCESdkIncludePath = $(SqlCESdkIncludePath)" />

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -81,6 +81,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <PlatformSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot81', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
+    <PlatformSdkRegistryVersion Condition=" '$(PlatformSdkInstallPath)'!='' ">v8.1</PlatformSdkRegistryVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(PlatformSdkInstallPath)'=='' ">
     <PlatformSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
     <PlatformSdkRegistryVersion Condition=" '$(PlatformSdkInstallPath)'!='' ">v8.0</PlatformSdkRegistryVersion>
   </PropertyGroup>
@@ -168,7 +173,26 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VCPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\12.0\Setup\VC', 'ProductDir', null, RegistryView.Registry64, RegistryView.Registry32))</VCPath>
+    <VS2015Path Condition=" '$(VS2015Path)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0', 'InstallDir', null, RegistryView.Registry64, RegistryView.Registry32))</VS2015Path>
+    <VS2015SdkPath Condition=" '$(VS2015SdkPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0', 'InstallDir', null, RegistryView.Registry64, RegistryView.Registry32))</VS2015SdkPath>
+    <VS2015SdkTargetsPath Condition=" '$(VS2015SdkTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0\VSSDK\Microsoft.VsSDK.targets</VS2015SdkTargetsPath>
+    <VS2015SdkTargetsPath Condition=" '$(VS2015SdkTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v14.0\VSSDK\Microsoft.VsSDK.targets</VS2015SdkTargetsPath>
+
+    <VS2015Available Condition=" '$(VS2015Path)'!='' and Exists('$(VS2015Path)')">true</VS2015Available>
+    <VS2015Available Condition=" '$(VS2015Available)'=='' ">false</VS2015Available>
+    <VS2015SdkAvailable Condition=" $(VS2015Available) and '$(VS2015SdkPath)'!='' and Exists('$(VS2015SdkTargetsPath)')">true</VS2015SdkAvailable>
+    <VS2015SdkAvailable Condition=" '$(VS2015SdkAvailable)'=='' ">false</VS2015SdkAvailable>
+
+    <VS2015Path Condition=" $(VS2015Available) and !HasTrailingSlash('$(VS2015Path)')">$(VS2015Path)\</VS2015Path>
+    <VS2015SdkPath Condition=" $(VS2015SdkAvailable) and !HasTrailingSlash('$(VS2015SdkPath)')">$(VS2015SdkPath)\</VS2015SdkPath>
+
+    <VS2015PublicAssembliesPath>$(VS2015Path)PublicAssemblies\</VS2015PublicAssembliesPath>
+    <VS2015SdkVisualStudioIntegrationAssembliesPath>$(VS2015SdkPath)VisualStudioIntegration\Common\Assemblies\v4.0\</VS2015SdkVisualStudioIntegrationAssembliesPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VCPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC', 'ProductDir', null, RegistryView.Registry64, RegistryView.Registry32))</VCPath>
+    <VCPath Condition=" '$(VCPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\12.0\Setup\VC', 'ProductDir', null, RegistryView.Registry64, RegistryView.Registry32))</VCPath>
     <VCPath Condition=" '$(VCPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\11.0\Setup\VC', 'ProductDir', null, RegistryView.Registry64, RegistryView.Registry32))</VCPath>
     <VCPath Condition=" '$(VCPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\10.0\Setup\VC', 'ProductDir', null, RegistryView.Registry64, RegistryView.Registry32))</VCPath>
     <VCPath Condition="!HasTrailingSlash('$(VCPath)')">$(VCPath)\</VCPath>

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -9,8 +9,9 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
-  <PropertyGroup Condition=" $(StaticAnalysisEnabled) and $(VS2013Available) ">
+  <PropertyGroup Condition=" $(StaticAnalysisEnabled) and ($(VS2013Available) or $(VS2015Available)) ">
     <PlatformToolset Condition="$(VS2013Available)">v120</PlatformToolset>
+    <PlatformToolset Condition="$(VS2015Available)">v140</PlatformToolset>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <!-- turn off deprecation warning -->
@@ -18,10 +19,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- If available and we're not explicitly setting the toolset, use VS2013; otherwise fall back to VS2012 then VS2010. -->
+    <!-- If available and we're not explicitly setting the toolset, use VS2015; otherwise fall back to VS2013 then VS2012 then VS2010. -->
+    <PlatformToolset Condition=" '$(PlatformToolset)'=='' and $(VS2015Available) ">v140_xp</PlatformToolset>
     <PlatformToolset Condition=" '$(PlatformToolset)'=='' and $(VS2013Available) ">v120_xp</PlatformToolset>
     <PlatformToolset Condition=" '$(PlatformToolset)'=='' and $(VS2012Available) ">v110_xp</PlatformToolset>
     <ProjectSubSystem Condition=" '$(ProjectSubSystem)'=='' ">Windows</ProjectSubSystem>
+    <!-- VS2015: turn off 'typedef ignored when no variable declared' -->
+    <!-- VS2015: turn off 'declaration hides class member' -->
+    <DisableSpecificCompilerWarnings Condition=" '$(PlatformToolset)'=='v140_xp' or '$(PlatformToolset)'=='v140' ">$(DisableSpecificCompilerWarnings);4091;4458</DisableSpecificCompilerWarnings>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -32,6 +37,7 @@
     <MultiTargetDirSuffix Condition=" '$(PlatformToolset)'=='v110_xp' ">2012</MultiTargetDirSuffix>
     <MultiTargetDirSuffix Condition=" '$(PlatformToolset)'=='v120' ">2013</MultiTargetDirSuffix>
     <MultiTargetDirSuffix Condition=" '$(PlatformToolset)'=='v120_xp' ">2013</MultiTargetDirSuffix>
+    <MultiTargetDirSuffix Condition=" '$(PlatformToolset)'=='v140_xp' ">2015</MultiTargetDirSuffix>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -66,7 +72,7 @@
       <DisableSpecificWarnings>$(DisableSpecificCompilerWarnings)</DisableSpecificWarnings>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(WixVersionPath);$(ProjectDir)inc;$(MSBuildProjectDirectory);$(IntDir);$(SqlCESdkIncludePath);$(ProjectAdditionalIncludeDirectories);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_WIN32_MSI=500;_WIN32_WINNT=0x0501;$(ArmPreprocessorDefinitions);$(UnicodePreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_WIN32_MSI=500;_WIN32_WINNT=0x0501;$(ArmPreprocessorDefinitions);$(UnicodePreprocessorDefinitions);_CRT_STDIO_LEGACY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
       <CallingConvention>StdCall</CallingConvention>
@@ -89,6 +95,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>$(ProjectAdditionalLinkLibraries);advapi32.lib;comdlg32.lib;user32.lib;oleaut32.lib;gdi32.lib;shell32.lib;ole32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutputPath);$(AdditionalMultiTargetLibraryPath);$(ProjectAdditionalLinkLibraryDirectories);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions Condition=" '$(PlatformToolset)'=='v140_xp' or '$(PlatformToolset)'=='v140' ">/IGNORE:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
 

--- a/tools/WixBuild.wixproj.props
+++ b/tools/WixBuild.wixproj.props
@@ -32,6 +32,9 @@
     <DefineConstants Condition="$(VS2012SdkAvailable)">$(DefineConstants);VS2012SdkAvailable=true</DefineConstants>
     <DefineConstants Condition="$(VS2013Available)">$(DefineConstants);VS2013Available=true</DefineConstants>
     <DefineConstants Condition="$(VS2013SdkAvailable)">$(DefineConstants);VS2013SdkAvailable=true</DefineConstants>
+    <DefineConstants Condition="$(VS2015Available)">$(DefineConstants);VS2015Available=true</DefineConstants>
+    <DefineConstants Condition="$(VS2015SdkAvailable)">$(DefineConstants);VS2015SdkAvailable=true</DefineConstants>
+    <DefineConstants Condition="$(BuildSandcastleDocumentation)">$(DefineConstants);BuildSandcastleDocumentation=$(BuildSandcastleDocumentation)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
```
    Add VS2015 libraries to binaries and setup
    Add VS2015 support in build
    - Fix (or at least work around) warnings/errors introduced when using
    the v140 toolset.
    - Add VS2015 versions of native SDK libraries.
Add/register Votive for VS2015 (plus VS2013, VS2012, and VS2010).
Also fix setup to add missing schema files.
```
