### PR TITLE
Fix variadic macros for custom action messages

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: Fix variadic macros for custom action messages
+
 * SeanHall: WIXFEAT: 4703 - Move the PrereqPackage information out of the NetFx extension and into the Bal extension so that the NetFx extension doesn't require the Bal extension.
 
 * SeanHall: WIXBUG:4392 - Set WixBundleInstalled during Detect.

--- a/History.md
+++ b/History.md
@@ -1,5 +1,3 @@
-* HeathS: Fix variadic macros for custom action messages
-
 * SeanHall: WIXFEAT: 4703 - Move the PrereqPackage information out of the NetFx extension and into the Bal extension so that the NetFx extension doesn't require the Bal extension.
 
 * SeanHall: WIXBUG:4392 - Set WixBundleInstalled during Detect.

--- a/history/4668.md
+++ b/history/4668.md
@@ -1,0 +1,1 @@
+* HeathS: Fix variadic macros for custom action messages

--- a/src/libs/wcautil/wcautil.h
+++ b/src/libs/wcautil/wcautil.h
@@ -21,9 +21,9 @@ extern "C" {
 
 #include "dutil.h"
 
-#define MessageExitOnLastError(x, e, s, ...)      { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; } }
-#define MessageExitOnFailure(x, e, s, ...)           if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, 0, __VA_ARGS__);  goto LExit; }
-#define MessageExitOnNullWithLastError(p, x, e, s, ...) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, 0, __VA_ARGS__);  goto LExit; }
+#define MessageExitOnLastError(x, e, s, ...)      { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, -1, __VA_ARGS__);  goto LExit; } }
+#define MessageExitOnFailure(x, e, s, ...)           if (FAILED(x)) { ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, INSTALLMESSAGE_ERROR | MB_OK, -1, __VA_ARGS__);  goto LExit; }
+#define MessageExitOnNullWithLastError(p, x, e, s, ...) if (NULL == p) { x = ::GetLastError(); x = HRESULT_FROM_WIN32(x); if (!FAILED(x)) { x = E_FAIL; } ExitTrace(x, "%s", s, __VA_ARGS__); WcaErrorMessage(e, x, MB_OK, -1, __VA_ARGS__);  goto LExit; }
 
 // Generic action enum.
 typedef enum WCA_ACTION
@@ -112,7 +112,7 @@ UINT __cdecl WcaErrorMessage(
     __in int iError,
     __in HRESULT hrError,
     __in UINT uiType,
-    __in DWORD cArgs,
+    __in INT cArgs,
     ...
     );
 HRESULT WIXAPI WcaProgressMessage(

--- a/src/libs/wcautil/wcawrap.cpp
+++ b/src/libs/wcautil/wcawrap.cpp
@@ -44,7 +44,7 @@ extern "C" UINT __cdecl WcaErrorMessage(
     __in int iError,
     __in HRESULT hrError,
     __in UINT uiType,
-    __in DWORD cArgs,
+    __in INT cArgs,
     ...
     )
 {
@@ -79,7 +79,7 @@ extern "C" UINT __cdecl WcaErrorMessage(
         }
     }
 
-    for (DWORD i = 0; i < cArgs; i++)
+    for (INT i = 0; i < cArgs; i++)
     {
         er = ::MsiRecordSetStringW(hRec, i + 3, va_arg(args, WCHAR*));
         ExitOnFailure(HRESULT_FROM_WIN32(er), "failed to set string string into error message");


### PR DESCRIPTION
I was trying to make wcautil unit-testable but figured I'd better get the actual fix in (been done for a while but forgot I hadn't pushed it yet - sorry).
