### PR TITLE
Settings Browser UI Fixes

### DIFF
--- a/history/4359.md
+++ b/history/4359.md
@@ -1,0 +1,1 @@
+* MikeGC: WIXBUG:4359 - In settings browser, display manifested displayname (instead of ID) for friendlier UI

--- a/history/uifixes.md
+++ b/history/uifixes.md
@@ -1,0 +1,1 @@
+* MikeGC: Refactor settings browser and make it more responsive, and less likely to show a "loading" screen (instead showing the most recent data until the new data is available)

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -206,7 +206,7 @@ LExit:
             // Don't free local database here - we only have one open, it must be freed after all remotes, and is specifically freed below this loop
         }
 
-        ReleaseDB(bdlDatabaseList.rgDatabases + i);
+        UtilFreeDatabase(bdlDatabaseList.rgDatabases + i);
     }
     ReleaseMem(bdlDatabaseList.rgDatabases);
 
@@ -372,14 +372,13 @@ BOOL ProcessMessage(
         CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].cehProductList);
         bdlDatabaseList.rgDatabases[dwIndex].cehProductList = cehHandle;
         cehHandle = NULL;
-        bdlDatabaseList.rgDatabases[dwIndex].dwProductListCount = dwEnumCount;
 
         ::LeaveCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = FALSE;
 
         if (SUCCEEDED(hr))
         {
-            hrSend = CheckProductInstalledState(cdbLocal, bdlDatabaseList.rgDatabases[dwIndex].cehProductList, bdlDatabaseList.rgDatabases[dwIndex].dwProductListCount, &bdlDatabaseList.rgDatabases[dwIndex].rgfProductInstalled);
+            hrSend = CheckProductInstalledState(cdbLocal, bdlDatabaseList.rgDatabases[dwIndex].cehProductList, dwEnumCount, &bdlDatabaseList.rgDatabases[dwIndex].rgfProductInstalled);
             ExitOnFailure(hrSend, "Failed to check product installed state");
         }
         else

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -369,8 +369,8 @@ BOOL ProcessMessage(
         ::EnterCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = TRUE;
 
-        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].cehProductList);
-        bdlDatabaseList.rgDatabases[dwIndex].cehProductList = cehHandle;
+        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].productEnum.cehItems);
+        bdlDatabaseList.rgDatabases[dwIndex].productEnum.cehItems = cehHandle;
         cehHandle = NULL;
 
         ::LeaveCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
@@ -378,7 +378,7 @@ BOOL ProcessMessage(
 
         if (SUCCEEDED(hr))
         {
-            hrSend = CheckProductInstalledState(cdbLocal, bdlDatabaseList.rgDatabases[dwIndex].cehProductList, dwEnumCount, &bdlDatabaseList.rgDatabases[dwIndex].rgfProductInstalled);
+            hrSend = CheckProductInstalledState(cdbLocal, bdlDatabaseList.rgDatabases[dwIndex].productEnum.cehItems, dwEnumCount, &bdlDatabaseList.rgDatabases[dwIndex].rgfProductInstalled);
             ExitOnFailure(hrSend, "Failed to check product installed state");
         }
         else
@@ -397,10 +397,10 @@ BOOL ProcessMessage(
         ::EnterCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = TRUE;
 
-        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].cehDatabaseList);
-        bdlDatabaseList.rgDatabases[dwIndex].cehDatabaseList = cehHandle;
+        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].dbEnum.cehItems);
+        bdlDatabaseList.rgDatabases[dwIndex].dbEnum.cehItems = cehHandle;
         cehHandle = NULL;
-        bdlDatabaseList.rgDatabases[dwIndex].dwDatabaseListCount = dwEnumCount;
+        bdlDatabaseList.rgDatabases[dwIndex].dbEnum.cItems = dwEnumCount;
 
         if (!::PostMessageW(hwnd, WM_BROWSE_ENUMERATE_DATABASES_FINISHED, static_cast<WPARAM>(hrSend), static_cast<LPARAM>(dwIndex)))
         {
@@ -468,10 +468,10 @@ BOOL ProcessMessage(
         ::EnterCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = TRUE;
 
-        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].cehValueList);
-        bdlDatabaseList.rgDatabases[dwIndex].cehValueList = cehHandle;
+        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].valueEnum.cehItems);
+        bdlDatabaseList.rgDatabases[dwIndex].valueEnum.cehItems = cehHandle;
         cehHandle = NULL;
-        bdlDatabaseList.rgDatabases[dwIndex].dwValueCount = dwEnumCount;
+        bdlDatabaseList.rgDatabases[dwIndex].valueEnum.cItems = dwEnumCount;
 
         if (!::PostMessageW(hwnd, WM_BROWSE_ENUMERATE_VALUES_FINISHED, static_cast<WPARAM>(hrSend), static_cast<LPARAM>(dwIndex)))
         {
@@ -487,10 +487,10 @@ BOOL ProcessMessage(
         ::EnterCriticalSection(&bdlDatabaseList.rgDatabases[dwIndex].cs);
         fCsEntered = TRUE;
 
-        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].cehValueHistory);
-        bdlDatabaseList.rgDatabases[dwIndex].cehValueHistory = cehHandle;
+        CfgReleaseEnumeration(bdlDatabaseList.rgDatabases[dwIndex].valueHistoryEnum.cehItems);
+        bdlDatabaseList.rgDatabases[dwIndex].valueHistoryEnum.cehItems = cehHandle;
         cehHandle = NULL;
-        bdlDatabaseList.rgDatabases[dwIndex].dwValueHistoryCount = dwEnumCount;
+        bdlDatabaseList.rgDatabases[dwIndex].valueHistoryEnum.cItems = dwEnumCount;
 
         if (!::PostMessageW(hwnd, WM_BROWSE_ENUMERATE_VALUE_HISTORY_FINISHED, static_cast<WPARAM>(hrSend), static_cast<LPARAM>(dwIndex)))
         {
@@ -577,7 +577,7 @@ BOOL ProcessMessage(
 
         pdsDwordString = reinterpret_cast<DWORD_STRING *>(msg->lParam);
 
-        hrSend = CfgEnumReadBinary(bdlDatabaseList.rgDatabases[dwIndex].cdb, bdlDatabaseList.rgDatabases[dwIndex].cehValueHistory, pdsDwordString->dwDword1, ENUM_DATA_BLOBCONTENT, &pbData, &cbData);
+        hrSend = CfgEnumReadBinary(bdlDatabaseList.rgDatabases[dwIndex].cdb, bdlDatabaseList.rgDatabases[dwIndex].valueHistoryEnum.cehItems, pdsDwordString->dwDword1, ENUM_DATA_BLOBCONTENT, &pbData, &cbData);
         if (FAILED(hr))
         {
             if (!::PostMessageW(hwnd, WM_BROWSE_EXPORT_FILE_FROM_HISTORY_FINISHED, static_cast<WPARAM>(hrSend), static_cast<LPARAM>(dwIndex)))

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -133,6 +133,9 @@ int WINAPI wWinMain(
     hr = browser->Initialize(&dwUIThreadId);
     ExitOnFailure(hr, "Failed to initialize main window");
 
+    // Nobody cares about failure - this is just best effort to boost UI responsiveness.
+    ::SetThreadPriority(::GetCurrentThread(), THREAD_MODE_BACKGROUND_BEGIN);
+
     while (0 != (fRet = ::GetMessageW(&msg, NULL, 0, 0)))
     {
         if (-1 == fRet)
@@ -178,6 +181,9 @@ LExit:
         browser->Uninitialize();
         delete browser;
     }
+
+    // UI is dead, this is no longer the background thread. Set thread priority back to normal for potentially quicker shutdown.
+    ::SetThreadPriority(::GetCurrentThread(), THREAD_MODE_BACKGROUND_END);
 
     if (fThemeInitialized)
     {

--- a/src/SettingsEngine/browse/browse.cpp
+++ b/src/SettingsEngine/browse/browse.cpp
@@ -102,8 +102,7 @@ int WINAPI wWinMain(
 
     if (commandLineRequest.fHelpRequested)
     {
-        //printf("CfgBrowser.exe [/?] | [/manifest manifest.udm] [/manifest anothermanifest.udm] ...");
-        // TODO: get printf working so we can output usage information
+        ::MessageBoxW(NULL, L"CfgBrowser.exe [/?] | [/manifest manifest.udm] [/manifest anothermanifest.udm] ...", L"WiX Settings Browser Commandline Help", MB_OK);
         return 0;
     }
 

--- a/src/SettingsEngine/browse/en-us.wxl
+++ b/src/SettingsEngine/browse/en-us.wxl
@@ -17,7 +17,6 @@
   <String Id="ProductListHeader" Overridable="yes">Product List:</String>
   <String Id="ProductName" Overridable="yes">Product Name</String>
   <String Id="ProductVersion" Overridable="yes">Version</String>
-  <String Id="ProductPublicKey" Overridable="yes">Public Key</String>
   <String Id="ShowUninstalledProducts" Overridable="yes">Show Uninstalled Products</String>
   <String Id="ResolutionColumn" Overridable="yes">Resolution</String>
   <String Id="ProductForgetButton" Overridable="yes">Forget Product</String>

--- a/src/SettingsEngine/browse/precomp.h
+++ b/src/SettingsEngine/browse/precomp.h
@@ -14,9 +14,6 @@
 #pragma once
 
 #define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
 
 #include <windows.h>
 #include <windowsx.h>

--- a/src/SettingsEngine/browse/thm.xml
+++ b/src/SettingsEngine/browse/thm.xml
@@ -128,9 +128,8 @@
       <Label Name="SingleDbConflictsDatabaseName" X="10" Y="25" Width="200" Height="15" FontId="0" />
       <Label X="10" Y="40" Width="200" Height="15" FontId="0">#(loc.ConflictsHeader)</Label>
       <ListView Name="SingleDbConflictsView" TabStop="yes" X="10" Y="65" Width="-210" Height="-40" FontId="0" HexStyle="00000019" HexExtendedStyle="00000021">
-        <Column Width="380" Expands="yes">#(loc.ProductName)</Column>
+        <Column Width="455" Expands="yes">#(loc.ProductName)</Column>
         <Column Width="110">#(loc.ResolutionColumn)</Column>
-        <Column Width="75">#(loc.ProductVersion)</Column>
       </ListView>
       <Button Name="SingleDbConflictsBackButton" X="-20" Y="50" Width="150" Height="20" FontId="0" TabStop="yes">#(loc.BackButton)</Button>
       <Button Name="SingleDbConflictsSyncButton" X="-20" Y="75" Width="150" Height="20" FontId="0" TabStop="yes">#(loc.SyncResolveButton)</Button>

--- a/src/SettingsEngine/browse/thm.xml
+++ b/src/SettingsEngine/browse/thm.xml
@@ -21,9 +21,7 @@
       <Label Name="ProductListDatabaseName" X="10" Y="25" Width="200" Height="15" FontId="0" />
       <Label X="10" Y="40" Width="200" Height="15" FontId="0">#(loc.ProductListHeader)</Label>
       <ListView Name="ProductListView" TabStop="yes" X="10" Y="55" Width="-210" Height="-35" FontId="0" ImageListSmall="InstallState" HexStyle="0000000D" HexExtendedStyle="00000021">
-        <Column Width="354" Expands="yes">#(loc.ProductName)</Column>
-        <Column Width="80">#(loc.ProductVersion)</Column>
-        <Column Width="115">#(loc.ProductPublicKey)</Column>
+        <Column Width="549" Expands="yes">#(loc.ProductName)</Column>
       </ListView>
       <Checkbox Name="ShowUninstalledProductsCheckBox" FontId="0" TabStop="yes" X="10" Y="-10" Width="200" Height="20">#(loc.ShowUninstalledProducts)</Checkbox>
       <Button Name="ProductListBackButton" X="-10" Y="50" Width="150" Height="20" FontId="0" TabStop="yes">#(loc.BackButton)</Button>

--- a/src/SettingsEngine/browse/ui.cpp
+++ b/src/SettingsEngine/browse/ui.cpp
@@ -387,7 +387,7 @@ HRESULT UISetListViewToValueEnum(
         ExitFunction1(hr = S_OK);
     }
 
-    if (!GetTimeZoneInformation(&tzi))
+    if (!::GetTimeZoneInformation(&tzi))
     {
         ExitWithLastError(hr, "Failed to get time zone information");
     }
@@ -536,7 +536,7 @@ HRESULT UISetListViewToValueHistoryEnum(
         ExitFunction1(hr = S_OK);
     }
 
-    if (!GetTimeZoneInformation(&tzi))
+    if (!::GetTimeZoneInformation(&tzi))
     {
         ExitWithLastError(hr, "Failed to get time zone information");
     }

--- a/src/SettingsEngine/browse/ui.h
+++ b/src/SettingsEngine/browse/ui.h
@@ -121,6 +121,11 @@ HRESULT UIMessageBoxDisplayError(
     __in LPCWSTR wzErrorMessage,
     __in HRESULT hr
     );
+HRESULT UISelectBestLCIDToDisplay(
+    __in DISPLAY_NAME *rgDisplayNames,
+    __in DWORD cDisplayNames,
+    __out DWORD *pdwIndex
+    );
 
 #ifdef __cplusplus
 }

--- a/src/SettingsEngine/browse/utils.cpp
+++ b/src/SettingsEngine/browse/utils.cpp
@@ -28,10 +28,10 @@ void UtilFreeDatabase(
     ReleaseStr(pDatabase->sczStatusMessage);
     ReleaseStr(pDatabase->sczCurrentProductDisplayName);
     ReleaseStr(pDatabase->sczValueName);
-    CfgReleaseEnumeration(pDatabase->cehDatabaseList);
-    CfgReleaseEnumeration(pDatabase->cehProductList);
-    CfgReleaseEnumeration(pDatabase->cehValueList);
-    CfgReleaseEnumeration(pDatabase->cehValueHistory);
+    CfgReleaseEnumeration(pDatabase->dbEnum.cehItems);
+    CfgReleaseEnumeration(pDatabase->productEnum.cehItems);
+    CfgReleaseEnumeration(pDatabase->valueEnum.cehItems);
+    CfgReleaseEnumeration(pDatabase->valueHistoryEnum.cehItems);
     CfgReleaseConflictProductArray(pDatabase->pcplConflictProductList, pDatabase->dwConflictProductCount);
 }
 

--- a/src/SettingsEngine/browse/utils.cpp
+++ b/src/SettingsEngine/browse/utils.cpp
@@ -70,3 +70,17 @@ BOOL UtilReadyToSync(
 
     return TRUE;
 }
+
+void UtilWipeEnum(
+    __in BROWSE_DATABASE *pDatabase,
+    __inout BROWSE_ENUM *pEnum
+    )
+{
+    ::EnterCriticalSection(&pDatabase->cs);
+
+    CfgReleaseEnumeration(pEnum->cehItems);
+    pEnum->cehItems = NULL;
+    pEnum->cItems = 0;
+
+    ::LeaveCriticalSection(&pDatabase->cs);
+}

--- a/src/SettingsEngine/browse/utils.h
+++ b/src/SettingsEngine/browse/utils.h
@@ -40,6 +40,15 @@ struct PRODUCT
     LPWSTR sczPublicKey;
 };
 
+struct BROWSE_ENUM
+{
+    BOOL fRefreshing;
+    HRESULT hrResult;
+    CFG_ENUMERATION_HANDLE cehItems;
+    DWORD cItems;
+    LPCWSTR wzDisplayStatusText;
+};
+
 struct BROWSE_DATABASE
 {
     // Don't need to enter this every time you're messing with the struct. If you're just modifying a field that's only meant
@@ -88,45 +97,30 @@ struct BROWSE_DATABASE
     BOOL fForgetting;
     HRESULT hrForgetResult;
 
-    // Product enumeration
-    BOOL fProductListLoading;
-    HRESULT hrProductListResult;
-    CFG_ENUMERATION_HANDLE cehProductList;
-    BOOL *rgfProductInstalled;
-    LPCWSTR wzProductListText;
-    PRODUCT prodCurrent;
-
-    // Database enumeration
-    BOOL fDatabaseListLoading;
-    HRESULT hrDatabaseListResult;
-    CFG_ENUMERATION_HANDLE cehDatabaseList;
-    DWORD dwDatabaseListCount;
-    LPCWSTR wzDatabaseListText;
-
     // Product setting functionality
     BOOL fProductSet;
     BOOL fSettingProduct;
     HRESULT hrSetProductResult;
 
+    // Product enumeration
+    BROWSE_ENUM productEnum;
+    BOOL *rgfProductInstalled;
+    PRODUCT prodCurrent;
+
+    // Database enumeration
+    BROWSE_ENUM dbEnum;
+
     // Value enumeration
-    BOOL fValueListLoading;
-    HRESULT hrValueListResult;
-    CFG_ENUMERATION_HANDLE cehValueList;
+    BROWSE_ENUM valueEnum;
     BOOL fNewValue;
-    DWORD dwValueCount;
-    LPCWSTR wzValueListText;
 
     // Set Value Screen
     CONFIG_VALUETYPE cdSetValueType;
 
     // Value history information
+    BROWSE_ENUM valueHistoryEnum;
     HISTORY_MODE vhmValueHistoryMode;
     LPWSTR sczValueName;
-    BOOL fValueHistoryLoading;
-    HRESULT hrValueHistoryResult;
-    CFG_ENUMERATION_HANDLE cehValueHistory;
-    DWORD dwValueHistoryCount;
-    LPCWSTR wzValueHistoryListText;
 
     // Conflicts
     CONFLICT_PRODUCT *pcplConflictProductList;

--- a/src/SettingsEngine/browse/utils.h
+++ b/src/SettingsEngine/browse/utils.h
@@ -154,6 +154,10 @@ HRESULT UtilGrowDatabaseList(
 BOOL UtilReadyToSync(
     __in BROWSE_DATABASE *pbdDatabase
     );
+void UtilWipeEnum(
+    __in BROWSE_DATABASE *pDatabase,
+    __inout BROWSE_ENUM *pEnum
+    );
 
 #ifdef __cplusplus
 }

--- a/src/SettingsEngine/browse/utils.h
+++ b/src/SettingsEngine/browse/utils.h
@@ -17,9 +17,6 @@
 extern "C" {
 #endif
 
-#define ReleaseDB(db) if (db) { UtilFreeDatabase(db); }
-#define ReleaseNullDB(db) if (db) { UtilFreeDatabase(db); db = NULL; }
-
 enum DATABASE_TYPE
 {
     DATABASE_UNKNOWN = 0,
@@ -96,8 +93,6 @@ struct BROWSE_DATABASE
     HRESULT hrProductListResult;
     CFG_ENUMERATION_HANDLE cehProductList;
     BOOL *rgfProductInstalled;
-    DWORD dwProductListCount;
-    DWORD dwSelectedProductIndex;
     LPCWSTR wzProductListText;
     PRODUCT prodCurrent;
 
@@ -112,7 +107,6 @@ struct BROWSE_DATABASE
     BOOL fProductSet;
     BOOL fSettingProduct;
     HRESULT hrSetProductResult;
-    DWORD dwSetProductIndex;
 
     // Value enumeration
     BOOL fValueListLoading;

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -57,7 +57,6 @@ HRESULT BrowseWindow::SetSelectedProduct(
 {
     HRESULT hr = S_OK;
     LPCWSTR wzTemp = NULL;
-    CURRENTDATABASE.dwSetProductIndex = dwIndex;
     ::EnterCriticalSection(&CURRENTDATABASE.cs);
 
     hr = CfgEnumReadString(CURRENTDATABASE.cehProductList, dwIndex, ENUM_DATA_PRODUCTNAME, &wzTemp);

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -1026,6 +1026,7 @@ DWORD WINAPI BrowseWindow::UiThreadProc(
     ExitOnFailure(hr, "Failed to copy name of local database to database list entry");
 
     pThis->m_pbdlDatabaseList->rgDatabases[dwDatabaseIndex].dtType = DATABASE_LOCAL;
+    pThis->m_pbdlDatabaseList->rgDatabases[dwDatabaseIndex].fInitializing = TRUE;
 
     // create main window
     hr = pThis->CreateMainWindow();
@@ -1376,6 +1377,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
     case WM_BROWSE_INITIALIZE_FINISHED:
         dwIndex = static_cast<DWORD>(lParam);
 
+        UXDATABASE(dwIndex).fInitializing = FALSE;
         UXDATABASE(dwIndex).hrInitializeResult = static_cast<HRESULT>(wParam);
 
         hr = pUX->SetDatabaseIndex(0);

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -1409,7 +1409,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
         dwIndex = static_cast<DWORD>(lParam);
 
         UXDATABASE(dwIndex).hrDatabaseListResult = static_cast<HRESULT>(wParam);
-        UXDATABASE(dwIndex).fDatabaseListLoading = TRUE;
+        UXDATABASE(dwIndex).fDatabaseListLoading = FALSE;
 
         if (0 < UXDATABASE(dwIndex).dwDatabaseListCount)
         {

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -1050,11 +1050,6 @@ HRESULT BrowseWindow::CreateMainWindow()
     HRESULT hr = S_OK;
     WNDCLASSW wc = { };
     DWORD dwWindowStyle = 0;
-    LPWSTR sczThemePath = NULL;
-
-    // load theme relative to BROWSE.dll.
-    hr = PathRelativeToModule(&sczThemePath, L"thm.xml", m_hModule);
-    ExitOnFailure(hr, "Failed to combine module path with thm.xml.");
 
     hr = ThemeLoadFromResource(m_hModule, MAKEINTRESOURCEA(BROWSE_RES_THEME_FILE), &m_pTheme);
     ExitOnFailure(hr, "Failed to load theme from embedded resource.");
@@ -1113,7 +1108,6 @@ HRESULT BrowseWindow::CreateMainWindow()
     ExitOnFailure(hr, "Failed to display value list");
 
 LExit:
-    ReleaseStr(sczThemePath);
     ReleaseStr(m_sczLanguage);
 
     if (FAILED(hr))
@@ -2794,7 +2788,6 @@ HRESULT BrowseWindow::SetMainState(
     )
 {
     HRESULT hr = S_OK;
-    LPWSTR sczText = NULL;
     DWORD dwNewPageId = 0;
     DWORD dwOldPageId = 0;
 
@@ -2844,8 +2837,6 @@ HRESULT BrowseWindow::SetMainState(
     ::SetFocus(m_hWnd);
 
 LExit:
-    ReleaseStr(sczText);
-
     return hr;
 }
 

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -980,6 +980,9 @@ DWORD WINAPI BrowseWindow::UiThreadProc(
     BOOL fRet = FALSE;
     MSG msg = { };
 
+    // Nobody cares about failure - this is just best effort to boost UI responsiveness.
+    ::SetThreadPriority(::GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+
     // initialize COM
     hr = ::CoInitialize(NULL);
     ExitOnFailure(hr, "Failed to initialize COM.");

--- a/src/SettingsEngine/browse/window.cpp
+++ b/src/SettingsEngine/browse/window.cpp
@@ -258,8 +258,7 @@ HRESULT BrowseWindow::EnumerateValues(
     // If we're changing to a different product, clear out the current enumeration so we don't show inaccurate data
     if (fDifferentProduct)
     {
-        CfgReleaseEnumeration(m_pbdlDatabaseList->rgDatabases[dwIndex].valueEnum.cehItems);
-        m_pbdlDatabaseList->rgDatabases[dwIndex].valueEnum.cehItems = NULL;
+        UtilWipeEnum(m_pbdlDatabaseList->rgDatabases + dwIndex, &m_pbdlDatabaseList->rgDatabases[dwIndex].valueEnum);
     }
 
     hr = RefreshValueList(dwIndex);
@@ -289,8 +288,7 @@ HRESULT BrowseWindow::EnumerateValueHistory(
     // If we're changing to a different value, clear out the current enumeration so we don't show inaccurate data
     if (fDifferentValue)
     {
-        CfgReleaseEnumeration(m_pbdlDatabaseList->rgDatabases[dwIndex].valueHistoryEnum.cehItems);
-        m_pbdlDatabaseList->rgDatabases[dwIndex].valueHistoryEnum.cehItems = NULL;
+        UtilWipeEnum(m_pbdlDatabaseList->rgDatabases + dwIndex, &m_pbdlDatabaseList->rgDatabases[dwIndex].valueHistoryEnum);
     }
 
     hr = RefreshValueHistoryList(dwIndex);
@@ -1851,8 +1849,7 @@ LRESULT CALLBACK BrowseWindow::WndProc(
                 }
 
                 // We're switching products in the UI - any old value list is inaccurate, and should be released immediately
-                CfgReleaseEnumeration(UXDATABASE(dwIndex).valueEnum.cehItems);
-                UXDATABASE(dwIndex).valueEnum.cehItems = NULL;
+                UtilWipeEnum(pUX->m_pbdlDatabaseList->rgDatabases + dwIndex, &pUX->m_pbdlDatabaseList->rgDatabases[dwIndex].valueEnum);
 
                 hr = pUX->RefreshValueList(dwIndex);
                 ExitOnFailure(hr, "Failed to refresh value list for main single product screen");

--- a/src/SettingsEngine/browse/window.h
+++ b/src/SettingsEngine/browse/window.h
@@ -285,8 +285,8 @@ public:
 
     HRESULT EnumerateProducts(DWORD dwIndex);
     HRESULT EnumerateDatabases(DWORD dwIndex);
-    HRESULT EnumerateValues(DWORD dwIndex);
-    HRESULT EnumerateValueHistory(DWORD dwIndex);
+    HRESULT EnumerateValues(DWORD dwIndex, BOOL fDifferentProduct);
+    HRESULT EnumerateValueHistory(DWORD dwIndex, BOOL fDifferentValue);
 
     DWORD GetSelectedValueIndex();
     DWORD GetSelectedValueHistoryIndex();

--- a/src/SettingsEngine/lib/cfgadmin.cpp
+++ b/src/SettingsEngine/lib/cfgadmin.cpp
@@ -184,6 +184,12 @@ extern "C" HRESULT CfgAdminRegisterProduct(
         hr = SceSetColumnString(sceRow, PRODUCT_PUBLICKEY, sczLowPublicKey);
         ExitOnFailure(hr, "Failed to set publickey column");
 
+        hr = SceSetColumnBool(sceRow, PRODUCT_REGISTERED, TRUE);
+        ExitOnFailure(hr, "Failed to set registered column");
+
+        hr = SceSetColumnBool(sceRow, PRODUCT_IS_LEGACY, FALSE);
+        ExitOnFailure(hr, "Failed to set IsLegacy column");
+
         hr = SceFinishUpdate(sceRow);
         ExitOnFailure(hr, "Failed to finish update");
 

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -1969,6 +1969,8 @@ extern "C" void CfgReleaseConflictProductArray(
         ReleaseStr(rgcpProduct[i].sczVersion);
         ReleaseStr(rgcpProduct[i].sczPublicKey);
 
+        ReleaseDisplayNameArray(rgcpProduct[i].rgDisplayNames, rgcpProduct[i].cDisplayNames);
+
         for (DWORD j = 0; j < rgcpProduct[i].cValues; ++j)
         {
             CfgReleaseEnumeration(rgcpProduct[i].rgcesValueEnumLocal[j]);

--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -1087,6 +1087,7 @@ extern "C" HRESULT CfgEnumerateProducts(
     CFGDB_STRUCT *pcdb = static_cast<CFGDB_STRUCT *>(cdHandle);
     SCE_ROW_HANDLE sceRow = NULL;
     BOOL fLocked = FALSE;
+    DWORD dwAppID = DWORD_MAX;
 
     ExitOnNull(pcdb, hr, E_INVALIDARG, "Database handle must not be NULL");
     ExitOnNull(ppvHandle, hr, E_INVALIDARG, "Must pass in pointer to output handle to CfgEnumerateProducts()");
@@ -1127,6 +1128,12 @@ extern "C" HRESULT CfgEnumerateProducts(
         ExitOnFailure(hr, "Failed to retrieve public key while enumerating products");
 
         hr = SceGetColumnBool(sceRow, PRODUCT_REGISTERED, &(pcesEnum->products.rgfRegistered[pcesEnum->dwNumValues]));
+        ExitOnFailure(hr, "Failed to retrieve registered flag while enumerating products");
+
+        hr = SceGetColumnDword(sceRow, PRODUCT_ID, &dwAppID);
+        ExitOnFailure(hr, "Failed to retrieve dwAppID while enumerating products");
+
+        hr = DisplayNameEnumerate(pcdb, dwAppID, &(pcesEnum->products.rgrgDisplayNames[pcesEnum->dwNumValues]), &(pcesEnum->products.rgcDisplayNames[pcesEnum->dwNumValues]));
         ExitOnFailure(hr, "Failed to retrieve registered flag while enumerating products");
 
         ++pcesEnum->dwNumValues;
@@ -1855,6 +1862,40 @@ LExit:
         HandleUnlock(pcdb);
     }
 
+    return hr;
+}
+
+extern "C" HRESULT CFGAPI CfgEnumReadDisplayNameArray(
+    __in_bcount(CFG_ENUMERATION_HANDLE_BYTES) C_CFG_ENUMERATION_HANDLE cehHandle,
+    __in DWORD dwIndex,
+    __out DISPLAY_NAME **prgDisplayNames,
+    __out DWORD *pcDisplayNames
+    )
+{
+    HRESULT hr = S_OK;
+    const CFG_ENUMERATION *pcesEnum = static_cast<const CFG_ENUMERATION *>(cehHandle);
+
+    ExitOnNull(pcesEnum, hr, E_INVALIDARG, "CfgEnumReadDisplayNameArray() requires an enumeration handle");
+    ExitOnNull(prgDisplayNames, hr, E_INVALIDARG, "CfgEnumReadDisplayNameArray()'s must not be sent NULL for its DISPLAY_NAME ** output parameter");
+    ExitOnNull(pcDisplayNames, hr, E_INVALIDARG, "CfgEnumReadDisplayNameArray() must not be sent NULL for DWORD * output parameter");
+
+    // Index out of bounds
+    if (dwIndex >= pcesEnum->dwNumValues)
+    {
+        hr = E_INVALIDARG;
+        ExitOnFailure(hr, "Index %u out of bounds (max value: %u)", dwIndex, pcesEnum->dwNumValues);
+    }
+
+    if (ENUMERATION_PRODUCTS != pcesEnum->enumType)
+    {
+        hr = E_INVALIDARG;
+        ExitOnFailure(hr, "Only product enumeration type supports enumerating display names");
+    }
+
+    *prgDisplayNames = pcesEnum->products.rgrgDisplayNames[dwIndex];
+    *pcDisplayNames = pcesEnum->products.rgcDisplayNames[dwIndex];
+
+LExit:
     return hr;
 }
 

--- a/src/SettingsEngine/lib/cfglib.vcxproj
+++ b/src/SettingsEngine/lib/cfglib.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="database.cpp" />
     <ClCompile Include="dblist.cpp" />
     <ClCompile Include="detect.cpp" />
+    <ClCompile Include="dispname.cpp" />
     <ClCompile Include="drdfault.cpp" />
     <ClCompile Include="drspcial.cpp" />
     <ClCompile Include="enum.cpp" />
@@ -89,6 +90,7 @@
     <ClInclude Include="database.h" />
     <ClInclude Include="dblist.h" />
     <ClInclude Include="detect.h" />
+    <ClInclude Include="dispname.h" />
     <ClInclude Include="drdfault.h" />
     <ClInclude Include="drspcial.h" />
     <ClInclude Include="enum.h" />

--- a/src/SettingsEngine/lib/database.cpp
+++ b/src/SettingsEngine/lib/database.cpp
@@ -165,9 +165,6 @@ HRESULT DatabaseSetupSchema(
     pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_REGISTERED].dbtColumnType = DBTYPE_BOOL;
     pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_IS_LEGACY].wzName = L"IsLegacy";
     pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_IS_LEGACY].dbtColumnType = DBTYPE_BOOL;
-    pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_LEGACY_SEQUENCE].wzName = L"Sequence";
-    pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_LEGACY_SEQUENCE].dbtColumnType = DBTYPE_I4;
-    pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_LEGACY_SEQUENCE].fNullable = TRUE;
 
     static DWORD rgdwUserProductIndex1[] = { PRODUCT_ID };
     static DWORD rgdwUserProductIndex2[] = { PRODUCT_NAME, PRODUCT_VERSION, PRODUCT_PUBLICKEY };

--- a/src/SettingsEngine/lib/database.cpp
+++ b/src/SettingsEngine/lib/database.cpp
@@ -392,7 +392,7 @@ HRESULT DatabaseSetupAdminSchema(
 
     // Set actual table info - this is the 1st interesting bit
     pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].wzName = L"AdminProduct";
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].cColumns = ADMIN_PRODUCT_INDEX_COLUMNS;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].cColumns = PRODUCT_INDEX_COLUMNS;
     pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].cIndexes = 2;
 
     // Allocate 
@@ -414,22 +414,25 @@ HRESULT DatabaseSetupAdminSchema(
         }
     }
 
-    // Set actual column info - this is the other interesting bit
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_ID].wzName = L"ID";
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_ID].dbtColumnType = DBTYPE_I4;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_ID].fAutoIncrement = TRUE;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_ID].fPrimaryKey = TRUE;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_NAME].wzName = L"Name";
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_NAME].dbtColumnType = DBTYPE_WSTR;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_VERSION].wzName = L"Version";
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_VERSION].dbtColumnType = DBTYPE_WSTR;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_VERSION].dwLength = 24;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_PUBLICKEY].wzName = L"PublicKey";
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_PUBLICKEY].dbtColumnType = DBTYPE_WSTR;
-    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[ADMIN_PRODUCT_PUBLICKEY].dwLength = 20;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_ID].wzName = L"ID";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_ID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_ID].fAutoIncrement = TRUE;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_ID].fPrimaryKey = TRUE;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_NAME].wzName = L"Name";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_NAME].dbtColumnType = DBTYPE_WSTR;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_VERSION].wzName = L"Version";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_VERSION].dbtColumnType = DBTYPE_WSTR;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_VERSION].dwLength = 24;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_PUBLICKEY].wzName = L"PublicKey";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_PUBLICKEY].dbtColumnType = DBTYPE_WSTR;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_PUBLICKEY].dwLength = 20;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_REGISTERED].wzName = L"Installed";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_REGISTERED].dbtColumnType = DBTYPE_BOOL;
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_IS_LEGACY].wzName = L"IsLegacy";
+    pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgColumns[PRODUCT_IS_LEGACY].dbtColumnType = DBTYPE_BOOL;
 
-    static DWORD rgdwAdminProductIndex1[] = { ADMIN_PRODUCT_ID };
-    static DWORD rgdwAdminProductIndex2[] = { ADMIN_PRODUCT_NAME, ADMIN_PRODUCT_VERSION, ADMIN_PRODUCT_PUBLICKEY };
+    static DWORD rgdwAdminProductIndex1[] = { PRODUCT_ID };
+    static DWORD rgdwAdminProductIndex2[] = { PRODUCT_NAME, PRODUCT_VERSION, PRODUCT_PUBLICKEY };
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgIndexes[0], rgdwAdminProductIndex1, L"PrimaryKey");
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgIndexes[1], rgdwAdminProductIndex2, L"Name_Version_PublicKey");
 

--- a/src/SettingsEngine/lib/database.cpp
+++ b/src/SettingsEngine/lib/database.cpp
@@ -103,6 +103,10 @@ HRESULT DatabaseSetupSchema(
     pdsSchema->rgTables[PRODUCT_INDEX_TABLE].cColumns = PRODUCT_INDEX_COLUMNS;
     pdsSchema->rgTables[PRODUCT_INDEX_TABLE].cIndexes = 2;
 
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].wzName = L"ProductDisplayName";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].cColumns = PRODUCT_DISPLAY_NAME_COLUMNS;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].cIndexes = 2;
+
     pdsSchema->rgTables[VALUE_INDEX_TABLE].wzName = L"ValueIndex";
     pdsSchema->rgTables[VALUE_INDEX_TABLE].cColumns = VALUE_INDEX_COLUMNS;
     pdsSchema->rgTables[VALUE_INDEX_TABLE].cIndexes = 1;
@@ -170,6 +174,25 @@ HRESULT DatabaseSetupSchema(
     static DWORD rgdwUserProductIndex2[] = { PRODUCT_NAME, PRODUCT_VERSION, PRODUCT_PUBLICKEY };
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgIndexes[0], rgdwUserProductIndex1, L"PrimaryKey");
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[PRODUCT_INDEX_TABLE].rgIndexes[1], rgdwUserProductIndex2, L"Name_Version_PublicKey");
+
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].wzName = L"ID";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].fAutoIncrement = TRUE;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].fPrimaryKey = TRUE;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].wzName = L"AppID";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].wzRelationName = L"AppID";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dwForeignKeyTable = PRODUCT_INDEX_TABLE;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dwForeignKeyColumn = PRODUCT_ID;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_LCID].wzName = L"LCID";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_LCID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_NAME].wzName = L"Name";
+    pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_NAME].dbtColumnType = DBTYPE_WSTR;
+
+    static DWORD rgdwUserProductDisplayNameIndex1[] = { PRODUCT_DISPLAY_NAME_ID };
+    static DWORD rgdwUserProductDisplayNameIndex2[] = { PRODUCT_DISPLAY_NAME_APPID, PRODUCT_DISPLAY_NAME_LCID };
+    ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgIndexes[0], rgdwUserProductDisplayNameIndex1, L"PrimaryKey");
+    ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[PRODUCT_DISPLAY_NAME_TABLE].rgIndexes[1], rgdwUserProductDisplayNameIndex2, L"AppId_LCID");
 
     pdsSchema->rgTables[VALUE_INDEX_TABLE].rgColumns[VALUE_COMMON_ID].wzName = L"ID";
     pdsSchema->rgTables[VALUE_INDEX_TABLE].rgColumns[VALUE_COMMON_ID].dbtColumnType = DBTYPE_I4;
@@ -392,6 +415,10 @@ HRESULT DatabaseSetupAdminSchema(
     pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].cColumns = PRODUCT_INDEX_COLUMNS;
     pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].cIndexes = 2;
 
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].wzName = L"AdminProductDisplayName";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].cColumns = PRODUCT_DISPLAY_NAME_COLUMNS;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].cIndexes = 2;
+
     // Allocate 
     for (i = 0; i < pdsSchema->cTables; ++i)
     {
@@ -432,6 +459,25 @@ HRESULT DatabaseSetupAdminSchema(
     static DWORD rgdwAdminProductIndex2[] = { PRODUCT_NAME, PRODUCT_VERSION, PRODUCT_PUBLICKEY };
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgIndexes[0], rgdwAdminProductIndex1, L"PrimaryKey");
     ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_INDEX_TABLE].rgIndexes[1], rgdwAdminProductIndex2, L"Name_Version_PublicKey");
+
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].wzName = L"ID";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].fAutoIncrement = TRUE;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_ID].fPrimaryKey = TRUE;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].wzName = L"AppID";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].wzRelationName = L"AppID";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dwForeignKeyTable = PRODUCT_INDEX_TABLE;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_APPID].dwForeignKeyColumn = PRODUCT_ID;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_LCID].wzName = L"LCID";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_LCID].dbtColumnType = DBTYPE_I4;
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_NAME].wzName = L"Name";
+    pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgColumns[PRODUCT_DISPLAY_NAME_NAME].dbtColumnType = DBTYPE_WSTR;
+
+    static DWORD rgdwUserProductDisplayNameIndex1[] = { PRODUCT_DISPLAY_NAME_ID };
+    static DWORD rgdwUserProductDisplayNameIndex2[] = { PRODUCT_DISPLAY_NAME_APPID, PRODUCT_DISPLAY_NAME_LCID };
+    ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgIndexes[0], rgdwUserProductDisplayNameIndex1, L"PrimaryKey");
+    ASSIGN_INDEX_STRUCT(pdsSchema->rgTables[ADMIN_PRODUCT_DISPLAY_NAME_TABLE].rgIndexes[1], rgdwUserProductDisplayNameIndex2, L"AppId_LCID");
 
 LExit:
     return hr;

--- a/src/SettingsEngine/lib/database.h
+++ b/src/SettingsEngine/lib/database.h
@@ -38,17 +38,18 @@ enum USERTABLES
 {
     SUMMARY_DATA_TABLE = 0, // Only has 1 row - stores information global to this user's database
     PRODUCT_INDEX_TABLE = 1, // Associates a particular product name, version and public key with an ID number. This number is guaranteed unique within one user's DB, but isn't necessarily the same in another user's DB.
-    VALUE_INDEX_TABLE = 2, // Stores user data
-    VALUE_INDEX_HISTORY_TABLE = 3, // Stores user data history
-    BINARY_CONTENT_TABLE = 4, // Stores user blobs
-    DATABASE_GUID_LIST_TABLE = 5, // Associates each database GUID with a unique ID
+    PRODUCT_DISPLAY_NAME_TABLE = 2, // Associates a particular AppID and LCID combination with a displayable string.
+    VALUE_INDEX_TABLE = 3, // Stores user data
+    VALUE_INDEX_HISTORY_TABLE = 4, // Stores user data history
+    BINARY_CONTENT_TABLE = 5, // Stores user blobs
+    DATABASE_GUID_LIST_TABLE = 6, // Associates each database GUID with a unique ID
 
     // User-specific tables
-    DATABASE_INDEX_TABLE = 6, // Remembers databases you may want to connect to
-    USER_TABLES_NUMBER = 7, // not an actual table, just represents the number of tables
+    DATABASE_INDEX_TABLE = 7, // Remembers databases you may want to connect to
+    USER_TABLES_NUMBER = 8, // not an actual table, just represents the number of tables
 
     // Remote-specific tables
-    REMOTE_TABLES_NUMBER = 6 // not an actual table, just represents the number of tables
+    REMOTE_TABLES_NUMBER = 7 // not an actual table, just represents the number of tables
 };
 
 // User column enums
@@ -61,6 +62,15 @@ enum PRODUCT_INDEX_COLUMN
     PRODUCT_REGISTERED = 4,
     PRODUCT_IS_LEGACY = 5,
     PRODUCT_INDEX_COLUMNS = 6
+};
+
+enum PRODUCT_DISPLAY_NAME_COLUMN
+{
+    PRODUCT_DISPLAY_NAME_ID = 0,
+    PRODUCT_DISPLAY_NAME_APPID = 1,
+    PRODUCT_DISPLAY_NAME_LCID = 2,
+    PRODUCT_DISPLAY_NAME_NAME = 3,
+    PRODUCT_DISPLAY_NAME_COLUMNS = 4
 };
 
 // Columns used by both value index and value index history tables
@@ -140,7 +150,8 @@ enum DATABASE_GUID_LIST_COLUMN
 enum ADMINTABLES
 {
     ADMIN_PRODUCT_INDEX_TABLE = 0, // Associates a particular product name, version and public key with an ID number. This number is guaranteed unique within one DB, but isn't necessarily the same in another DB.
-    ADMIN_TABLES_NUMBER = 1 // not an actual table, just represents the number of tables
+    ADMIN_PRODUCT_DISPLAY_NAME_TABLE = 1, // Associates a particular product name, version and public key with an ID number. This number is guaranteed unique within one DB, but isn't necessarily the same in another DB.
+    ADMIN_TABLES_NUMBER = 2 // not an actual table, just represents the number of tables
 };
 
 HRESULT DatabaseGetUserDir(

--- a/src/SettingsEngine/lib/database.h
+++ b/src/SettingsEngine/lib/database.h
@@ -60,8 +60,7 @@ enum PRODUCT_INDEX_COLUMN
     PRODUCT_PUBLICKEY = 3,
     PRODUCT_REGISTERED = 4,
     PRODUCT_IS_LEGACY = 5,
-    PRODUCT_LEGACY_SEQUENCE = 6,
-    PRODUCT_INDEX_COLUMNS = 7
+    PRODUCT_INDEX_COLUMNS = 6
 };
 
 // Columns used by both value index and value index history tables

--- a/src/SettingsEngine/lib/database.h
+++ b/src/SettingsEngine/lib/database.h
@@ -64,15 +64,6 @@ enum PRODUCT_INDEX_COLUMN
     PRODUCT_INDEX_COLUMNS = 7
 };
 
-enum ADMIN_PRODUCT_INDEX_COLUMN
-{
-    ADMIN_PRODUCT_ID = 0,
-    ADMIN_PRODUCT_NAME = 1,
-    ADMIN_PRODUCT_VERSION = 2,
-    ADMIN_PRODUCT_PUBLICKEY = 3,
-    ADMIN_PRODUCT_INDEX_COLUMNS = 4
-};
-
 // Columns used by both value index and value index history tables
 enum VALUE_COMMON_COLUMN
 {

--- a/src/SettingsEngine/lib/dispname.cpp
+++ b/src/SettingsEngine/lib/dispname.cpp
@@ -1,0 +1,291 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="dispname.cpp" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//
+// <summary>
+//    Utilities for interacting with the PRODUCT_DISPLAY_NAME_TABLE
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+#include "precomp.h"
+
+HRESULT DisplayNameLookup(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __in DWORD dwLCID,
+    __out LPWSTR *psczDisplayName
+    )
+{
+    HRESULT hr = S_OK;
+    BOOL fInSceTransaction = FALSE;
+    SCE_QUERY_HANDLE query = NULL;
+    SCE_ROW_HANDLE row = NULL;
+
+    hr = SceBeginQuery(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, 1, &query);
+    ExitOnFailure(hr, "Failed to begin query into display name table");
+
+    hr = SceSetQueryColumnDword(query, dwAppID);
+    ExitOnFailure(hr, "Failed to set query column to appid");
+
+    hr = SceSetQueryColumnDword(query, dwLCID);
+    ExitOnFailure(hr, "Failed to set query column to lcid");
+
+    hr = SceRunQueryExact(&query, &row);
+    if (E_NOTFOUND == hr)
+    {
+        ExitFunction();
+    }
+    else
+    {
+        ExitOnFailure(hr, "Failed to run display name query");
+
+        hr = SceGetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, psczDisplayName);
+        ExitOnFailure(hr, "Failed to get display name");
+    }
+
+LExit:
+    if (fInSceTransaction)
+    {
+        SceRollbackTransaction(pcdb->psceDb);
+    }
+    ReleaseSceQuery(query);
+    ReleaseSceRow(row);
+
+    return hr;
+}
+
+HRESULT DisplayNameEnumerate(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __out DISPLAY_NAME **prgDisplayNames,
+    __out DWORD *pcDisplayNames
+    )
+{
+    HRESULT hr = S_OK;
+    DWORD dwNewItemIndex;
+    SCE_QUERY_RESULTS_HANDLE results = NULL;
+    SCE_QUERY_HANDLE query = NULL;
+    SCE_ROW_HANDLE row = NULL;
+
+    hr = SceBeginQuery(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, 1, &query);
+    ExitOnFailure(hr, "Failed to begin query into display name table");
+
+    hr = SceSetQueryColumnDword(query, dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
+
+    hr = SceRunQueryRange(&query, &results);
+    if (E_NOTFOUND == hr)
+    {
+        ExitFunction1(hr = S_OK);
+    }
+    ExitOnFailure(hr, "Failed to run query");
+
+    *pcDisplayNames = 0;
+
+    hr = SceGetNextResultRow(results, &row);
+    while (E_NOTFOUND != hr)
+    {
+        ExitOnFailure(hr, "Failed to get next result row");
+
+        dwNewItemIndex = *pcDisplayNames;
+        hr = MemEnsureArraySize(reinterpret_cast<void **>(prgDisplayNames), *pcDisplayNames + 1, sizeof(DISPLAY_NAME), 0);
+        ExitOnFailure(hr, "Failed to ensure display name array size");
+        ++(*pcDisplayNames);
+
+        hr = SceGetColumnDword(row, PRODUCT_DISPLAY_NAME_LCID, &(*prgDisplayNames)[dwNewItemIndex].dwLCID);
+        ExitOnFailure(hr, "Failed to get display name lcid");
+
+        hr = SceGetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, &(*prgDisplayNames)[dwNewItemIndex].sczName);
+        ExitOnFailure(hr, "Failed to get display name");
+
+        ReleaseNullSceRow(row);
+        hr = SceGetNextResultRow(results, &row);
+    }
+    hr = S_OK;
+
+LExit:
+    ReleaseSceQuery(query);
+    ReleaseSceQueryResults(results);
+    ReleaseSceRow(row);
+
+    return hr;
+}
+
+HRESULT DisplayNameAny(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __out DWORD *pdwLCID,
+    __out LPWSTR *psczDisplayName
+    )
+{
+    HRESULT hr = S_OK;
+    BOOL fInSceTransaction = FALSE;
+    SCE_QUERY_HANDLE query = NULL;
+    SCE_ROW_HANDLE row = NULL;
+
+    hr = SceBeginQuery(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, 1, &query);
+    ExitOnFailure(hr, "Failed to begin query into display name table");
+
+    hr = SceSetQueryColumnDword(query, dwAppID);
+    ExitOnFailure(hr, "Failed to set query column to appid");
+
+    hr = SceRunQueryExact(&query, &row);
+    if (E_NOTFOUND == hr)
+    {
+        ExitFunction();
+    }
+    else
+    {
+        ExitOnFailure(hr, "Failed to run lcid-neutral display name query");
+
+        hr = SceGetColumnDword(row, PRODUCT_DISPLAY_NAME_LCID, pdwLCID);
+        ExitOnFailure(hr, "Failed to get LCID");
+
+        hr = SceGetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, psczDisplayName);
+        ExitOnFailure(hr, "Failed to get display name");
+    }
+
+LExit:
+    if (fInSceTransaction)
+    {
+        SceRollbackTransaction(pcdb->psceDb);
+    }
+    ReleaseSceQuery(query);
+    ReleaseSceRow(row);
+
+    return hr;
+}
+
+HRESULT DisplayNamePersist(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __in DWORD dwLCID,
+    __in LPCWSTR wzDisplayName
+    )
+{
+    HRESULT hr = S_OK;
+    LPWSTR sczDisplayName = NULL;
+    BOOL fInSceTransaction = FALSE;
+    SCE_QUERY_HANDLE query = NULL;
+    SCE_ROW_HANDLE row = NULL;
+
+    hr = SceBeginQuery(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, 1, &query);
+    ExitOnFailure(hr, "Failed to begin query into display name table");
+
+    hr = SceSetQueryColumnDword(query, dwAppID);
+    ExitOnFailure(hr, "Failed to set query column to appid");
+
+    hr = SceSetQueryColumnDword(query, dwLCID);
+    ExitOnFailure(hr, "Failed to set query column to lcid");
+
+    hr = SceRunQueryExact(&query, &row);
+    if (E_NOTFOUND == hr)
+    {
+        hr = S_OK;
+
+        hr = SceBeginTransaction(pcdb->psceDb);
+        ExitOnFailure(hr, "Failed to start transaction");
+        fInSceTransaction = TRUE;
+
+        hr = ScePrepareInsert(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, &row);
+        ExitOnFailure(hr, "Failed to prepare insert");
+
+        hr = SceSetColumnDword(row, PRODUCT_DISPLAY_NAME_APPID, dwAppID);
+        ExitOnFailure(hr, "Failed to set display name");
+
+        hr = SceSetColumnDword(row, PRODUCT_DISPLAY_NAME_LCID, dwLCID);
+        ExitOnFailure(hr, "Failed to set display name");
+
+        hr = SceSetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, wzDisplayName);
+        ExitOnFailure(hr, "Failed to set display name");
+
+        hr = SceFinishUpdate(row);
+        ExitOnFailure(hr, "Failed to finish insert");
+
+        hr = SceCommitTransaction(pcdb->psceDb);
+        ExitOnFailure(hr, "Failed to commit transaction");
+        fInSceTransaction = FALSE;
+    }
+    else
+    {
+        ExitOnFailure(hr, "Failed to run display name query");
+
+        hr = SceGetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, &sczDisplayName);
+        ExitOnFailure(hr, "Failed to get display name");
+
+        // If the strings are not identical, update to the desired value
+        if (CSTR_EQUAL != ::CompareStringW(LOCALE_INVARIANT, 0, sczDisplayName, -1, wzDisplayName, -1))
+        {
+            hr = SceBeginTransaction(pcdb->psceDb);
+            ExitOnFailure(hr, "Failed to start transaction");
+            fInSceTransaction = TRUE;
+
+            hr = SceSetColumnString(row, PRODUCT_DISPLAY_NAME_NAME, wzDisplayName);
+            ExitOnFailure(hr, "Failed to set display name");
+
+            hr = SceCommitTransaction(pcdb->psceDb);
+            ExitOnFailure(hr, "Failed to commit transaction");
+            fInSceTransaction = FALSE;
+        }
+    }
+
+LExit:
+    if (fInSceTransaction)
+    {
+        SceRollbackTransaction(pcdb->psceDb);
+    }
+    ReleaseStr(sczDisplayName);
+    ReleaseSceQuery(query);
+    ReleaseSceRow(row);
+
+    return hr;
+}
+
+HRESULT DisplayNameRemoveAllForAppID(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID
+    )
+{
+    HRESULT hr = S_OK;
+    SCE_QUERY_RESULTS_HANDLE results = NULL;
+    SCE_QUERY_HANDLE query = NULL;
+    SCE_ROW_HANDLE row = NULL;
+
+    hr = SceBeginQuery(pcdb->psceDb, PRODUCT_DISPLAY_NAME_TABLE, 0, &query);
+    ExitOnFailure(hr, "Failed to begin query into display name table");
+
+    hr = SceSetQueryColumnDword(query, dwAppID);
+    ExitOnFailure(hr, "Failed to set query column dword to: %u", pcdb->dwAppID);
+
+    hr = SceRunQueryRange(&query, &results);
+    if (E_NOTFOUND == hr)
+    {
+        ExitFunction1(hr = S_OK);
+    }
+    ExitOnFailure(hr, "Failed to run query");
+
+    hr = SceGetNextResultRow(results, &row);
+    while (E_NOTFOUND != hr)
+    {
+        ExitOnFailure(hr, "Failed to get next result row");
+
+        hr = SceDeleteRow(&row);
+        ExitOnFailure(hr, "Failed to delete row");
+
+        ReleaseNullSceRow(row);
+        hr = SceGetNextResultRow(results, &row);
+    }
+    hr = S_OK;
+
+LExit:
+    ReleaseSceQuery(query);
+    ReleaseSceQueryResults(results);
+    ReleaseSceRow(row);
+
+    return hr;
+}
+

--- a/src/SettingsEngine/lib/dispname.cpp
+++ b/src/SettingsEngine/lib/dispname.cpp
@@ -13,6 +13,19 @@
 
 #include "precomp.h"
 
+void DisplayNameArrayFree(
+    __in DISPLAY_NAME *rgDisplayNames,
+    __in DWORD cDisplayNames
+    )
+{
+    for (DWORD i = 0; i < cDisplayNames; ++i)
+    {
+        ReleaseDisplayName(rgDisplayNames[i]);
+    }
+
+    ReleaseMem(rgDisplayNames);
+}
+
 HRESULT DisplayNameLookup(
     __in CFGDB_STRUCT *pcdb,
     __in DWORD dwAppID,

--- a/src/SettingsEngine/lib/dispname.h
+++ b/src/SettingsEngine/lib/dispname.h
@@ -19,8 +19,13 @@ extern "C" {
 #endif
 
 #define ReleaseDisplayName(x) { ReleaseStr(x.sczName); }
-#define ReleaseDisplayNameArray(rg, c) { if (rg) { for (DWORD i = 0; i < c; ++i) { ReleaseDisplayName(rg[i]); } } ReleaseMem(rg); }
+#define ReleaseDisplayNameArray(rg, c) { if (rg) { DisplayNameArrayFree(rg, c); } }
 
+
+void DisplayNameArrayFree(
+    __in DISPLAY_NAME *rgDisplayNames,
+    __in DWORD cDisplayNames
+    );
 HRESULT DisplayNameLookup(
     __in CFGDB_STRUCT *pcdb,
     __in DWORD dwAppID,

--- a/src/SettingsEngine/lib/dispname.h
+++ b/src/SettingsEngine/lib/dispname.h
@@ -21,12 +21,6 @@ extern "C" {
 #define ReleaseDisplayName(x) { ReleaseStr(x.sczName); }
 #define ReleaseDisplayNameArray(rg, c) { if (rg) { for (DWORD i = 0; i < c; ++i) { ReleaseDisplayName(rg[i]); } } ReleaseMem(rg); }
 
-struct DISPLAY_NAME
-{
-    LPWSTR sczName;
-    DWORD dwLCID;
-};
-
 HRESULT DisplayNameLookup(
     __in CFGDB_STRUCT *pcdb,
     __in DWORD dwAppID,

--- a/src/SettingsEngine/lib/dispname.h
+++ b/src/SettingsEngine/lib/dispname.h
@@ -1,0 +1,61 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="dispname.h" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+//    Utilities for interacting with the PRODUCT_DISPLAY_NAME_TABLE
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ReleaseDisplayName(x) { ReleaseStr(x.sczName); }
+#define ReleaseDisplayNameArray(rg, c) { if (rg) { for (DWORD i = 0; i < c; ++i) { ReleaseDisplayName(rg[i]); } } ReleaseMem(rg); }
+
+struct DISPLAY_NAME
+{
+    LPWSTR sczName;
+    DWORD dwLCID;
+};
+
+HRESULT DisplayNameLookup(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __in DWORD dwLCID,
+    __out LPWSTR *psczDisplayName
+    );
+HRESULT DisplayNameEnumerate(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __out DISPLAY_NAME **prgDisplayNames,
+    __out DWORD *pcDisplayNames
+    );
+HRESULT DisplayNameAny(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __out DWORD *pdwLCID,
+    __out LPWSTR *psczDisplayName
+    );
+HRESULT DisplayNamePersist(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID,
+    __in DWORD dwLCID,
+    __in LPCWSTR wzDisplayName
+    );
+HRESULT DisplayNameRemoveAllForAppID(
+    __in CFGDB_STRUCT *pcdb,
+    __in DWORD dwAppID
+    );
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/SettingsEngine/lib/enum.cpp
+++ b/src/SettingsEngine/lib/enum.cpp
@@ -23,6 +23,7 @@ HRESULT EnumResize(
     size_t cbPointerSize = 0;
     size_t cbConfigValueSize = 0;
     size_t cbBoolSize = 0;
+    size_t cbDwordSize = 0;
 
     // If we're shrinking, release strings before we actually resize the arrays, losing the pointers
     if (dwNewSize < pcesEnum->dwNumValues)
@@ -43,6 +44,7 @@ HRESULT EnumResize(
                 ReleaseStr(pcesEnum->products.rgsczName[i]);
                 ReleaseStr(pcesEnum->products.rgsczVersion[i]);
                 ReleaseStr(pcesEnum->products.rgsczPublicKey[i]);
+                ReleaseDisplayNameArray(pcesEnum->products.rgrgDisplayNames[i], pcesEnum->products.rgcDisplayNames[i]);
             }
             break;
 
@@ -82,6 +84,8 @@ HRESULT EnumResize(
             ReleaseNullMem(pcesEnum->products.rgsczName);
             ReleaseNullMem(pcesEnum->products.rgsczVersion);
             ReleaseNullMem(pcesEnum->products.rgsczPublicKey);
+            ReleaseNullMem(pcesEnum->products.rgrgDisplayNames);
+            ReleaseNullMem(pcesEnum->products.rgcDisplayNames);
             ReleaseNullMem(pcesEnum->products.rgfRegistered);
             break;
 
@@ -112,6 +116,9 @@ HRESULT EnumResize(
     hr = ::SizeTMult(dwNewSize, sizeof(BOOL), &(cbBoolSize));
     ExitOnFailure(hr, "Maximum allocation of datatype array exceeded (BOOL).");
 
+    hr = ::SizeTMult(dwNewSize, sizeof(DWORD), &(cbDwordSize));
+    ExitOnFailure(hr, "Maximum allocation of datatype array exceeded (DWORD).");
+
     // If it's a new struct, call memalloc
     if (0 == pcesEnum->dwMaxValues)
     {
@@ -133,6 +140,12 @@ HRESULT EnumResize(
 
             pcesEnum->products.rgsczPublicKey = static_cast<LPWSTR *>(MemAlloc(cbPointerSize, TRUE));
             ExitOnNull(pcesEnum->products.rgsczPublicKey, hr, E_OUTOFMEMORY, "Failed to allocate public key array for product type Cfg Enumeration Struct");
+
+            pcesEnum->products.rgrgDisplayNames = static_cast<DISPLAY_NAME **>(MemAlloc(cbPointerSize, TRUE));
+            ExitOnNull(pcesEnum->products.rgrgDisplayNames, hr, E_OUTOFMEMORY, "Failed to allocate display name array of arrays for product type Cfg Enumeration Struct");
+
+            pcesEnum->products.rgcDisplayNames = static_cast<DWORD *>(MemAlloc(cbDwordSize, TRUE));
+            ExitOnNull(pcesEnum->products.rgrgDisplayNames, hr, E_OUTOFMEMORY, "Failed to allocate display name array of counts for product type Cfg Enumeration Struct");
 
             pcesEnum->products.rgfRegistered = static_cast<BOOL *>(MemAlloc(cbBoolSize, TRUE));
             ExitOnNull(pcesEnum->products.rgfRegistered, hr, E_OUTOFMEMORY, "Failed to allocate registered flag array for product type Cfg Enumeration Struct");
@@ -179,6 +192,12 @@ HRESULT EnumResize(
 
             pcesEnum->products.rgsczPublicKey = static_cast<LPWSTR *>(MemReAlloc(pcesEnum->products.rgsczPublicKey, cbPointerSize, TRUE));
             ExitOnNull(pcesEnum->products.rgsczPublicKey, hr, E_OUTOFMEMORY, "Failed to reallocate public key array for product type Cfg Enumeration Struct");
+
+            pcesEnum->products.rgrgDisplayNames = static_cast<DISPLAY_NAME **>(MemReAlloc(pcesEnum->products.rgrgDisplayNames, cbPointerSize, TRUE));
+            ExitOnNull(pcesEnum->products.rgrgDisplayNames, hr, E_OUTOFMEMORY, "Failed to reallocate display name array of arrays for product type Cfg Enumeration Struct");
+
+            pcesEnum->products.rgcDisplayNames = static_cast<DWORD *>(MemReAlloc(pcesEnum->products.rgcDisplayNames, cbDwordSize, TRUE));
+            ExitOnNull(pcesEnum->products.rgrgDisplayNames, hr, E_OUTOFMEMORY, "Failed to reallocate display name array of counts for product type Cfg Enumeration Struct");
 
             pcesEnum->products.rgfRegistered = static_cast<BOOL *>(MemReAlloc(pcesEnum->products.rgfRegistered, cbBoolSize, TRUE));
             ExitOnNull(pcesEnum->products.rgfRegistered, hr, E_OUTOFMEMORY, "Failed to allocate registered flag array for product type Cfg Enumeration Struct");

--- a/src/SettingsEngine/lib/enum.h
+++ b/src/SettingsEngine/lib/enum.h
@@ -44,6 +44,8 @@ struct CFG_ENUMERATION
             LPWSTR *rgsczName;
             LPWSTR *rgsczVersion;
             LPWSTR *rgsczPublicKey;
+            DISPLAY_NAME **rgrgDisplayNames;
+            DWORD *rgcDisplayNames;
             BOOL *rgfRegistered;
         } products;
         struct

--- a/src/SettingsEngine/lib/inc/cfgapi.h
+++ b/src/SettingsEngine/lib/inc/cfgapi.h
@@ -98,6 +98,12 @@ struct CONFLICT_PRODUCT
     DWORD cValues;
 };
 
+struct DISPLAY_NAME
+{
+    LPWSTR sczName;
+    DWORD dwLCID;
+};
+
 enum BACKGROUND_STATUS_TYPE
 {
     BACKGROUND_STATUS_INVALID = 0,
@@ -327,6 +333,12 @@ HRESULT CFGAPI CfgEnumReadBinary(
     __in CFG_ENUM_DATA cedData,
     __deref_out_bcount(*piBuffer) BYTE** ppbBuffer,
     __inout SIZE_T* piBuffer
+    );
+HRESULT CFGAPI CfgEnumReadDisplayNameArray(
+    __in_bcount(CFG_ENUMERATION_HANDLE_BYTES) C_CFG_ENUMERATION_HANDLE cehHandle,
+    __in DWORD dwIndex,
+    __out DISPLAY_NAME **prgDisplayNames,
+    __out DWORD *pcDisplayNames
     );
 
 void CFGAPI CfgReleaseEnumeration(

--- a/src/SettingsEngine/lib/inc/cfgapi.h
+++ b/src/SettingsEngine/lib/inc/cfgapi.h
@@ -78,11 +78,20 @@ enum RESOLUTION_CHOICE
     RESOLUTION_REMOTE
 };
 
+struct DISPLAY_NAME
+{
+    LPWSTR sczName;
+    DWORD dwLCID;
+};
+
 struct CONFLICT_PRODUCT
 {
     LPWSTR sczProductName;
     LPWSTR sczVersion;
     LPWSTR sczPublicKey;
+
+    DISPLAY_NAME *rgDisplayNames;
+    DWORD cDisplayNames;
 
     // An enumeration just like what is returned from CfgEnumPastValues, but only contains conflicting values in local store
     CFG_ENUMERATION_HANDLE *rgcesValueEnumLocal;
@@ -96,12 +105,6 @@ struct CONFLICT_PRODUCT
 
     // This is the number of conflicting values for the product. This is also the array size for both rgcesValueEnumLocal, rgcesValueEnumRemote, and rgrcValueChoices
     DWORD cValues;
-};
-
-struct DISPLAY_NAME
-{
-    LPWSTR sczName;
-    DWORD dwLCID;
 };
 
 enum BACKGROUND_STATUS_TYPE

--- a/src/SettingsEngine/lib/manifest.h
+++ b/src/SettingsEngine/lib/manifest.h
@@ -21,6 +21,9 @@ extern "C" {
 #include "inc\cfgapi.h"
 #include "detect.h"
 
+#define ReleaseDisplayName(x) { ReleaseStr(x.sczName); }
+#define ReleaseDisplayNameArray(rg, c) { if (rg) { for (DWORD i = 0; i < c; ++i) { ReleaseDisplayName(rg[i]); } } ReleaseMem(rg); }
+
 struct LEGACY_SYNC_PRODUCT_SESSION;
 
 const DWORD CfgLegacyDbRegistryRootClassesRoot = 0;
@@ -113,12 +116,6 @@ struct LEGACY_FILE
     DWORD cFileSpecials;
 };
 
-struct LEGACY_DISPLAYNAME
-{
-    LPWSTR sczName;
-    DWORD dwLCID;
-};
-
 struct LEGACY_VALUE_FILTER
 {
     LPWSTR sczExactName;
@@ -150,7 +147,7 @@ struct LEGACY_PRODUCT
     LEGACY_VALUE_FILTER *rgFilters;
     DWORD cFilters;
 
-    LEGACY_DISPLAYNAME *rgDisplayNames;
+    DISPLAY_NAME *rgDisplayNames;
     DWORD cDisplayNames;
 };
 

--- a/src/SettingsEngine/lib/manifest.h
+++ b/src/SettingsEngine/lib/manifest.h
@@ -21,9 +21,6 @@ extern "C" {
 #include "inc\cfgapi.h"
 #include "detect.h"
 
-#define ReleaseDisplayName(x) { ReleaseStr(x.sczName); }
-#define ReleaseDisplayNameArray(rg, c) { if (rg) { for (DWORD i = 0; i < c; ++i) { ReleaseDisplayName(rg[i]); } } ReleaseMem(rg); }
-
 struct LEGACY_SYNC_PRODUCT_SESSION;
 
 const DWORD CfgLegacyDbRegistryRootClassesRoot = 0;

--- a/src/SettingsEngine/lib/parse.cpp
+++ b/src/SettingsEngine/lib/parse.cpp
@@ -1177,7 +1177,7 @@ HRESULT ParseDisplayName(
     ExitOnFailure(hr, "Failed to get text from DisplayName element");
 
     ++pProduct->cDisplayNames;
-    hr = MemEnsureArraySize(reinterpret_cast<void **>(&pProduct->rgDisplayNames), pProduct->cDisplayNames, sizeof(LEGACY_DISPLAYNAME), 5);
+    hr = MemEnsureArraySize(reinterpret_cast<void **>(&pProduct->rgDisplayNames), pProduct->cDisplayNames, sizeof(DISPLAY_NAME), 5);
     ExitOnFailure(hr, "Failed to resize displayname array");
 
     pProduct->rgDisplayNames[pProduct->cDisplayNames-1].dwLCID = dwLCID;

--- a/src/SettingsEngine/lib/precomp.h
+++ b/src/SettingsEngine/lib/precomp.h
@@ -14,9 +14,6 @@
 #pragma once
 
 #define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
 
 #include <windows.h>
 #include <stdlib.h>

--- a/src/SettingsEngine/lib/precomp.h
+++ b/src/SettingsEngine/lib/precomp.h
@@ -55,6 +55,7 @@
 #include "testhook.h"
 #include "handle.h"
 #include "dblist.h"
+#include "dispname.h"
 #include "manifest.h"
 #include "parse.h"
 #include "mapdata.h"

--- a/src/SettingsEngine/lib/product.cpp
+++ b/src/SettingsEngine/lib/product.cpp
@@ -417,9 +417,6 @@ HRESULT ProductEnsureCreated(
         hr = SceSetColumnBool(sceRow, PRODUCT_IS_LEGACY, fLegacyProduct);
         ExitOnFailure(hr, "Failed to set IsLegacy column");
 
-        hr = SceSetColumnNull(sceRow, PRODUCT_LEGACY_SEQUENCE);
-        ExitOnFailure(hr, "Failed to set ProductLegacySequence column");
-
         hr = SceFinishUpdate(sceRow);
         ExitOnFailure(hr, "Failed to finish insert");
 

--- a/src/burn/engine/precomp.h
+++ b/src/burn/engine/precomp.h
@@ -15,9 +15,6 @@
 
 
 #define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
-#define ExitTrace LogErrorString
 
 #include <wixver.h>
 


### PR DESCRIPTION
The big change is to show the displayname of a product instead of its internal ID. Also some refactoring along the way, and also instead of showing "loading..." whenever the worker thread is refreshing a listview, just show the most recent result (even if it's outdated) until the new result is available. This makes the UI feel more responsive.
