### PR TITLE
When linking, ignore missing table definitions in unlinked sections

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXFEAT: 4703 - Don't always require WixBalExtension when using WixNetFxExtension.
+
 * thfabba: WIXBUG:4681 - Corrected return type on the lone WOW64 redirection function that returns a BOOLEAN instead of BOOL.
 
 * MikeGC: Fix an issue in ValueMatch() where we can in certain scenarios create unnecessary extra history entries. This is related to upcoming settings expiration feature.

--- a/src/chm/documents/customactions/wixnetfxextension.html.md
+++ b/src/chm/documents/customactions/wixnetfxextension.html.md
@@ -9,7 +9,7 @@ The [WixNetfxExtension](~/xsd/netfx/index.html) includes a set of custom actions
 
 ## PackageGroups
 
-The WixNetfxExtension includes package groups that make it easier to include .NET in your bundles.
+The WixNetfxExtension includes package groups that make it easier to include .NET in your bundles.  When using these package groups, the WixBalExtension must also be given on the command line to light, or referenced in the .wixproj file.
 
 <table cellspacing="0" cellpadding="4" class="style1" border="1">
   <tr>

--- a/src/ext/BalExtension/wixext/BalExtensionData.cs
+++ b/src/ext/BalExtension/wixext/BalExtensionData.cs
@@ -35,10 +35,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return BalExtensionData.GetExtensionLibrary(tableDefinitions);
+            return BalExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -53,10 +54,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.bal.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.bal.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/ComPlusExtension/wixext/ComPlusExtensionData.cs
+++ b/src/ext/ComPlusExtension/wixext/ComPlusExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return ComPlusExtensionData.GetExtensionLibrary(tableDefinitions);
+            return ComPlusExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.complus.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.complus.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/DependencyExtension/wixext/DependencyExtensionData.cs
+++ b/src/ext/DependencyExtension/wixext/DependencyExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return DependencyExtensionData.GetExtensionLibrary(tableDefinitions);
+            return DependencyExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.Dependency.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.Dependency.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/DirectXExtension/wixext/DirectXExtensionData.cs
+++ b/src/ext/DirectXExtension/wixext/DirectXExtensionData.cs
@@ -23,19 +23,22 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return DirectXExtensionData.GetExtensionLibrary(tableDefinitions);
+            return DirectXExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.DirectX.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.DirectX.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/FirewallExtension/wixext/FirewallExtensionData.cs
+++ b/src/ext/FirewallExtension/wixext/FirewallExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return FirewallExtensionData.GetExtensionLibrary(tableDefinitions);
+            return FirewallExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.firewall.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.firewall.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/GamingExtension/wixext/GamingExtensionData.cs
+++ b/src/ext/GamingExtension/wixext/GamingExtensionData.cs
@@ -32,10 +32,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return GamingExtensionData.GetExtensionLibrary(tableDefinitions);
+            return GamingExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -50,10 +51,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.gaming.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.gaming.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/HttpExtension/wixext/HttpExtensionData.cs
+++ b/src/ext/HttpExtension/wixext/HttpExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return HttpExtensionData.GetExtensionLibrary(tableDefinitions);
+            return HttpExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.http.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.http.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/IIsExtension/wixext/IIsExtensionData.cs
+++ b/src/ext/IIsExtension/wixext/IIsExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return IIsExtensionData.GetExtensionLibrary(tableDefinitions);
+            return IIsExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.iis.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.iis.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/MsmqExtension/wixext/MsmqExtensionData.cs
+++ b/src/ext/MsmqExtension/wixext/MsmqExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return MsmqExtensionData.GetExtensionLibrary(tableDefinitions);
+            return MsmqExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.msmq.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.msmq.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/NetFxExtension/wixext/NetFxExtensionData.cs
+++ b/src/ext/NetFxExtension/wixext/NetFxExtensionData.cs
@@ -35,10 +35,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return NetFxExtensionData.GetExtensionLibrary(tableDefinitions);
+            return NetFxExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -53,10 +54,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.netfx.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.netfx.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/PSExtension/wixext/PSExtensionData.cs
+++ b/src/ext/PSExtension/wixext/PSExtensionData.cs
@@ -23,19 +23,22 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return PSExtensionData.GetExtensionLibrary(tableDefinitions);
+            return PSExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.ps.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.ps.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/SettingsEngineExtension/wixext/CfgExtensionData.cs
+++ b/src/ext/SettingsEngineExtension/wixext/CfgExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return CfgExtensionData.GetExtensionLibrary(tableDefinitions);
+            return CfgExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.cfg.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.cfg.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/SqlExtension/wixext/SqlExtensionData.cs
+++ b/src/ext/SqlExtension/wixext/SqlExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return SqlExtensionData.GetExtensionLibrary(tableDefinitions);
+            return SqlExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.sql.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.sql.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/TagExtension/wixext/TagExtensionData.cs
+++ b/src/ext/TagExtension/wixext/TagExtensionData.cs
@@ -35,10 +35,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return TagExtensionData.GetExtensionLibrary(tableDefinitions);
+            return TagExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -53,10 +54,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.tag.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.tag.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/UIExtension/wixext/UIExtensionData.cs
+++ b/src/ext/UIExtension/wixext/UIExtensionData.cs
@@ -32,19 +32,22 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return UIExtensionData.GetExtensionLibrary(tableDefinitions);
+            return UIExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.ui.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.ui.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/UtilExtension/wixext/UtilExtensionData.cs
+++ b/src/ext/UtilExtension/wixext/UtilExtensionData.cs
@@ -44,10 +44,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return UtilExtensionData.GetExtensionLibrary(tableDefinitions);
+            return UtilExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -62,10 +63,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.util.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.util.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/VSExtension/wixext/VSExtensionData.cs
+++ b/src/ext/VSExtension/wixext/VSExtensionData.cs
@@ -35,10 +35,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return VSExtensionData.GetExtensionLibrary(tableDefinitions);
+            return VSExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -53,10 +54,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.vs.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.vs.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/ext/lux/wixext/LuxExtensionData.cs
+++ b/src/ext/lux/wixext/LuxExtensionData.cs
@@ -35,10 +35,11 @@ namespace WixToolset.Extensions
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        public override Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public override Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
-            return LuxExtensionData.GetExtensionLibrary(tableDefinitions);
+            return LuxExtensionData.GetExtensionLibrary(tableDefinitions, allowIncompleteSections);
         }
 
         /// <summary>
@@ -53,10 +54,12 @@ namespace WixToolset.Extensions
         /// <summary>
         /// Internal mechanism to access the extension's library.
         /// </summary>
+        /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Extension's library.</returns>
-        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions)
+        internal static Library GetExtensionLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections = false)
         {
-            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.LuxLib.wixlib", tableDefinitions);
+            return ExtensionData.LoadLibraryHelper(Assembly.GetExecutingAssembly(), "WixToolset.Extensions.Data.LuxLib.wixlib", tableDefinitions, allowIncompleteSections);
         }
     }
 }

--- a/src/libs/WixToolset.Data/Intermediate.cs
+++ b/src/libs/WixToolset.Data/Intermediate.cs
@@ -60,8 +60,9 @@ namespace WixToolset.Data
         /// <param name="path">Path to intermediate file saved on disk.</param>
         /// <param name="tableDefinitions">Collection containing TableDefinitions to use when reconstituting the intermediate.</param>
         /// <param name="suppressVersionCheck">Suppress checking for wix.dll version mismatches.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Returns the loaded intermediate.</returns>
-        public static Intermediate Load(string path, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck)
+        public static Intermediate Load(string path, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck, bool allowIncompleteSections = false)
         {
             using (FileStream stream = File.OpenRead(path))
             using (FileStructure fs = FileStructure.Read(stream))
@@ -77,7 +78,7 @@ namespace WixToolset.Data
                     try
                     {
                         reader.MoveToContent();
-                        return Intermediate.Read(reader, tableDefinitions, suppressVersionCheck);
+                        return Intermediate.Read(reader, tableDefinitions, suppressVersionCheck, allowIncompleteSections);
                     }
                     catch (XmlException xe)
                     {
@@ -111,8 +112,9 @@ namespace WixToolset.Data
         /// <param name="reader">XmlReader where the intermediate is persisted.</param>
         /// <param name="tableDefinitions">TableDefinitions to use in the intermediate.</param>
         /// <param name="suppressVersionCheck">Suppress checking for wix.dll version mismatch.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The parsed Intermediate.</returns>
-        private static Intermediate Read(XmlReader reader, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck)
+        private static Intermediate Read(XmlReader reader, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck, bool allowIncompleteSections)
         {
             if ("wixObject" != reader.LocalName)
             {
@@ -156,7 +158,7 @@ namespace WixToolset.Data
                             switch (reader.LocalName)
                             {
                                 case "section":
-                                    intermediate.AddSection(Section.Read(reader, tableDefinitions));
+                                    intermediate.AddSection(Section.Read(reader, tableDefinitions, allowIncompleteSections));
                                     break;
                                 default:
                                     throw new XmlException();

--- a/src/libs/WixToolset.Data/Library.cs
+++ b/src/libs/WixToolset.Data/Library.cs
@@ -98,12 +98,13 @@ namespace WixToolset.Data
         /// <param name="path">Path to library file saved on disk.</param>
         /// <param name="tableDefinitions">Collection containing TableDefinitions to use when reconstituting the intermediates.</param>
         /// <param name="suppressVersionCheck">Suppresses wix.dll version mismatch check.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Returns the loaded library.</returns>
-        public static Library Load(string path, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck)
+        public static Library Load(string path, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck, bool allowIncompleteSections = false)
         {
             using (FileStream stream = File.OpenRead(path))
             {
-                return Load(stream, new Uri(Path.GetFullPath(path)), tableDefinitions, suppressVersionCheck);
+                return Load(stream, new Uri(Path.GetFullPath(path)), tableDefinitions, suppressVersionCheck, allowIncompleteSections);
             }
         }
 
@@ -114,8 +115,9 @@ namespace WixToolset.Data
         /// <param name="uri">Uri for finding this stream.</param>
         /// <param name="tableDefinitions">Collection containing TableDefinitions to use when reconstituting the intermediates.</param>
         /// <param name="suppressVersionCheck">Suppresses wix.dll version mismatch check.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>Returns the loaded library.</returns>
-        public static Library Load(Stream stream, Uri uri, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck)
+        public static Library Load(Stream stream, Uri uri, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck, bool allowIncompleteSections = false)
         {
             using (FileStructure fs = FileStructure.Read(stream))
             {
@@ -129,7 +131,7 @@ namespace WixToolset.Data
                     try
                     {
                         reader.MoveToContent();
-                        return Library.Read(reader, tableDefinitions, suppressVersionCheck);
+                        return Library.Read(reader, tableDefinitions, suppressVersionCheck, allowIncompleteSections);
                     }
                     catch (XmlException xe)
                     {
@@ -207,8 +209,9 @@ namespace WixToolset.Data
         /// <param name="reader">XmlReader with library persisted as Xml.</param>
         /// <param name="tableDefinitions">Collection containing TableDefinitions to use when reconstituting the intermediates.</param>
         /// <param name="suppressVersionCheck">Suppresses check for wix.dll version mismatch.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The parsed Library.</returns>
-        private static Library Read(XmlReader reader, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck)
+        private static Library Read(XmlReader reader, TableDefinitionCollection tableDefinitions, bool suppressVersionCheck, bool allowIncompleteSections)
         {
             if (!reader.LocalName.Equals("wixLibrary"))
             {
@@ -253,7 +256,7 @@ namespace WixToolset.Data
                                     library.localizations.Add(localization.Culture, localization);
                                     break;
                                 case "section":
-                                    Section section = Section.Read(reader, tableDefinitions);
+                                    Section section = Section.Read(reader, tableDefinitions, allowIncompleteSections);
                                     section.LibraryId = library.id;
                                     library.sections.Add(section);
                                     break;

--- a/src/libs/WixToolset.Data/Section.cs
+++ b/src/libs/WixToolset.Data/Section.cs
@@ -196,6 +196,30 @@ namespace WixToolset.Data
                                         if (allowIncompleteSection)
                                         {
                                             section.MissingTableNames.Add(missingTableDefExc.TableName);
+
+                                            // Read the rest of the table.
+                                            if (!reader.IsEmptyElement)
+                                            {
+                                                int depth = 1;
+
+                                                while (0 < depth && reader.Read())
+                                                {
+                                                    switch (reader.NodeType)
+                                                    {
+                                                        case XmlNodeType.Element:
+                                                            depth++;
+                                                            break;
+                                                        case XmlNodeType.EndElement:
+                                                            --depth;
+                                                            break;
+                                                    }
+                                                }
+
+                                                if (0 != depth)
+                                                {
+                                                    throw new XmlException();
+                                                }
+                                            }
                                         }
                                         else
                                         {

--- a/src/libs/WixToolset.Data/TableDefinitionCollection.cs
+++ b/src/libs/WixToolset.Data/TableDefinitionCollection.cs
@@ -68,7 +68,7 @@ namespace WixToolset.Data
                 TableDefinition table;
                 if (!this.collection.TryGetValue(tableName, out table))
                 {
-                    throw new WixMissingTableDefinitionException(WixDataErrors.MissingTableDefinition(tableName));
+                    throw new WixMissingTableDefinitionException(tableName);
                 }
 
                 return table;

--- a/src/libs/WixToolset.Data/WixMissingTableDefinitionException.cs
+++ b/src/libs/WixToolset.Data/WixMissingTableDefinitionException.cs
@@ -24,10 +24,13 @@ namespace WixToolset.Data
         /// <summary>
         /// Instantiate new WixMissingTableDefinitionException.
         /// </summary>
-        /// <param name="error">Localized error information.</param>
-        public WixMissingTableDefinitionException(MessageEventArgs error)
-            : base(error)
+        /// <param name="tableName">Name of the missing table.</param>
+        public WixMissingTableDefinitionException(string tableName)
+            : base(WixDataErrors.MissingTableDefinition(tableName))
         {
+            TableName = tableName;
         }
+
+        public string TableName { get; private set; }
     }
 }

--- a/src/libs/WixToolset.Extensibility/ExtensionData.cs
+++ b/src/libs/WixToolset.Extensibility/ExtensionData.cs
@@ -20,7 +20,7 @@ namespace WixToolset.Extensibility
         /// <summary>
         /// Gets the optional table definitions for this extension.
         /// </summary>
-        /// <value>Table definisions for this extension or null if there are no table definitions.</value>
+        /// <value>Table definitions for this extension or null if there are no table definitions.</value>
         public virtual TableDefinitionCollection TableDefinitions
         {
             get { return null; }
@@ -39,8 +39,9 @@ namespace WixToolset.Extensibility
         /// Gets the optional library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The library for this extension or null if there is no library.</returns>
-        public virtual Library GetLibrary(TableDefinitionCollection tableDefinitions)
+        public virtual Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
             return null;
         }
@@ -51,8 +52,9 @@ namespace WixToolset.Extensibility
         /// <param name="assembly">The assembly containing the embedded resource.</param>
         /// <param name="resourceName">The name of the embedded resource being requested.</param>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The loaded library.</returns>
-        protected static Library LoadLibraryHelper(Assembly assembly, string resourceName, TableDefinitionCollection tableDefinitions)
+        protected static Library LoadLibraryHelper(Assembly assembly, string resourceName, TableDefinitionCollection tableDefinitions, bool allowIncompleteSections)
         {
             using (Stream resourceStream = assembly.GetManifestResourceStream(resourceName))
             {
@@ -60,7 +62,7 @@ namespace WixToolset.Extensibility
                 uriBuilder.Scheme = "embeddedresource";
                 uriBuilder.Fragment = resourceName;
 
-                return Library.Load(resourceStream, uriBuilder.Uri, tableDefinitions, false);
+                return Library.Load(resourceStream, uriBuilder.Uri, tableDefinitions, false, allowIncompleteSections);
             }
         }
 

--- a/src/libs/WixToolset.Extensibility/IExtensionData.cs
+++ b/src/libs/WixToolset.Extensibility/IExtensionData.cs
@@ -32,7 +32,8 @@ namespace WixToolset.Extensibility
         /// Gets the library associated with this extension.
         /// </summary>
         /// <param name="tableDefinitions">The table definitions to use while loading the library.</param>
+        /// <param name="allowIncompleteSections">Whether a WixMissingTableDefinitionException should be thrown if a section has a table without a table definition.</param>
         /// <returns>The library for this extension or null if there is no library.</returns>
-        Library GetLibrary(TableDefinitionCollection tableDefinitions);
+        Library GetLibrary(TableDefinitionCollection tableDefinitions, bool allowIncompleteSections);
     }
 }

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -233,12 +233,12 @@ namespace WixToolset.Tools
                         switch (format)
                         {
                             case FileFormat.Wixobj:
-                                Intermediate intermediate = Intermediate.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck);
+                                Intermediate intermediate = Intermediate.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, false);
                                 sections.AddRange(intermediate.Sections);
                                 break;
 
                             case FileFormat.Wixlib:
-                                Library library = Library.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck);
+                                Library library = Library.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, false);
                                 AddLibraryLocalizationsToLocalizer(library, this.commandLine.Cultures, localizer);
                                 sections.AddRange(library.Sections);
                                 break;
@@ -400,7 +400,7 @@ namespace WixToolset.Tools
                 // Load localizations provided by extensions with data.
                 foreach (IExtensionData data in this.extensionData)
                 {
-                    Library library = data.GetLibrary(tableDefinitions);
+                    Library library = data.GetLibrary(tableDefinitions, false);
                     if (null != library)
                     {
                         // Load the extension's default culture if it provides one and no cultures were specified.

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -233,12 +233,12 @@ namespace WixToolset.Tools
                         switch (format)
                         {
                             case FileFormat.Wixobj:
-                                Intermediate intermediate = Intermediate.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, false);
+                                Intermediate intermediate = Intermediate.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, true);
                                 sections.AddRange(intermediate.Sections);
                                 break;
 
                             case FileFormat.Wixlib:
-                                Library library = Library.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, false);
+                                Library library = Library.Load(inputFileFullPath, linker.TableDefinitions, this.commandLine.SuppressVersionCheck, true);
                                 AddLibraryLocalizationsToLocalizer(library, this.commandLine.Cultures, localizer);
                                 sections.AddRange(library.Sections);
                                 break;
@@ -400,7 +400,7 @@ namespace WixToolset.Tools
                 // Load localizations provided by extensions with data.
                 foreach (IExtensionData data in this.extensionData)
                 {
-                    Library library = data.GetLibrary(tableDefinitions, false);
+                    Library library = data.GetLibrary(tableDefinitions, true);
                     if (null != library)
                     {
                         // Load the extension's default culture if it provides one and no cultures were specified.

--- a/src/tools/wix/Linker.cs
+++ b/src/tools/wix/Linker.cs
@@ -175,7 +175,7 @@ namespace WixToolset
             // Add sections from the extensions with data.
             foreach (IExtensionData data in this.extensionData)
             {
-                Library library = data.GetLibrary(this.tableDefinitions, false);
+                Library library = data.GetLibrary(this.tableDefinitions, true);
 
                 if (null != library)
                 {
@@ -273,6 +273,11 @@ namespace WixToolset
             int sectionCount = 0;
             foreach (Section section in output.Sections)
             {
+                if (section.IsIncomplete)
+                {
+                    throw new WixMissingTableDefinitionException(string.Join(", ", section.MissingTableNames));
+                }
+
                 sectionCount++;
                 string sectionId = section.Id;
                 if (null == sectionId && this.sectionIdOnRows)

--- a/src/tools/wix/Linker.cs
+++ b/src/tools/wix/Linker.cs
@@ -175,7 +175,7 @@ namespace WixToolset
             // Add sections from the extensions with data.
             foreach (IExtensionData data in this.extensionData)
             {
-                Library library = data.GetLibrary(this.tableDefinitions);
+                Library library = data.GetLibrary(this.tableDefinitions, false);
 
                 if (null != library)
                 {


### PR DESCRIPTION
Fixes [4703 - Don't always require WixBalExtension when using WixNetFxExtension](http://wixtoolset.org/issues/4703/).
