### PR TITLE
Bug 4532 - InstallPrivileges and InstallScope can specify contradicting values

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-* BMurri: WIXBUG:4532 - Made it an error for InstallPrivileges and InstallScope to both be specified.
+* BMurri: WIXBUG:4532 - Make it an error for InstallPrivileges and InstallScope to both be specified.
 
 ## WixBuild: Version 4.0.2926.0
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BMurri: WIXBUG:4532 - Made it an error for InstallPrivileges and InstallScope to both be specified.
+
 ## WixBuild: Version 4.0.2926.0
 
 * BobArnson: WIXFEAT:4772 - Replace hyperlink ShelExec with ShelExecUnelevated.

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -10781,6 +10781,8 @@ namespace WixToolset
             YesNoDefaultType security = YesNoDefaultType.Default;
             int sourceBits = (this.compilingModule ? 2 : 0);
             Row row;
+            bool installPrivilegeSeen = false;
+            bool installScopeSeen = false;
 
             switch (this.CurrentPlatform)
             {
@@ -10840,6 +10842,7 @@ namespace WixToolset
                             string installPrivileges = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             if (0 < installPrivileges.Length)
                             {
+                                installPrivilegeSeen = true;
                                 Wix.Package.InstallPrivilegesType installPrivilegesType = Wix.Package.ParseInstallPrivilegesType(installPrivileges);
                                 switch (installPrivilegesType)
                                 {
@@ -10859,6 +10862,7 @@ namespace WixToolset
                             string installScope = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             if (0 < installScope.Length)
                             {
+                                installScopeSeen = true;
                                 Wix.Package.InstallScopeType installScopeType = Wix.Package.ParseInstallScopeType(installScope);
                                 switch (installScopeType)
                                 {
@@ -10957,6 +10961,11 @@ namespace WixToolset
                 {
                     this.core.ParseExtensionAttribute(node, attrib);
                 }
+            }
+
+            if (installPrivilegeSeen && installScopeSeen)
+            {
+                this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "InstallPrivileges", "InstallScope"));
             }
 
             if ((0 != String.Compare(platform, "Intel", StringComparison.OrdinalIgnoreCase)) && 200 > msiVersion)


### PR DESCRIPTION
This is the wix4 version of the fix for this bug. It simply doesn't allow both attributes to be specified.

My preference, actually would be to simply remove Package/@InstallPrivileges entirely, but it is showing up in a couple places I'm not sure how to deal with (possibly obsolete test code and/or decompiler).

The wix3 version of the fix is [here](https://github.com/wixtoolset/wix3/pull/265). It's a little different.
