### PR TITLE
Check for correct strong name public key token

### DIFF
--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -64,8 +64,8 @@
     <Message Importance="low" Text="WIX_BUILDROOT = $(WIX_BUILDROOT)" />
 
     <PropertyGroup>
-      <DisabledWixStrongName32>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\StrongName\Verification\*,36e4ce08b8ecfb17', '', 'ABSENT', RegistryView.Registry32))</DisabledWixStrongName32>
-      <DisabledWixStrongName64>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\StrongName\Verification\*,36e4ce08b8ecfb17', '', 'ABSENT', RegistryView.Registry64))</DisabledWixStrongName64>
+      <DisabledWixStrongName32>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\StrongName\Verification\*,c9acf360d0e036e3', '', 'ABSENT', RegistryView.Registry32))</DisabledWixStrongName32>
+      <DisabledWixStrongName64>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\StrongName\Verification\*,c9acf360d0e036e3', '', 'ABSENT', RegistryView.Registry64))</DisabledWixStrongName64>
     </PropertyGroup>
 
     <Error


### PR DESCRIPTION
Seems the wix3 change was pulled over as-is but didn't match what wix4's `tools\OneTimeWixBuildInitialization.proj` specified for strong name validation skipping.
