### PR TITLE
Upgrade Sandcastle

### DIFF
--- a/src/DTF/Documents/Reference/dtfref.shfbproj
+++ b/src/DTF/Documents/Reference/dtfref.shfbproj
@@ -14,17 +14,17 @@
     <Name>Documentation</Name>
 
     <!-- SHFB properties -->
-    <SHFBSchemaVersion>1.8.0.3</SHFBSchemaVersion>
+    <SHFBSchemaVersion>1.9.9.0</SHFBSchemaVersion>
     <HtmlHelpName>DTFAPI</HtmlHelpName>
-    <ProjectSummary></ProjectSummary>
     <MissingTags>Namespace, TypeParameter</MissingTags>
     <VisibleItems>InheritedMembers, InheritedFrameworkMembers, Protected, ProtectedInternalAsProtected, SealedProtected</VisibleItems>
 
+    <RootNamespaceContainer>True</RootNamespaceContainer>
     <RootNamespaceTitle>Deployment Tools Foundation Namespaces</RootNamespaceTitle>
     <HelpTitle>Deployment Tools Foundation</HelpTitle>
     <FeedbackEMailAddress>wix-users%40lists.sourceforge.net</FeedbackEMailAddress>
     <FooterText>&amp;lt%3bscript src=&amp;quot%3bhelplink.js&amp;quot%3b&amp;gt%3b&amp;lt%3b/script&amp;gt%3b</FooterText>
-    <PresentationStyle>Prototype</PresentationStyle>
+    <PresentationStyle>VS2013</PresentationStyle>
     <NamingMethod>MemberName</NamingMethod>
   </PropertyGroup>
 

--- a/src/chm/documents/wixdev/building_wix.html.md
+++ b/src/chm/documents/wixdev/building_wix.html.md
@@ -23,13 +23,13 @@ Then, simply run `msbuild` from the root directory of your clone of the WiX Git 
 In order to fully build WiX, you must have the following Frameworks and SDKs installed:
 
   <ul>
-    <li>The following components from the <a href="http://www.microsoft.com/en-us/download/details.aspx?id=3138" target="_blank">Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1</a>, and/or Visual Studio 2010 and/or Visual Studio 2012:</li>
+    <li>The following components from the <a href="http://www.microsoft.com/en-us/download/details.aspx?id=3138" target="_blank">Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1</a>, and/or Visual Studio 2010/2012/2013/2015:</li>
 
     <li style="list-style: none; display: inline">
       <ul>
         <li>x86 and x64 compilers, headers and libraries</li>
 
-        <li><a href="http://msdn.microsoft.com/library/ms670169.aspx" target="_blank">HTML Help SDK 1.4</a> or higher [installed to Program Files or Program Files (x86)] (Note that this component is installed by default by Visual Studio 2013.)</li>
+        <li><a href="http://msdn.microsoft.com/library/ms670169.aspx" target="_blank">HTML Help SDK 1.4</a> or higher [installed to Program Files or Program Files (x86)] (Note that this component is installed by default by Visual Studio 2013/2015.)</li>
       </ul>
     </li>
   </ul>
@@ -38,17 +38,7 @@ To build Votive, you must have Visual Studio 2010 and the [Visual Studio 2010 SP
 
 More information about the Visual Studio SDK can be found at the <a href="http://msdn.microsoft.com/en-us/vstudio/vextend.aspx" target="_blank">Visual Studio Extensibility Center</a>.
 
-To install Votive on Visual Studio 2010, 2012, or 2013, you must have the Professional Edition or higher. The Express editions of Visual Studio do not support packages like Votive.
-
-To build DTF help files, you need the following tools:
-
-* [Sandcastle May 2008 Release](http://sandcastle.codeplex.com/releases/view/13873)
-* [Sandcastle Help File Builder 1.8.0.3](http://shfb.codeplex.com/releases/view/29710)
-
-The DTF help build process looks for these tools in an &quot;external&quot; directory parallel to the WiX &quot;src&quot; directory:
-
-* Sandcastle: external\Sandcastle
-* Sandcastle Help File Builder: external\SandcastleBuilder
+To install Votive on Visual Studio 2010, 2012, or 2013, you must have the Professional Edition or higher. The Express editions of Visual Studio do not support packages like Votive until VS 2015.
 
 To create a build that can be installed on different machines, create a new strong name key pair and point OFFICIAL\_WIX\_BUILD to it:
 

--- a/tools/Nuget.targets
+++ b/tools/Nuget.targets
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <AzureStorageBuildTasksPath>$(NugetPackageFolder)FireGiant.BuildTasks.AzureStorage.1.0.0.0\tools\</AzureStorageBuildTasksPath>
     <ExtensionPackPath>$(NugetPackageFolder)MSBuild.Extension.Pack.1.2.0\lib\net40\</ExtensionPackPath>
+    <SHFBROOT>$(NugetPackageFolder)EWSoftware.SHFB.2014.11.22.0\Tools\</SHFBROOT>
     <XunitPath>$(NugetPackageFolder)xunit.1.9.2\lib\net20\</XunitPath>
   </PropertyGroup>
 
@@ -28,10 +29,13 @@
   ================================================================================================
   -->
   <ItemGroup>
+    <RestoreNugetPackage Include="EWSoftware.SHFB">
+      <Version>2014.11.22.0</Version>
+    </RestoreNugetPackage>
     <RestoreNugetPackage Include="FireGiant.BuildTasks.AzureStorage">
       <Version>1.0.0.0</Version>
     </RestoreNugetPackage>
-    <RestoreNugetPackage Include="MSBuild.Extension.Pack ">
+    <RestoreNugetPackage Include="MSBuild.Extension.Pack">
       <Version>1.2.0</Version>
     </RestoreNugetPackage>
     <RestoreNugetPackage Include="xunit">

--- a/tools/OneTimeWixBuildInitialization.proj
+++ b/tools/OneTimeWixBuildInitialization.proj
@@ -7,7 +7,7 @@
     LICENSE.TXT at the root directory of the distribution.
   </copyright>
 -->
-<Project DefaultTargets="RegisterStrongNameSkip" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="RegisterStrongNameSkip" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="WixBuild.props" />
 
   <!--

--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -84,16 +84,6 @@
       Text="$(HelpCompiler) does not exist. Please install the HTML Help Workshop that is part of the HTML Help SDK." />
 
     <Error
-      Code="WIXBUILD005"
-      Condition=" '$(OFFICIAL_WIX_BUILD)'!='' and !Exists('$(SandcastlePath)')"
-      Text="Sandcastle is required on an official build. Install the Sandcastle Help File Builder that is available on CodePlex to get Sandcastle and Sandcastle Help File Builder." />
-
-    <Error
-      Code="WIXBUILD006"
-      Condition=" '$(OFFICIAL_WIX_BUILD)'!='' and !Exists('$(SandcastleHelpFileBuilderTargets)')"
-      Text="$(SandcastleHelpFileBuilderTargets) is required on an official build. Install the Sandcastle Help File Builder that is available on CodePlex." />
-
-    <Error
       Code="WIXBUILD007"
       Condition=" !Exists('$(XunitPath)xunit.dll') "
       Text="Cannot locate xUnit assemblies. Ensure xUnit is present at: $(XunitPath) and that the 'xunit.dll' exists. If not, run the following command from the root of the project: msbuild -t:PackageRestore" />

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -34,7 +34,7 @@
     <WIX_EXTERNALROOT Condition="!HasTrailingSlash('$(WIX_EXTERNALROOT)')">$(WIX_EXTERNALROOT)\</WIX_EXTERNALROOT>
   </PropertyGroup>
 
-  <Import Project="Nuget.targets"/>
+  <Import Project="Nuget.targets" />
 
   <!-- Converts the VS-standard Debug and Release to the wix-standard debug and ship -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == '' ">
@@ -70,13 +70,7 @@
     <HelpCompilerPath>$(ProgramFiles)\HTML Help Workshop</HelpCompilerPath>
     <HelpCompiler>$(HelpCompilerPath)\hhc.exe</HelpCompiler>
 
-    <SandcastlePath>$(ProgramFiles)\Sandcastle\</SandcastlePath>
-
-    <SandcastleHelpFileBuilderTargets>$(SHFBROOT)\SandcastleHelpFileBuilder.targets</SandcastleHelpFileBuilderTargets>
-    <SHFBROOT Condition="!Exists('$(SandcastleHelpFileBuilderTargets)')">$(ProgramFiles)\EWSoftware\Sandcastle Help File Builder</SHFBROOT>
-    <SandcastleHelpFileBuilderTargets>$(SHFBROOT)\SandcastleHelpFileBuilder.targets</SandcastleHelpFileBuilderTargets>
-
-    <BuildSandcastleDocumentation Condition=" Exists('$(SandcastleHelpFileBuilderTargets)') and '$(Configuration)'=='Release' ">true</BuildSandcastleDocumentation>
+    <BuildSandcastleDocumentation Condition=" '$(BuildSandcastleDocumentation)'=='' and '$(Configuration)'=='Release' ">true</BuildSandcastleDocumentation>
     <BuildSandcastleDocumentation Condition=" '$(BuildSandcastleDocumentation)'=='' ">false</BuildSandcastleDocumentation>
   </PropertyGroup>
 
@@ -262,6 +256,7 @@
     <AssemblyOriginatorKeyFile>$(OFFICIAL_WIX_BUILD)</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <SignAssembly>true</SignAssembly>
+    <BuildSandcastleDocumentation>true</BuildSandcastleDocumentation>
   </PropertyGroup>
 
   <!-- StyleCop settings -->

--- a/tools/WixBuild.shfbproj.targets
+++ b/tools/WixBuild.shfbproj.targets
@@ -12,5 +12,5 @@
     <HtmlHelp1xCompilerPath>$(HelpCompilerPath)</HtmlHelp1xCompilerPath>
   </PropertyGroup>
 
-  <Import Project="$(SandcastleHelpFileBuilderTargets)" />
+  <Import Project="$(SHFBROOT)SandcastleHelpFileBuilder.targets" />
 </Project>

--- a/tools/WixBuild.wixproj.props
+++ b/tools/WixBuild.wixproj.props
@@ -34,7 +34,6 @@
     <DefineConstants Condition="$(VS2013SdkAvailable)">$(DefineConstants);VS2013SdkAvailable=true</DefineConstants>
     <DefineConstants Condition="$(VS2015Available)">$(DefineConstants);VS2015Available=true</DefineConstants>
     <DefineConstants Condition="$(VS2015SdkAvailable)">$(DefineConstants);VS2015SdkAvailable=true</DefineConstants>
-    <DefineConstants Condition="$(BuildSandcastleDocumentation)">$(DefineConstants);BuildSandcastleDocumentation=$(BuildSandcastleDocumentation)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Sandcastle now has a Nuget package, so use that.  Update the dtfref project to work with the latest Sandcastle, and switch to the VS2013 presentation style.  Fix bug where the Sandcastle preprocessor variable was defined twice in WixBuild.wixproj.props.  Update Building Wix documentation.
