### PR TITLE
Fix setting binding if the binding protocol not set in WIX source file.

### DIFF
--- a/src/ext/ca/serverca/scasched/scaweb7.cpp
+++ b/src/ext/ca/serverca/scasched/scaweb7.cpp
@@ -828,16 +828,16 @@ static HRESULT ScaWebWrite7(
     }
 
     // set the IP address appropriately
-    if (0 == wcscmp(psw->swaBinding.wzIP, L"*"))
+    if (0 == wcscmp(psw->swaBinding.wzIP, L""))
     {
-        ::ZeroMemory(wzIP, sizeof(wzIP));
+				hr = ::StringCchCopyW(wzIP, countof(wzIP), L"*"); // if no IP specified = add *
     }
     else
     {
 #pragma prefast(suppress:26037, "Source string is null terminated - it is populated as target of ::StringCchCopyW")
-        hr = ::StringCchCopyW(wzIP, countof(wzIP), psw->swaBinding.wzIP);
-        ExitOnFailure(hr, "Failed to copy IP string");
+        hr = ::StringCchCopyW(wzIP, countof(wzIP), psw->swaBinding.wzIP); // else leave untouched
     }
+		ExitOnFailure(hr, "Failed to copy IP string");
 
     hr = ::StringCchPrintfW(wzBinding, countof(wzBinding), L"%s:%d:%s", wzIP, psw->swaBinding.iPort, psw->swaBinding.wzHeader);
     ExitOnFailure(hr, "Failed to format IP:Port:Header binding string");
@@ -849,16 +849,16 @@ static HRESULT ScaWebWrite7(
     for (ui = 0; (ui < MAX_ADDRESSES_PER_WEB) && (ui < psw->cExtraAddresses); ++ui)
     {
         // set the IP address appropriately
-        if (0 == wcscmp(psw->swaExtraAddresses[ui].wzIP, L"*"))
+        if (0 == wcscmp(psw->swaExtraAddresses[ui].wzIP, L""))
         {
-            ::ZeroMemory(wzIP, sizeof(wzIP));
+					hr = ::StringCchCopyW(wzIP, countof(wzIP), L"*"); // if no IP specified = add *
         }
         else
         {
 #pragma prefast(suppress:26037, "Source string is null terminated - it is populated as target of ::StringCchCopyW")
-            hr = ::StringCchCopyW(wzIP, countof(wzIP), psw->swaExtraAddresses[ui].wzIP);
-            ExitOnFailure(hr, "Failed to copy web IP");
+            hr = ::StringCchCopyW(wzIP, countof(wzIP), psw->swaExtraAddresses[ui].wzIP); //else leave untouched
         }
+		ExitOnFailure(hr, "Failed to copy IP string");
         hr = ::StringCchPrintfW(wzBinding, countof(wzBinding), L"%s:%d:%s", wzIP, psw->swaExtraAddresses[ui].iPort, psw->swaExtraAddresses[ui].wzHeader);
         ExitOnFailure(hr, "Failed to copy web IP");
 


### PR DESCRIPTION
This fix adds "*" (star) in IP address to http binding if the address was not specified in source WIX file.