### PR TITLE
Fix dependency bug where custom keys were skipped

### DIFF
--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -188,6 +188,8 @@ extern "C" HRESULT DependencyDetectProviderKeyPackageId(
             continue;
         }
         ExitOnFailure(hr, "Failed to get the package provider information.");
+
+        ExitFunction();
     }
 
     // Older bundles may not have written the id so try the default.


### PR DESCRIPTION
I'm not 100% confident in this one, but I needed this when testing the CompatibleMsiPackage events with a custom provider key in the MSI.
