### PR TITLE
resolve an issue identified by cppcheck:

### DIFF
--- a/src/SettingsEngine/lib/cfgapi.cpp
+++ b/src/SettingsEngine/lib/cfgapi.cpp
@@ -2050,19 +2050,20 @@ extern "C" HRESULT CfgResolve(
     }
 
 LExit:
-    LegacySyncUninitializeSession(pcdb->pcdbLocal, &syncSession);
-
-    // Restore the previous AppIDs that were set before resolving began
-    if (fRevertProducts)
+    if (NULL != pcdb)
     {
-        if (NULL != pcdb)
-        {
-            pcdb->dwAppID = dwOriginalAppIDRemote;
-            if (NULL != pcdb->pcdbLocal)
+            LegacySyncUninitializeSession(pcdb->pcdbLocal, &syncSession); 
+
+            // Restore the previous AppIDs that were set before resolving began
+            if (fRevertProducts)
             {
-                pcdb->pcdbLocal->dwAppID = dwOriginalAppIDLocal;
+                pcdb->dwAppID = dwOriginalAppIDRemote;
+                if (NULL != pcdb->pcdbLocal)
+                {
+                    pcdb->pcdbLocal->dwAppID = dwOriginalAppIDLocal;
+                }
             }
-        }
+
     }
 
     if (fLocked)


### PR DESCRIPTION
[src/SettingsEngine/lib/cfgapi.cpp:2053] -> [src/SettingsEngine/lib/cfgapi.cpp:2058]: (warning) Either the condition 'NULL!=pcdb' is redundant or there is possible null pointer dereference: pcdb.