### PR TITLE
Dropbox Scenario Fix

### DIFF
--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -305,12 +305,23 @@ DWORD BrowseWindow::GetSelectedValueIndex()
 
 DWORD BrowseWindow::GetSelectedValueHistoryIndex()
 {
-    DWORD dwRetVal = DWORD_MAX;
+    HWND hwnd = ::GetDlgItem(m_hWnd, BROWSE_CONTROL_SINGLE_VALUE_HISTORY_LIST_VIEW);
+
+    DWORD dwSelectionIndex = DWORD_MAX;
+    DWORD dwListViewRowCount = ::SendMessageW(hwnd, LVM_GETITEMCOUNT, 0, 0);
 
     // Ignore errors
-    UIGetSingleSelectedItemFromListView(::GetDlgItem(m_hWnd, BROWSE_CONTROL_SINGLE_VALUE_HISTORY_LIST_VIEW), NULL, &dwRetVal);
+    UIGetSingleSelectedItemFromListView(hwnd, NULL, &dwSelectionIndex);
 
-    return dwRetVal;
+    if (DWORD_MAX == dwSelectionIndex || dwListViewRowCount <= dwSelectionIndex)
+    {
+        // Something weird, indicate error
+        return DWORD_MAX;
+    }
+    else
+    {
+        return dwListViewRowCount - dwSelectionIndex - 1;
+    }
 }
 
 DWORD BrowseWindow::GetSelectedConflictProductIndex()

--- a/src/SettingsEngine/lib/util.cpp
+++ b/src/SettingsEngine/lib/util.cpp
@@ -470,17 +470,9 @@ static HRESULT SyncSingleProduct(
     ExitOnFailure(hr, "Failed to create dictionary of values seen");
 
     hr = ProductSyncValues(pcdb1, pcdb2, fRegistered, shDictItemsSeen, ppcpProductTemp);
-    if (E_NOTFOUND == hr)
-    {
-        hr = S_OK;
-    }
     ExitOnFailure(hr, "Failed to sync product values for application (1)");
 
     hr = ProductSyncValues(pcdb2, pcdb1, fRegistered, shDictItemsSeen, ppcpProductTemp);
-    if (E_NOTFOUND == hr)
-    {
-        hr = S_OK;
-    }
     ExitOnFailure(hr, "Failed to sync product values for application (2)");
 
 LExit:

--- a/src/SettingsEngine/lib/value.cpp
+++ b/src/SettingsEngine/lib/value.cpp
@@ -447,6 +447,12 @@ HRESULT ValueTransferFromHistory(
     SCE_ROW_HANDLE sceValueRow = NULL;
     SCE_ROW_HANDLE sceValueHistoryRow = NULL;
 
+    if (dwStartingEnumIndex >= pceValueHistoryEnum->dwNumValues)
+    {
+        hr = E_INVALIDARG;
+        ExitOnFailure(hr, "Incorrect starting enum index passed to ValueTransferFromHistory()");
+    }
+
     hr = SceBeginTransaction(pcdb->psceDb);
     ExitOnFailure(hr, "Failed to begin transaction");
     fInSceTransaction = TRUE;

--- a/src/SettingsEngine/lib/value.cpp
+++ b/src/SettingsEngine/lib/value.cpp
@@ -493,7 +493,7 @@ HRESULT ValueTransferFromHistory(
             UtilAddToSystemTime(1, &pceValueHistoryEnum->valueHistory.rgcValues[i].stWhen);
 
             // Since we changed the timestamp, make sure the updated timestamp appears in both databases
-            hr = EnumWriteValue(pcdbReferencedBy, wzValueName, pceValueHistoryEnum, i, pcdb);
+            hr = ValueWrite(pcdbReferencedBy, pcdbReferencedBy->dwAppID, wzValueName, pceValueHistoryEnum->valueHistory.rgcValues + i, FALSE, pcdb);
             ExitOnFailure(hr, "Failed to write value in referenced by %ls index %u", wzValueName, i);
         }
         

--- a/src/SettingsEngine/lib/value.cpp
+++ b/src/SettingsEngine/lib/value.cpp
@@ -1288,37 +1288,42 @@ static HRESULT ExpireOldRows(
         // If it's older than 30 days, keep values that are at least 30 days apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60 * 24 * 30)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60 * 24 * 30);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 60 * 24 * 30);
         }
         // If it's older than 2 weeks, keep values that are at least 3 day apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60 * 24 * 14)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60 * 24 * 3);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 60 * 24 * 3);
         }
         // If it's older than a week, keep values that are at least 1 day apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60 * 24 * 7)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60 * 24);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 60 * 24);
         }
         // If it's older than 3 days, keep values that are at least 12 hours apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60 * 24 * 3)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60 * 12);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 60 * 12);
         }
         // If it's older than a day, keep values that are at least 3 hours apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60 * 24)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60 * 3);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 60 * 3);
         }
-        // If it's older than an hour, keep values at least 1 hour apart, and discard ones closer together
+        // If it's older than an hour, keep values at least 15 minutes apart, and discard ones closer together
         else if (llTimeDiffFromNow > 60 * 60)
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 60);
+            fKeepThisValue = (llTimeDiffFromLastKept >= 60 * 15);
         }
-        // It must be newer than an hour, so only keep values at least 3 minutes apart
+        // It must be newer than an hour, so keep all values. This is unfortunately critical in the dropbox-like scenario,
+        // where we can commit a database, and later discover that perhaps it didn't really commit after all (due to two machines
+        // updating the database file at around the same time, which is common when a value is being modified on machine A regularly,
+        // and machine B is trying to update the database to indicate a recent value is referenced).
+        // A better solution should be explored because this just dramatically lowers the chance of conflicts, but does
+        // not completely eliminate it. It is important for now to make sure that the expiration feature doesn't usually have conflicts.
         else
         {
-            fKeepThisValue = (llTimeDiffFromLastKept > 60 * 3);
+            fKeepThisValue = TRUE;
         }
 
         if (fKeepThisValue)

--- a/src/SettingsEngine/lib/value.cpp
+++ b/src/SettingsEngine/lib/value.cpp
@@ -483,7 +483,7 @@ HRESULT ValueTransferFromHistory(
         if (fValueExists && 0 > UtilCompareSystemTimes(&pceValueHistoryEnum->valueHistory.rgcValues[i].stWhen, &stValue))
         {
             // If we're not on the last loop iteration, just don't transfer this enum
-            // TODO: we could write historical values by inserting them in the old history
+            // TODO: we could write historical values by inserting them in the old history, someday if we have a separate timestamp for arrival-at-this-db time vs original-modified-time
             if (!fLastValue)
             {
                 continue;
@@ -491,6 +491,10 @@ HRESULT ValueTransferFromHistory(
 
             pceValueHistoryEnum->valueHistory.rgcValues[i].stWhen = stValue;
             UtilAddToSystemTime(1, &pceValueHistoryEnum->valueHistory.rgcValues[i].stWhen);
+
+            // Since we changed the timestamp, make sure the updated timestamp appears in both databases
+            hr = EnumWriteValue(pcdbReferencedBy, wzValueName, pceValueHistoryEnum, i, pcdb);
+            ExitOnFailure(hr, "Failed to write value in referenced by %ls index %u", wzValueName, i);
         }
         
         // Make sure to set the referenced by column for the last value only

--- a/test/src/SettingsEngineTests/EnumPastValuesTest.cpp
+++ b/test/src/SettingsEngineTests/EnumPastValuesTest.cpp
@@ -46,39 +46,40 @@ namespace CfgTests
             hr = CfgSetString(cdhLocal, L"Test1", L"Value1");
             ExitOnFailure(hr, "Failed to set Test1 string (to 'Value1')");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetString(cdhLocal, L"Test1", L"Value2");
             ExitOnFailure(hr, "Failed to set Test1 string (to 'Value2')");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetDword(cdhLocal, L"Test1", 500);
             ExitOnFailure(hr, "Failed to set Test1 string (to 500)");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetString(cdhLocal, L"Test1", L"Value3");
             ExitOnFailure(hr, "Failed to set Test1 string (to 'Value3')");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgDeleteValue(cdhLocal, L"Test1");
             ExitOnFailure(hr, "Failed to delete value Test1");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetBool(cdhLocal, L"Test1", FALSE);
             ExitOnFailure(hr, "Failed to set Test1 string (to FALSE)");
 
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetBlob(cdhLocal, L"Test1", rgbData, sizeof(rgbData));
             ExitOnFailure(hr, "Failed to set Test1 string (to blob)");
 
-            AddToSystemTime(300);
-            hr = CfgSetBool(cdhLocal, L"Test1", TRUE);
-            ExitOnFailure(hr, "Failed to set Test1 string (to TRUE)");
-
-            AddToSystemTime(300);
+            AddToSystemTime(900);
             hr = CfgSetString(cdhLocal, L"Test1", L"ValueThatWillBeExpiredDueToShortLife");
             ExitOnFailure(hr, "Failed to set Test1 string (to 'ValueThatWillBeExpiredDueToShortLife')");
 
             AddToSystemTime(1);
+            hr = CfgSetBool(cdhLocal, L"Test1", TRUE);
+            ExitOnFailure(hr, "Failed to set Test1 string (to TRUE)");
+
+            // After values are older than an hour, they must be kept 
+            AddToSystemTime(3601);
             hr = CfgSetString(cdhLocal, L"Test1", L"LatestValue");
             ExitOnFailure(hr, "Failed to set Test1 string (to 'LatestValue')");
 
@@ -88,7 +89,7 @@ namespace CfgTests
             if (dwCount != 9)
             {
                 hr = E_FAIL;
-                ExitOnFailure(hr, "There should be 9 values in Test1's history - there were only %u found", dwCount);
+                ExitOnFailure(hr, "There should be 9 values in Test1's history - there were %u found", dwCount);
             }
 
             VerifyHistoryString(cehHandle, dwCount - 1, L"LatestValue");

--- a/test/src/SettingsEngineTests/SettingsEngineTest.cpp
+++ b/test/src/SettingsEngineTests/SettingsEngineTest.cpp
@@ -212,7 +212,7 @@ namespace CfgTests
         DWORD64 ul;
         C_ASSERT(sizeof(ul) == sizeof(ft));
         memcpy(&ul, &ft, sizeof(ul));
-        ul += dwSeconds * 10000000;
+        ul += (DWORD64)(dwSeconds) * 10000000;
         memcpy(&ft, &ul, sizeof(ft));
 
         if (!FileTimeToSystemTime(&ft, &stCurrent))


### PR DESCRIPTION
I've discovered a bug in the dropbox-like (dropbox, onedrive, etc.) scenario with the expiration feature that can result in unnecessary sync conflicts when a setting is being changed often, and another machine to sync to is online. Because we can believe we commited a database (committed to local dropbox folder), but dropbox can throw out that commit (another machine uploaded the same file at around the same time - dropbox picks one to win), we can end up in a situation where one machine expires values that another machine actually references (requires to maintain some common history with the remote).

I have a few ideas for better solutions than this (keeping references in a separate guid-named database file - ugh - or sync rules to trust newer values from on the remote from remote guids, as long as our latest value is not from the local guid). However this change is extremely simple and low-risk, and avoids the problematic scenario for 99.9% of cases by just keeping values from the last hour around, which is not horribly painful.
