### PR TITLE
WIXBUG:4412 - Improve cache progress

### DIFF
--- a/history/4412.md
+++ b/history/4412.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:4412 - Improve cache progress.

--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -67,8 +67,10 @@ static HRESULT ExtractContainer(
     __in_ecount(cExtractPayloads) BURN_EXTRACT_PAYLOAD* rgExtractPayloads,
     __in DWORD cExtractPayloads
     );
-static DWORD64 GetCacheActionSuccessProgress(
-    __in BURN_CACHE_ACTION* pCacheAction
+static void UpdateCacheSuccessProgress(
+    __in BURN_PLAN* pPlan,
+    __in BURN_CACHE_ACTION* pCacheAction,
+    __inout DWORD64* pqwSuccessfulCachedProgress
     );
 static HRESULT LayoutBundle(
     __in BURN_USER_EXPERIENCE* pUX,
@@ -95,6 +97,7 @@ static HRESULT LayoutOrCacheContainerOrPayload(
     __in_opt BURN_CONTAINER* pContainer,
     __in_opt BURN_PACKAGE* pPackage,
     __in_opt BURN_PAYLOAD* pPayload,
+    __in BOOL fAlreadyProvidedProgress,
     __in DWORD64 qwSuccessfullyCacheProgress,
     __in DWORD64 qwTotalCacheSize,
     __in_z_opt LPCWSTR wzLayoutDirectory,
@@ -476,8 +479,6 @@ extern "C" HRESULT ApplyCache(
                 }
                 else // skip the action.
                 {
-                    // If we skipped it, we can assume it was successful so add the action's progress now.
-                    qwSuccessfulCachedProgress += GetCacheActionSuccessProgress(pCacheAction);
                     continue;
                 }
             }
@@ -492,7 +493,7 @@ extern "C" HRESULT ApplyCache(
                 hr = LayoutBundle(pUX, hPipe, pCacheAction->bundleLayout.sczExecutableName, pCacheAction->bundleLayout.sczLayoutDirectory, pCacheAction->bundleLayout.sczUnverifiedPath, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal);
                 if (SUCCEEDED(hr))
                 {
-                    qwSuccessfulCachedProgress += pCacheAction->bundleLayout.qwBundleSize;
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
                     ++(*pcOverallProgressTicks);
 
                     hr = ReportOverallProgressTicks(pUX, FALSE, pPlan->cOverallProgressTicksTotal, *pcOverallProgressTicks);
@@ -520,7 +521,7 @@ extern "C" HRESULT ApplyCache(
                 hr = AcquireContainerOrPayload(pUX, pVariables, pCacheAction->resolveContainer.pContainer, NULL, NULL, pCacheAction->resolveContainer.sczUnverifiedPath, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal);
                 if (SUCCEEDED(hr))
                 {
-                    qwSuccessfulCachedProgress += pCacheAction->resolveContainer.pContainer->qwFileSize;
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
                 }
                 else
                 {
@@ -533,25 +534,23 @@ extern "C" HRESULT ApplyCache(
                 // action is still being skipped then skip this action.
                 if (BURN_PLAN_INVALID_ACTION_INDEX != pCacheAction->extractContainer.iSkipUntilAcquiredByAction && pPlan->rgCacheActions[pCacheAction->extractContainer.iSkipUntilAcquiredByAction].fSkipUntilRetried)
                 {
-                    // TODO: Note there is a potential bug here where retry can cause this cost to be added multiple times.
-                    qwSuccessfulCachedProgress += pCacheAction->extractContainer.qwTotalExtractSize;
                     break;
                 }
 
                 hr = ExtractContainer(hEngineFile, pUX, pCacheAction->extractContainer.pContainer, pCacheAction->extractContainer.sczContainerUnverifiedPath, pCacheAction->extractContainer.rgPayloads, pCacheAction->extractContainer.cPayloads);
-                if (SUCCEEDED(hr))
-                {
-                    qwSuccessfulCachedProgress += pCacheAction->extractContainer.qwTotalExtractSize;
-                }
-                else
+                if (FAILED(hr))
                 {
                     LogErrorId(hr, MSG_FAILED_EXTRACT_CONTAINER, pCacheAction->extractContainer.pContainer->sczId, pCacheAction->extractContainer.sczContainerUnverifiedPath, NULL);
                 }
                 break;
 
             case BURN_CACHE_ACTION_TYPE_LAYOUT_CONTAINER:
-                hr = LayoutOrCacheContainerOrPayload(pUX, hPipe, pCacheAction->layoutContainer.pContainer, pCacheAction->layoutContainer.pPackage, NULL, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, pCacheAction->layoutContainer.sczLayoutDirectory, pCacheAction->layoutContainer.sczUnverifiedPath, pCacheAction->layoutContainer.fMove, pCacheAction->layoutContainer.cTryAgainAttempts, &fRetryContainerOrPayload);
-                if (FAILED(hr))
+                hr = LayoutOrCacheContainerOrPayload(pUX, hPipe, pCacheAction->layoutContainer.pContainer, pCacheAction->layoutContainer.pPackage, NULL, pPlan->rgContainerProgress[pCacheAction->layoutContainer.iProgress].fCachedDuringApply, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, pCacheAction->layoutContainer.sczLayoutDirectory, pCacheAction->layoutContainer.sczUnverifiedPath, pCacheAction->layoutContainer.fMove, pCacheAction->layoutContainer.cTryAgainAttempts, &fRetryContainerOrPayload);
+                if (SUCCEEDED(hr))
+                {
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
+                }
+                else
                 {
                     LogErrorId(hr, MSG_FAILED_LAYOUT_CONTAINER, pCacheAction->layoutContainer.pContainer->sczId, pCacheAction->layoutContainer.sczLayoutDirectory, pCacheAction->layoutContainer.sczUnverifiedPath);
 
@@ -569,7 +568,7 @@ extern "C" HRESULT ApplyCache(
                 hr = AcquireContainerOrPayload(pUX, pVariables, NULL, pCacheAction->resolvePayload.pPackage, pCacheAction->resolvePayload.pPayload, pCacheAction->resolvePayload.sczUnverifiedPath, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal);
                 if (SUCCEEDED(hr))
                 {
-                    qwSuccessfulCachedProgress += pCacheAction->resolvePayload.pPayload->qwFileSize;
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
                 }
                 else
                 {
@@ -578,8 +577,12 @@ extern "C" HRESULT ApplyCache(
                 break;
 
             case BURN_CACHE_ACTION_TYPE_CACHE_PAYLOAD:
-                hr = LayoutOrCacheContainerOrPayload(pUX, pCacheAction->cachePayload.pPackage->fPerMachine ? hPipe : INVALID_HANDLE_VALUE, NULL, pCacheAction->cachePayload.pPackage, pCacheAction->cachePayload.pPayload, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, NULL, pCacheAction->cachePayload.sczUnverifiedPath, pCacheAction->cachePayload.fMove, pCacheAction->cachePayload.cTryAgainAttempts, &fRetryContainerOrPayload);
-                if (FAILED(hr))
+                hr = LayoutOrCacheContainerOrPayload(pUX, pCacheAction->cachePayload.pPackage->fPerMachine ? hPipe : INVALID_HANDLE_VALUE, NULL, pCacheAction->cachePayload.pPackage, pCacheAction->cachePayload.pPayload, pPlan->rgPayloadProgress[pCacheAction->cachePayload.iProgress].fCachedDuringApply, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, NULL, pCacheAction->cachePayload.sczUnverifiedPath, pCacheAction->cachePayload.fMove, pCacheAction->cachePayload.cTryAgainAttempts, &fRetryContainerOrPayload);
+                if (SUCCEEDED(hr))
+                {
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
+                }
+                else
                 {
                     LogErrorId(hr, MSG_FAILED_CACHE_PAYLOAD, pCacheAction->cachePayload.pPayload->sczKey, pCacheAction->cachePayload.sczUnverifiedPath, NULL);
 
@@ -594,8 +597,12 @@ extern "C" HRESULT ApplyCache(
                 break;
 
             case BURN_CACHE_ACTION_TYPE_LAYOUT_PAYLOAD:
-                hr = LayoutOrCacheContainerOrPayload(pUX, hPipe, NULL, pCacheAction->layoutPayload.pPackage, pCacheAction->layoutPayload.pPayload, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, pCacheAction->layoutPayload.sczLayoutDirectory, pCacheAction->layoutPayload.sczUnverifiedPath, pCacheAction->layoutPayload.fMove, pCacheAction->layoutPayload.cTryAgainAttempts, &fRetryContainerOrPayload);
-                if (FAILED(hr))
+                hr = LayoutOrCacheContainerOrPayload(pUX, hPipe, NULL, pCacheAction->layoutPayload.pPackage, pCacheAction->layoutPayload.pPayload, pPlan->rgPayloadProgress[pCacheAction->layoutPayload.iProgress].fCachedDuringApply, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal, pCacheAction->layoutPayload.sczLayoutDirectory, pCacheAction->layoutPayload.sczUnverifiedPath, pCacheAction->layoutPayload.fMove, pCacheAction->layoutPayload.cTryAgainAttempts, &fRetryContainerOrPayload);
+                if (SUCCEEDED(hr))
+                {
+                    UpdateCacheSuccessProgress(pPlan, pCacheAction, &qwSuccessfulCachedProgress);
+                }
+                else
                 {
                     LogErrorId(hr, MSG_FAILED_LAYOUT_PAYLOAD, pCacheAction->layoutPayload.pPayload->sczKey, pCacheAction->layoutPayload.sczLayoutDirectory, pCacheAction->layoutPayload.sczUnverifiedPath);
 
@@ -649,12 +656,6 @@ extern "C" HRESULT ApplyCache(
             Assert(wzRetryId);
 
             LogErrorId(hr, MSG_APPLY_RETRYING_PAYLOAD, wzRetryId, NULL, NULL);
-
-            // Reduce the successful progress since we're retrying the payload.
-            BURN_CACHE_ACTION* pRetryCacheAction = pPlan->rgCacheActions + iRetryContainerOrPayloadAction;
-            DWORD64 qwRetryCacheActionSuccessProgress = GetCacheActionSuccessProgress(pRetryCacheAction);
-            Assert(qwSuccessfulCachedProgress >= qwRetryCacheActionSuccessProgress);
-            qwSuccessfulCachedProgress -= qwRetryCacheActionSuccessProgress;
 
             iRetryAction = iRetryContainerOrPayloadAction;
             fRetry = TRUE;
@@ -935,26 +936,62 @@ LExit:
     return hr;
 }
 
-static DWORD64 GetCacheActionSuccessProgress(
-    __in BURN_CACHE_ACTION* pCacheAction
+static void UpdateCacheSuccessProgress(
+    __in BURN_PLAN* pPlan,
+    __in BURN_CACHE_ACTION* pCacheAction,
+    __inout DWORD64* pqwSuccessfulCachedProgress
     )
 {
     switch (pCacheAction->type)
     {
     case BURN_CACHE_ACTION_TYPE_LAYOUT_BUNDLE:
-        return pCacheAction->bundleLayout.qwBundleSize;
-
-    case BURN_CACHE_ACTION_TYPE_EXTRACT_CONTAINER:
-        return pCacheAction->extractContainer.qwTotalExtractSize;
+        *pqwSuccessfulCachedProgress += pCacheAction->bundleLayout.qwBundleSize;
+        break;
 
     case BURN_CACHE_ACTION_TYPE_ACQUIRE_CONTAINER:
-        return pCacheAction->resolveContainer.pContainer->qwFileSize;
+        if (!pPlan->rgContainerProgress[pCacheAction->resolveContainer.iProgress].fCachedDuringApply)
+        {
+            pPlan->rgContainerProgress[pCacheAction->resolveContainer.iProgress].fCachedDuringApply = TRUE;
+            *pqwSuccessfulCachedProgress += pCacheAction->resolveContainer.pContainer->qwFileSize;
+        }
+        break;
+
+    case BURN_CACHE_ACTION_TYPE_LAYOUT_CONTAINER:
+        if (!pPlan->rgContainerProgress[pCacheAction->layoutContainer.iProgress].fCachedDuringApply)
+        {
+            pPlan->rgContainerProgress[pCacheAction->layoutContainer.iProgress].fCachedDuringApply = TRUE;
+            *pqwSuccessfulCachedProgress += pCacheAction->layoutContainer.pContainer->qwFileSize;
+        }
+        break;
 
     case BURN_CACHE_ACTION_TYPE_ACQUIRE_PAYLOAD:
-        return pCacheAction->resolvePayload.pPayload->qwFileSize;
-    }
+        if (!pPlan->rgPayloadProgress[pCacheAction->resolvePayload.iProgress].fCachedDuringApply)
+        {
+            pPlan->rgPayloadProgress[pCacheAction->resolvePayload.iProgress].fCachedDuringApply = TRUE;
+            *pqwSuccessfulCachedProgress += pCacheAction->resolvePayload.pPayload->qwFileSize;
+        }
+        break;
 
-    return 0;
+    case BURN_CACHE_ACTION_TYPE_CACHE_PAYLOAD:
+        if (!pPlan->rgPayloadProgress[pCacheAction->cachePayload.iProgress].fCachedDuringApply)
+        {
+            pPlan->rgPayloadProgress[pCacheAction->cachePayload.iProgress].fCachedDuringApply = TRUE;
+            *pqwSuccessfulCachedProgress += pCacheAction->cachePayload.pPayload->qwFileSize;
+        }
+        break;
+
+    case BURN_CACHE_ACTION_TYPE_LAYOUT_PAYLOAD:
+        if (!pPlan->rgPayloadProgress[pCacheAction->layoutPayload.iProgress].fCachedDuringApply)
+        {
+            pPlan->rgPayloadProgress[pCacheAction->layoutPayload.iProgress].fCachedDuringApply = TRUE;
+            *pqwSuccessfulCachedProgress += pCacheAction->layoutPayload.pPayload->qwFileSize;
+        }
+        break;
+
+    default:
+        AssertSz(FALSE, "Unexpected cache action type.");
+        break;
+    }
 }
 
 static HRESULT LayoutBundle(
@@ -1188,6 +1225,7 @@ static HRESULT LayoutOrCacheContainerOrPayload(
     __in_opt BURN_CONTAINER* pContainer,
     __in_opt BURN_PACKAGE* pPackage,
     __in_opt BURN_PAYLOAD* pPayload,
+    __in BOOL fAlreadyProvidedProgress,
     __in DWORD64 qwSuccessfulCachedProgress,
     __in DWORD64 qwTotalCacheSize,
     __in_z_opt LPCWSTR wzLayoutDirectory,
@@ -1206,14 +1244,20 @@ static HRESULT LayoutOrCacheContainerOrPayload(
 
     liContainerOrPayloadSize.QuadPart = pContainer ? pContainer->qwFileSize : pPayload->qwFileSize;
 
-    Assert(qwSuccessfulCachedProgress >= static_cast<DWORD64>(liContainerOrPayloadSize.QuadPart));
-
     progress.pContainer = pContainer;
     progress.pPackage = pPackage;
     progress.pPayload = pPayload;
     progress.pUX = pUX;
-    progress.qwCacheProgress = qwSuccessfulCachedProgress - liContainerOrPayloadSize.QuadPart; // remove the payload size, since it was marked successful thus included in the successful size already.
     progress.qwTotalCacheSize = qwTotalCacheSize;
+    if (fAlreadyProvidedProgress)
+    {
+        Assert(qwSuccessfulCachedProgress >= static_cast<DWORD64>(liContainerOrPayloadSize.QuadPart));
+        progress.qwCacheProgress = qwSuccessfulCachedProgress - liContainerOrPayloadSize.QuadPart; // remove the payload size, since it was marked successful thus included in the successful size already.
+    }
+    else
+    {
+        progress.qwCacheProgress = qwSuccessfulCachedProgress;
+    }
 
     *pfRetry = FALSE;
 
@@ -1513,6 +1557,7 @@ static DWORD CALLBACK CacheProgressRoutine(
     DWORD64 qwCacheProgress = pProgress->qwCacheProgress + TotalBytesTransferred.QuadPart;
     if (qwCacheProgress > pProgress->qwTotalCacheSize)
     {
+        AssertSz(FALSE, "Apply has cached more than Plan envisioned.");
         qwCacheProgress = pProgress->qwTotalCacheSize;
     }
     DWORD dwOverallPercentage = pProgress->qwTotalCacheSize ? static_cast<DWORD>(qwCacheProgress * 100 / pProgress->qwTotalCacheSize) : 0;

--- a/src/burn/engine/plan.h
+++ b/src/burn/engine/plan.h
@@ -106,6 +106,22 @@ typedef struct _BURN_DEPENDENT_REGISTRATION_ACTION
     LPWSTR sczDependentProviderKey;
 } BURN_DEPENDENT_REGISTRATION_ACTION;
 
+typedef struct _BURN_CACHE_CONTAINER_PROGRESS
+{
+    LPWSTR wzId;
+    DWORD iIndex;
+    BOOL fCachedDuringApply;
+    BURN_CONTAINER* pContainer;
+} BURN_CACHE_CONTAINER_PROGRESS;
+
+typedef struct _BURN_CACHE_PAYLOAD_PROGRESS
+{
+    LPWSTR wzId;
+    DWORD iIndex;
+    BOOL fCachedDuringApply;
+    BURN_PAYLOAD* pPayload;
+} BURN_CACHE_PAYLOAD_PROGRESS;
+
 typedef struct _BURN_CACHE_ACTION
 {
     BURN_CACHE_ACTION_TYPE type;
@@ -145,12 +161,12 @@ typedef struct _BURN_CACHE_ACTION
         struct
         {
             BURN_CONTAINER* pContainer;
+            DWORD iProgress;
             LPWSTR sczUnverifiedPath;
         } resolveContainer;
         struct
         {
             BURN_CONTAINER* pContainer;
-            DWORD64 qwTotalExtractSize;
             DWORD iSkipUntilAcquiredByAction;
             LPWSTR sczContainerUnverifiedPath;
 
@@ -161,6 +177,7 @@ typedef struct _BURN_CACHE_ACTION
         {
             BURN_PACKAGE* pPackage;
             BURN_CONTAINER* pContainer;
+            DWORD iProgress;
             DWORD iTryAgainAction;
             DWORD cTryAgainAttempts;
             LPWSTR sczLayoutDirectory;
@@ -171,12 +188,14 @@ typedef struct _BURN_CACHE_ACTION
         {
             BURN_PACKAGE* pPackage;
             BURN_PAYLOAD* pPayload;
+            DWORD iProgress;
             LPWSTR sczUnverifiedPath;
         } resolvePayload;
         struct
         {
             BURN_PACKAGE* pPackage;
             BURN_PAYLOAD* pPayload;
+            DWORD iProgress;
             DWORD iTryAgainAction;
             DWORD cTryAgainAttempts;
             LPWSTR sczUnverifiedPath;
@@ -186,6 +205,7 @@ typedef struct _BURN_CACHE_ACTION
         {
             BURN_PACKAGE* pPackage;
             BURN_PAYLOAD* pPayload;
+            DWORD iProgress;
             DWORD iTryAgainAction;
             DWORD cTryAgainAttempts;
             LPWSTR sczLayoutDirectory;
@@ -346,6 +366,14 @@ typedef struct _BURN_PLAN
 
     DEPENDENCY* rgPlannedProviders;
     UINT cPlannedProviders;
+
+    BURN_CACHE_CONTAINER_PROGRESS* rgContainerProgress;
+    DWORD cContainerProgress;
+    STRINGDICT_HANDLE shContainerProgress;
+
+    BURN_CACHE_PAYLOAD_PROGRESS* rgPayloadProgress;
+    DWORD cPayloadProgress;
+    STRINGDICT_HANDLE shPayloadProgress;
 } BURN_PLAN;
 
 

--- a/src/burn/engine/precomp.h
+++ b/src/burn/engine/precomp.h
@@ -36,6 +36,7 @@
 #include <mscat.h>
 #include <lmcons.h>
 #include <wininet.h>
+#include <stddef.h>
 
 #include <dutil.h>
 #include <aclutil.h>

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -494,21 +494,11 @@ public: // IBootstrapperApplication
         __in DWORD dwOverallPercentage
         )
     {
-        WCHAR wzProgress[5] = { };
-
 #ifdef DEBUG
         BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "WIXSTDBA: OnCacheAcquireProgress() - container/package: %ls, payload: %ls, progress: %I64u, total: %I64u, overall progress: %u%%", wzPackageOrContainerId, wzPayloadId, dw64Progress, dw64Total, dwOverallPercentage);
 #endif
 
-        ::StringCchPrintfW(wzProgress, countof(wzProgress), L"%u%%", dwOverallPercentage);
-        ThemeSetTextControl(m_pTheme, WIXSTDBA_CONTROL_CACHE_PROGRESS_TEXT, wzProgress);
-
-        ThemeSetProgressControl(m_pTheme, WIXSTDBA_CONTROL_CACHE_PROGRESS_BAR, dwOverallPercentage);
-
-        m_dwCalculatedCacheProgress = dwOverallPercentage * WIXSTDBA_ACQUIRE_PERCENTAGE / 100;
-        ThemeSetProgressControl(m_pTheme, WIXSTDBA_CONTROL_OVERALL_CALCULATED_PROGRESS_BAR, m_dwCalculatedCacheProgress + m_dwCalculatedExecuteProgress);
-
-        SetTaskbarButtonProgress(m_dwCalculatedCacheProgress + m_dwCalculatedExecuteProgress);
+        UpdateCacheProgress(dwOverallPercentage);
 
         return __super::OnCacheAcquireProgress(wzPackageOrContainerId, wzPayloadId, dw64Progress, dw64Total, dwOverallPercentage);
     }
@@ -539,9 +529,10 @@ public: // IBootstrapperApplication
 
 
     virtual STDMETHODIMP_(void) OnCacheComplete(
-        __in HRESULT /*hrStatus*/
+        __in HRESULT hrStatus
         )
     {
+        UpdateCacheProgress(SUCCEEDED(hrStatus) ? 100 : 0);
         ThemeSetTextControl(m_pTheme, WIXSTDBA_CONTROL_CACHE_PROGRESS_PACKAGE_TEXT, L"");
         SetState(WIXSTDBA_STATE_CACHED, S_OK); // we always return success here and let OnApplyComplete() deal with the error.
     }
@@ -2594,6 +2585,23 @@ private: // privates
 
     LExit:
         return hr;
+    }
+
+    void UpdateCacheProgress(
+        __in DWORD dwOverallPercentage
+        )
+    {
+        WCHAR wzProgress[5] = { };
+
+        ::StringCchPrintfW(wzProgress, countof(wzProgress), L"%u%%", dwOverallPercentage);
+        ThemeSetTextControl(m_pTheme, WIXSTDBA_CONTROL_CACHE_PROGRESS_TEXT, wzProgress);
+
+        ThemeSetProgressControl(m_pTheme, WIXSTDBA_CONTROL_CACHE_PROGRESS_BAR, dwOverallPercentage);
+
+        m_dwCalculatedCacheProgress = dwOverallPercentage * WIXSTDBA_ACQUIRE_PERCENTAGE / 100;
+        ThemeSetProgressControl(m_pTheme, WIXSTDBA_CONTROL_OVERALL_CALCULATED_PROGRESS_BAR, m_dwCalculatedCacheProgress + m_dwCalculatedExecuteProgress);
+
+        SetTaskbarButtonProgress(m_dwCalculatedCacheProgress + m_dwCalculatedExecuteProgress);
     }
 
 


### PR DESCRIPTION
The goal here was to make sure that each container/payload only contributes to the overall progress once. It's possible that a container/payload never contributes. For example, if a container never has to be acquired because all of its payloads are already cached or a non-vital package is skipped.

WixStdBA had to be updated since it didn't set its cache progress variable to 100% on OnCacheComplete.

Improves cache progress by actually keeping track of when each payload is cached instead of making a bunch of assumptions.

Rebased version of #40 since a lot has changed since then.  Third time's the charm?
