### PR TITLE
updating for long path names

### DIFF
--- a/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
+++ b/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
@@ -1081,9 +1081,20 @@ namespace WixToolset.Extensions
             /// <returns>Short name for file.</returns>
             internal static string GetShortPathName(string fullPath)
             {
-                StringBuilder shortPath = new StringBuilder();
+                int bufSize = (Int32)GetShortPathName(fullPath, null, 0);
+				
+				if (0 == bufSize)
+                {
+                    int err = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                }
+				else
+				{
+					bufSize += 1;
+				}
+				
+				StringBuilder shortPath = new StringBuilder(bufSize);
 
-                uint result = GetShortPathName(fullPath, null, 0);
+                uint result = GetShortPathName(fullPath, shortPath, bufSize);
 
                 if (0 == result)
                 {

--- a/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
+++ b/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
@@ -1074,8 +1074,6 @@ namespace WixToolset.Extensions
         /// </summary>
         private class NativeMethods
         {
-            private const int MaxPath = 255;
-
             /// <summary>
             /// Gets the short name for a file.
             /// </summary>
@@ -1083,9 +1081,9 @@ namespace WixToolset.Extensions
             /// <returns>Short name for file.</returns>
             internal static string GetShortPathName(string fullPath)
             {
-                StringBuilder shortPath = new StringBuilder(MaxPath, MaxPath);
+                StringBuilder shortPath = new StringBuilder();
 
-                uint result = GetShortPathName(fullPath, shortPath, MaxPath);
+                uint result = GetShortPathName(fullPath, null, 0);
 
                 if (0 == result)
                 {

--- a/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
+++ b/src/ext/UtilExtension/wixext/UtilFinalizeHarvesterMutator.cs
@@ -1086,6 +1086,7 @@ namespace WixToolset.Extensions
 				if (0 == bufSize)
                 {
                     int err = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                    throw new System.Runtime.InteropServices.COMException(String.Concat("Failed to get short path buffer size for file: ", fullPath), err);
                 }
 				else
 				{

--- a/src/tools/heat/app.config
+++ b/src/tools/heat/app.config
@@ -8,5 +8,6 @@
     </appSettings>
     <runtime>
         <loadFromRemoteSources enabled="true"/>
+		 <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
     </runtime>
 </configuration>

--- a/src/tools/light/app.config
+++ b/src/tools/light/app.config
@@ -5,5 +5,6 @@
 <configuration>
     <runtime>
         <loadFromRemoteSources enabled="true"/>
+		 <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
     </runtime>
 </configuration>


### PR DESCRIPTION
This is a fix for issue #5314.  It allows users to bypass the issue when calling the utils directly via command line.  When called from wix.dll, however users will have to set  RunWixToolsOutOfProc to true in their .wixproj files, at least for now.  
error LGHT0103 : The system cannot find the file #5314