### PR TITLE
WIP4707: Win64 attribute change

### DIFF
--- a/src/libs/WixToolset.Data/Xsd/wix.xsd
+++ b/src/libs/WixToolset.Data/Xsd/wix.xsd
@@ -7571,18 +7571,23 @@
                     </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="Win64" type="YesNoTypeUnion">
+      <xs:attribute name="Platform">
         <xs:annotation>
           <xs:documentation>
-                        Set this attribute to 'yes' to mark this as a 64-bit component. This attribute facilitates
-                        the installation of packages that include both 32-bit and 64-bit components.  If this is a 64-bit
-                        component replacing a 32-bit component, set this attribute to 'yes' and assign a new GUID in the Guid attribute.
-          The default value is based on the platform set by the -arch switch to candle.exe
-          or the InstallerPlatform property in a .wixproj MSBuild project: 
-          For x86 and ARM, the default value is 'no'. 
-          For x64 and IA64, the default value is 'yes'.
+                        Set this attribute to 'win32' to mark this as a 32-bit component. This attribute facilitates
+                        the installation of packages that include both 32-bit and 64-bit components. 64-bit
+                        components must not share the same GUID with a 32-bit component.
+          If attribute is default (or specified as 'default'), the platform set by the -arch switch to candle.exe
+          or the InstallerPlatform property in a .wixproj MSBuild project will be used to determine if the component
+          is 32-bit or 64-bit. The default value is 'default'.
           </xs:documentation>
         </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="win32" />
+            <xs:enumeration value="default" />
+          </xs:restriction>
+        </xs:simpleType>
       </xs:attribute>
       <xs:anyAttribute namespace="##other" processContents="lax">
         <xs:annotation>
@@ -9007,17 +9012,21 @@
                             </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="Win64" type="YesNoTypeUnion">
+          <xs:attribute name="Platform">
             <xs:annotation>
               <xs:documentation>
-                                Specifies that a script custom action targets a 64-bit platform. Valid only when used with
-                                the Script, VBScriptCall, and JScriptCall attributes.
-          The default value is based on the platform set by the -arch switch to candle.exe
-          or the InstallerPlatform property in a .wixproj MSBuild project: 
-          For x86 and ARM, the default value is 'no'. 
-          For x64 and IA64, the default value is 'yes'.
+                            Set this attribute to 'win32' to mark this as a 32-bit custom action. Valid only when used with
+                                the Script, VBScriptCall, and JScriptCall attributes. The default value is 'default', which
+                                will be the platform set by the -arch switch in candle.exe or the InstallerPlatform property
+                                in a .wixproj MSBuild project. The default value is 'default'.
               </xs:documentation>
             </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="win32" />
+                <xs:enumeration value="default" />
+              </xs:restriction>
+            </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="TerminalServerAware" type="YesNoTypeUnion">
             <xs:annotation>

--- a/src/libs/WixToolset.Data/Xsd/wix.xsd
+++ b/src/libs/WixToolset.Data/Xsd/wix.xsd
@@ -2340,7 +2340,7 @@
       </xs:attribute>
       <xs:attribute name="CleanWorkingFolder" type="YesNoTypeUnion">
         <xs:annotation>
-          <xs:documentation>Use this to set whether Patchwiz should clean the temp folder when finished. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx" target="_blank">DontRemoveTempFolderWhenFinished</html:a> for more information.	</xs:documentation>
+          <xs:documentation>Use this to set whether Patchwiz should clean the temp folder when finished. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx" target="_blank">DontRemoveTempFolderWhenFinished</html:a> for more information.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="Codepage" type="xs:string">
@@ -7395,9 +7395,8 @@
                         Set this attribute to 'always32Bit' to mark this as a 32-bit component. This attribute facilitates
                         the installation of packages that include both 32-bit and 64-bit components. 64-bit
                         components must not share the same GUID with a 32-bit component.
-          If attribute is default (or specified as 'default'), the architecture set by the -arch switch to candle.exe
-          or the InstallerPlatform property in a .wixproj MSBuild project will be used to determine if the component
-          is 32-bit or 64-bit. The default value is 'default'.
+                        The default will be the Architecture set by the -arch switch in candle.exe or the
+                        InstallerPlatform property in a .wixproj MSBuild project.
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
@@ -8764,9 +8763,8 @@
             <xs:annotation>
               <xs:documentation>
                             Set this attribute to 'always32Bit' to mark this as a 32-bit custom action. Valid only when used with
-                                the Script, VBScriptCall, and JScriptCall attributes. The default value is 'default', which
-                                will be the Architecture set by the -arch switch in candle.exe or the InstallerPlatform property
-                                in a .wixproj MSBuild project. The default value is 'default'.
+                            the Script, VBScriptCall, and JScriptCall attributes. The default will be the Architecture set
+                            by the -arch switch in candle.exe or the InstallerPlatform property in a .wixproj MSBuild project.
               </xs:documentation>
             </xs:annotation>
             <xs:simpleType>

--- a/src/libs/WixToolset.Data/Xsd/wix.xsd
+++ b/src/libs/WixToolset.Data/Xsd/wix.xsd
@@ -7389,6 +7389,24 @@
                     </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="Architecture">
+        <xs:annotation>
+          <xs:documentation>
+                        Set this attribute to 'always32Bit' to mark this as a 32-bit component. This attribute facilitates
+                        the installation of packages that include both 32-bit and 64-bit components. 64-bit
+                        components must not share the same GUID with a 32-bit component.
+          If attribute is default (or specified as 'default'), the architecture set by the -arch switch to candle.exe
+          or the InstallerPlatform property in a .wixproj MSBuild project will be used to determine if the component
+          is 32-bit or 64-bit. The default value is 'default'.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="always32Bit" />
+            <xs:enumeration value="default" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="ComPlusFlags" type="xs:integer">
         <xs:annotation>
           <xs:documentation>
@@ -7570,24 +7588,6 @@
                         Windows Installer 4.5 and later.
                     </xs:documentation>
         </xs:annotation>
-      </xs:attribute>
-      <xs:attribute name="Platform">
-        <xs:annotation>
-          <xs:documentation>
-                        Set this attribute to 'win32' to mark this as a 32-bit component. This attribute facilitates
-                        the installation of packages that include both 32-bit and 64-bit components. 64-bit
-                        components must not share the same GUID with a 32-bit component.
-          If attribute is default (or specified as 'default'), the platform set by the -arch switch to candle.exe
-          or the InstallerPlatform property in a .wixproj MSBuild project will be used to determine if the component
-          is 32-bit or 64-bit. The default value is 'default'.
-          </xs:documentation>
-        </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="win32" />
-            <xs:enumeration value="default" />
-          </xs:restriction>
-        </xs:simpleType>
       </xs:attribute>
       <xs:anyAttribute namespace="##other" processContents="lax">
         <xs:annotation>
@@ -8760,6 +8760,22 @@
                         </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="Architecture">
+            <xs:annotation>
+              <xs:documentation>
+                            Set this attribute to 'always32Bit' to mark this as a 32-bit custom action. Valid only when used with
+                                the Script, VBScriptCall, and JScriptCall attributes. The default value is 'default', which
+                                will be the Architecture set by the -arch switch in candle.exe or the InstallerPlatform property
+                                in a .wixproj MSBuild project. The default value is 'default'.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="always32Bit" />
+                <xs:enumeration value="default" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
           <!-- CustomAction Source specification, sets source Attribute bits -->
           <xs:attribute name="BinaryKey" type="xs:string">
             <xs:annotation>
@@ -9011,22 +9027,6 @@
                                 behavior.
                             </xs:documentation>
             </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="Platform">
-            <xs:annotation>
-              <xs:documentation>
-                            Set this attribute to 'win32' to mark this as a 32-bit custom action. Valid only when used with
-                                the Script, VBScriptCall, and JScriptCall attributes. The default value is 'default', which
-                                will be the platform set by the -arch switch in candle.exe or the InstallerPlatform property
-                                in a .wixproj MSBuild project. The default value is 'default'.
-              </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-              <xs:restriction base="xs:string">
-                <xs:enumeration value="win32" />
-                <xs:enumeration value="default" />
-              </xs:restriction>
-            </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="TerminalServerAware" type="YesNoTypeUnion">
             <xs:annotation>

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -3399,7 +3399,7 @@ namespace WixToolset
                 id = Identifier.Invalid;
             }
 
-            // If we're a script CA and we're in a 64-bit package and our Platform was "default", then set the 64-bit flag
+            // If we're a script CA and we're in a 64-bit package and our Architecture was "default", then set the 64-bit flag
             if ((MsiInterop.MsidbCustomActionTypeVBScript == targetBits || MsiInterop.MsidbCustomActionTypeJScript == targetBits) && architectureType == Wix.CustomAction.ArchitectureType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
             {
                 bits |= MsiInterop.MsidbCustomActionType64BitScript;

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -2104,7 +2104,7 @@ namespace WixToolset
             string keyPath = null;
             bool shouldAddCreateFolder = false;
             bool win64 = false;
-            Wix.Component.PlatformType platformType = Wix.Component.PlatformType.@default;
+            Wix.Component.ArchitectureType architectureType = Wix.Component.ArchitectureType.@default;
             bool multiInstance = false;
             List<string> symbols = new List<string>();
             string feature = null;
@@ -2117,6 +2117,13 @@ namespace WixToolset
                     {
                         case "Id":
                             id = this.core.GetAttributeIdentifier(sourceLineNumbers, attrib);
+                            break;
+                        case "Architecture":
+                            string architecture = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            if (0 < architecture.Length)
+                            {
+                                architectureType = Wix.Component.ParseArchitectureType(architecture);
+                            }
                             break;
                         case "ComPlusFlags":
                             comPlusBits = this.core.GetAttributeIntegerValue(sourceLineNumbers, attrib, 0, short.MaxValue);
@@ -2184,13 +2191,6 @@ namespace WixToolset
                                 bits |= MsiInterop.MsidbComponentAttributesPermanent;
                             }
                             break;
-                        case "Platform":
-                            string platform = this.core.GetAttributeValue(sourceLineNumbers, attrib);
-                            if (0 < platform.Length)
-                            {
-                                platformType = Wix.Component.ParsePlatformType(platform);
-                            }
-                            break;
                         case "Shared":
                             if (YesNoType.Yes == this.core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
                             {
@@ -2226,7 +2226,7 @@ namespace WixToolset
                 }
             }
 
-            if (platformType == Wix.Component.PlatformType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
+            if (architectureType == Wix.Component.ArchitectureType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
             {
                 bits |= MsiInterop.MsidbComponentAttributes64bit;
                 win64 = true;
@@ -3138,7 +3138,7 @@ namespace WixToolset
             YesNoType suppressModularization = YesNoType.NotSet;
             string target = null;
             int targetBits = 0;
-            Wix.CustomAction.PlatformType platformType = Wix.CustomAction.PlatformType.@default;
+            Wix.CustomAction.ArchitectureType architectureType = Wix.CustomAction.ArchitectureType.@default;
 
             foreach (XAttribute attrib in node.Attributes())
             {
@@ -3148,6 +3148,13 @@ namespace WixToolset
                     {
                         case "Id":
                             id = this.core.GetAttributeIdentifier(sourceLineNumbers, attrib);
+                            break;
+                        case "Architecture":
+                            string architecture = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            if (0 < architecture.Length)
+                            {
+                                architectureType = Wix.CustomAction.ParseArchitectureType(architecture);
+                            }
                             break;
                         case "BinaryKey":
                             if (null != source)
@@ -3281,13 +3288,6 @@ namespace WixToolset
                                 extendedBits |= MsiInterop.MsidbCustomActionTypePatchUninstall;
                             }
                             break;
-                        case "Platform":
-                            string platform = this.core.GetAttributeValue(sourceLineNumbers, attrib);
-                            if (0 < platform.Length)
-                            {
-                                platformType = Wix.CustomAction.ParsePlatformType(platform);
-                            }
-                            break;
                         case "Property":
                             if (null != source)
                             {
@@ -3400,7 +3400,7 @@ namespace WixToolset
             }
 
             // If we're a script CA and we're in a 64-bit package and our Platform was "default", then set the 64-bit flag
-            if ((MsiInterop.MsidbCustomActionTypeVBScript == targetBits || MsiInterop.MsidbCustomActionTypeJScript == targetBits) && platformType == Wix.CustomAction.PlatformType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
+            if ((MsiInterop.MsidbCustomActionTypeVBScript == targetBits || MsiInterop.MsidbCustomActionTypeJScript == targetBits) && architectureType == Wix.CustomAction.ArchitectureType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
             {
                 bits |= MsiInterop.MsidbCustomActionType64BitScript;
             }

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -3399,7 +3399,7 @@ namespace WixToolset
                 id = Identifier.Invalid;
             }
 
-            // If we're a script CA and we're in a 64-bit package and our Architecture was "default", then set the 64-bit flag
+            // If we're a script CA and we're in a 64-bit package and our Architecture was "default", then set the 64-bit flag.
             if ((MsiInterop.MsidbCustomActionTypeVBScript == targetBits || MsiInterop.MsidbCustomActionTypeJScript == targetBits) && architectureType == Wix.CustomAction.ArchitectureType.@default && (Platform.IA64 == this.CurrentPlatform || Platform.X64 == this.CurrentPlatform))
             {
                 bits |= MsiInterop.MsidbCustomActionType64BitScript;

--- a/src/tools/wix/Converter.cs
+++ b/src/tools/wix/Converter.cs
@@ -668,7 +668,7 @@ namespace WixToolset
             SuppressSignatureValidationDeprecated,
 
             /// <summary>
-            /// Win64 attribute on a Component or CustomAction element could not be converted to the new Platform attribute.
+            /// Win64 attribute on a Component or CustomAction element could not be converted to the new Architecture attribute.
             /// </summary>
             Win64AttributeCouldNotBeConverted,
         }

--- a/src/tools/wix/Converter.cs
+++ b/src/tools/wix/Converter.cs
@@ -262,7 +262,7 @@ namespace WixToolset
                 }
                 else if (win64.Value == "no")
                 {
-                    element.SetAttributeValue("Platform", "win32");
+                    element.SetAttributeValue("Architecture", "always32Bit");
 
                     element.SetAttributeValue("Win64", null);
                 }
@@ -285,7 +285,7 @@ namespace WixToolset
                 }
                 else if (win64.Value == "no")
                 {
-                    element.SetAttributeValue("Platform", "win32");
+                    element.SetAttributeValue("Architecture", "always32Bit");
 
                     element.SetAttributeValue("Win64", null);
                 }

--- a/src/tools/wix/Decompiler.cs
+++ b/src/tools/wix/Decompiler.cs
@@ -4798,7 +4798,7 @@ namespace WixToolset
                     customAction.TerminalServerAware = Wix.YesNoType.yes;
                 }
 
-                // If it's a 64-bit package with a 32-bit custom action, then we need win32 specifically, otherwise use the default
+                // If it's a 64-bit package with a 32-bit custom action, then we need win32 specifically, otherwise use the default.
                 if ((this.platform == WixToolset.Data.Serialize.Package.PlatformType.x64 || this.platform == WixToolset.Data.Serialize.Package.PlatformType.ia64) && MsiInterop.MsidbCustomActionType64BitScript != (type & MsiInterop.MsidbCustomActionType64BitScript))
                 {
                     customAction.Architecture = Wix.CustomAction.ArchitectureType.always32Bit;

--- a/src/tools/wix/Decompiler.cs
+++ b/src/tools/wix/Decompiler.cs
@@ -4801,7 +4801,7 @@ namespace WixToolset
                 // If it's a 64-bit package with a 32-bit custom action, then we need win32 specifically, otherwise use the default
                 if ((this.platform == WixToolset.Data.Serialize.Package.PlatformType.x64 || this.platform == WixToolset.Data.Serialize.Package.PlatformType.ia64) && MsiInterop.MsidbCustomActionType64BitScript != (type & MsiInterop.MsidbCustomActionType64BitScript))
                 {
-                    customAction.Platform = Wix.CustomAction.PlatformType.win32;
+                    customAction.Architecture = Wix.CustomAction.ArchitectureType.always32Bit;
                 }
 
                 switch (type & MsiInterop.MsidbCustomActionTypeExecuteBits)
@@ -5041,7 +5041,7 @@ namespace WixToolset
 
                 if ((this.platform == WixToolset.Data.Serialize.Package.PlatformType.x64 || this.platform == WixToolset.Data.Serialize.Package.PlatformType.ia64) && MsiInterop.MsidbComponentAttributes64bit != (attributes & MsiInterop.MsidbComponentAttributes64bit))
                 {
-                    component.Platform = Wix.Component.PlatformType.win32;
+                    component.Architecture = Wix.Component.ArchitectureType.always32Bit;
                 }
 
                 if (MsiInterop.MsidbComponentAttributesDisableRegistryReflection == (attributes & MsiInterop.MsidbComponentAttributesDisableRegistryReflection))


### PR DESCRIPTION
New name of attribute "Architecture" with possible values "always32Bit" and "default" was agreed upon between, Rob, Bob, Sean and I during today's WiX Tuesday meeting.
