### PR TITLE
WIXBUG:5521 - Add BOOTSTRAPPER_ERROR_TYPE_APPLY

### DIFF
--- a/history/5521.md
+++ b/history/5521.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:5521 - Add BOOTSTRAPPER_ERROR_TYPE_APPLY to managed IBootstrapperApplication definition.

--- a/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
@@ -585,6 +585,11 @@ namespace WixToolset.Bootstrapper
         /// The error came while trying to authenticate with an HTTP proxy.
         /// </summary>
         HttpProxyAuthentication,
+
+        /// <summary>
+        /// The error occurred during apply.
+        /// </summary>
+        Apply,
     };
 
     public enum RelatedOperation


### PR DESCRIPTION
 to managed IBootstrapperApplication definition.

Closes wixtoolset/issues#5521