### PR TITLE
﻿Add tooltip support to ThmUtil

### DIFF
--- a/history/5412.md
+++ b/history/5412.md
@@ -1,0 +1,3 @@
+* @barnson: Implement wixtoolset/issues#5412: Add tooltips to ThmUtil
+  - New Tooltip element as a child of a control element.
+  - Add ThemeShowControlEx to make it easy to "poke" a control, to refresh its content based on variables and conditions.

--- a/src/libs/dutil/inc/thmutil.h
+++ b/src/libs/dutil/inc/thmutil.h
@@ -141,6 +141,7 @@ struct THEME_CONTROL
 
     LPWSTR sczName; // optional name for control, used to apply control id and link the control to a variable.
     LPWSTR sczText;
+    LPWSTR sczTooltip;
     LPWSTR sczNote; // optional text for command link
     int nX;
     int nY;
@@ -280,6 +281,7 @@ struct THEME
     HWND hwndParent; // parent for loaded controls
     HWND hwndHover; // current hwnd hovered over
     DWORD dwCurrentPageId;
+    HWND hwndTooltip;
 
     // callback functions
     PFNTHM_EVALUATE_VARIABLE_CONDITION pfnEvaluateCondition;
@@ -540,6 +542,17 @@ DAPI_(void) ThemeControlElevates(
 
  *******************************************************************/
 DAPI_(void) ThemeShowControl(
+    __in THEME* pTheme,
+    __in DWORD dwControl,
+    __in int nCmdShow
+    );
+
+/********************************************************************
+ThemeShowControlEx - shows/hides a control with support for 
+conditional text and notes.
+
+*******************************************************************/
+DAPI_(void) ThemeShowControlEx(
     __in THEME* pTheme,
     __in DWORD dwControl,
     __in int nCmdShow

--- a/src/libs/dutil/xsd/thmutil.xsd
+++ b/src/libs/dutil/xsd/thmutil.xsd
@@ -271,6 +271,7 @@
                 <xs:element ref="ChangePageAction" />
                 <xs:element ref="CloseWindowAction" />
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -401,6 +402,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -553,6 +555,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -594,6 +597,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -661,6 +665,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="Center" type="YesNoType" use="optional">
@@ -808,6 +813,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -859,6 +865,7 @@
             </xs:annotation>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="Text" />
+                <xs:element ref="Tooltip" maxOccurs="1" />
             </xs:choice>
             <xs:attributeGroup ref="CommonControlAttributes" />
             <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
@@ -952,6 +959,25 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                </xs:extension>                
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Tooltip">
+        <xs:annotation>
+            <xs:documentation>
+                Defines text for the parent control's tooltip.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Text for the parent control's tooltip.
+                        </xs:documentation>
+                    </xs:annotation>
                 </xs:extension>
             </xs:simpleContent>
         </xs:complexType>


### PR DESCRIPTION
- New Tooltip element as a child of a control element.
- Add ThemeShowControlEx to make it easy to "poke" a control, to refresh its content based on variables and conditions.
