### PR TITLE
Move MsiProperty check from ProcessMsiPackageCommand to the compiler …

### DIFF
--- a/history/5294.md
+++ b/history/5294.md
@@ -1,0 +1,2 @@
+* @barnson: Fix WIXBUG:5294 - Move MsiProperty check from 
+  ProcessMsiPackageCommand to the compiler for the earliest feedback.

--- a/src/tools/wix/Bind/Bundles/ProcessMsiPackageCommand.cs
+++ b/src/tools/wix/Bind/Bundles/ProcessMsiPackageCommand.cs
@@ -120,8 +120,6 @@ namespace WixToolset.Bind.Bundles
 
                     ISet<string> msiPropertyNames = this.GetMsiPropertyNames();
 
-                    this.VerifyMsiProperties(msiPropertyNames);
-
                     this.SetPerMachineAppropriately(db, sourcePath);
 
                     // Ensure the MSI package is appropriately marked visible or not.
@@ -174,20 +172,6 @@ namespace WixToolset.Bind.Bundles
                 .Select(r => r.Name);
 
             return new HashSet<string>(properties, StringComparer.Ordinal);
-        }
-
-        /// <summary>
-        /// Verifies that only allowed properties are passed to the MSI.
-        /// </summary>
-        private void VerifyMsiProperties(ISet<string> existingMsiProperties)
-        {
-            foreach (string disallowed in new string[] { "ACTION", "ALLUSERS", "REBOOT", "REINSTALL", "REINSTALLMODE" })
-            {
-                if (existingMsiProperties.Contains(disallowed))
-                {
-                    Messaging.Instance.OnMessage(WixErrors.DisallowedMsiProperty(this.Facade.Package.SourceLineNumbers, disallowed));
-                }
-            }
         }
 
         private void SetPerMachineAppropriately(Dtf.Database db, string sourcePath)

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -20185,7 +20185,7 @@ namespace WixToolset
                     switch (attrib.Name.LocalName)
                     {
                         case "Name":
-                            name = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            name = this.core.GetAttributeMsiPropertyNameValue(sourceLineNumbers, attrib);
                             break;
                         case "Value":
                             value = this.core.GetAttributeValue(sourceLineNumbers, attrib);

--- a/src/tools/wix/CompilerCore.cs
+++ b/src/tools/wix/CompilerCore.cs
@@ -124,6 +124,20 @@ namespace WixToolset
                 "WixBundleVersion",
             });
 
+        private static readonly List<string> DisallowedMsiProperties = new List<string>(
+            new string[] {
+                "ACTION",
+                "ADDLOCAL",
+                "ADDSOURCE",
+                "ADDDEFAULT",
+                "ADVERTISE",
+                "ALLUSERS",
+                "REBOOT",
+                "REINSTALL",
+                "REINSTALLMODE",
+                "REMOVE"
+            });
+
         private TableDefinitionCollection tableDefinitions;
         private Dictionary<XNamespace, ICompilerExtension> extensions;
         private Intermediate intermediate;
@@ -1396,6 +1410,29 @@ namespace WixToolset
                 {
                     string illegalValues = CompilerCore.CreateValueList(ValueListKind.Or, CompilerCore.BuiltinBundleVariables);
                     this.OnMessage(WixErrors.IllegalAttributeValueWithIllegalList(sourceLineNumbers, attribute.Parent.Name.LocalName, attribute.Name.LocalName, value, illegalValues));
+                }
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Gets an MsiProperty name value and displays an error for an illegal value.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Source line information about the owner element.</param>
+        /// <param name="attribute">The attribute containing the value to get.</param>
+        /// <returns>The attribute's value.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes")]
+        public string GetAttributeMsiPropertyNameValue(SourceLineNumber sourceLineNumbers, XAttribute attribute)
+        {
+            string value = this.GetAttributeValue(sourceLineNumbers, attribute);
+
+            if (0 < value.Length)
+            {
+                if (CompilerCore.DisallowedMsiProperties.Contains(value))
+                {
+                    string illegalValues = CompilerCore.CreateValueList(ValueListKind.Or, CompilerCore.DisallowedMsiProperties);
+                    this.OnMessage(WixErrors.DisallowedMsiProperty(sourceLineNumbers, value, illegalValues));
                 }
             }
 

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -2808,8 +2808,9 @@
       </Message>
       <Message Id="DisallowedMsiProperty" Number="365">
         <Instance>
-          The '{0}' MsiProperty is controlled by the bootstrapper and cannot be authored. Remove the MsiProperty element.
+          The '{0}' MsiProperty is controlled by the bootstrapper and cannot be authored. (Illegal properties are: {1}.) Remove the MsiProperty element.
           <Parameter Type="System.String" Name="property" />
+          <Parameter Type="System.String" Name="illegalValueList" />
         </Instance>
       </Message>
       <Message Id="MissingOrInvalidModuleInstallerVersion" Number="366">


### PR DESCRIPTION
…for the earliest feedback.

```
Fixes wixtoolset/issues#5294.
```
