### PR TITLE
Stop using deprecated copy of FILETIME

### DIFF
--- a/src/tools/wix/Msi/Interop/MsiInterop.cs
+++ b/src/tools/wix/Msi/Interop/MsiInterop.cs
@@ -5,6 +5,7 @@ namespace WixToolset.Msi.Interop
     using System;
     using System.Text;
     using System.Runtime.InteropServices;
+    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
     /// <summary>
     /// A callback function that the installer calls for progress notification and error messages.

--- a/src/tools/wix/Msi/SummaryInformation.cs
+++ b/src/tools/wix/Msi/SummaryInformation.cs
@@ -8,6 +8,7 @@ namespace WixToolset.Msi
     using System.Globalization;
     using System.Text;
     using System.Runtime.InteropServices;
+    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
     using WixToolset.Msi.Interop;
 
     /// <summary>

--- a/src/tools/wix/Ole32/Storage.cs
+++ b/src/tools/wix/Ole32/Storage.cs
@@ -4,6 +4,8 @@ namespace WixToolset.Ole32
 {
     using System;
     using System.Runtime.InteropServices;
+    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+    using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
 
     /// <summary>
     /// Specifies the access mode to use when opening, creating, or deleting a storage object.


### PR DESCRIPTION
Getting off the deprecated copy of FILETIME in System.Runtime.InteropServices as documented [here](https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.filetime%28v=vs.110%29.aspx).
