### PR TITLE
WixUI_Advanced: Never install files in [LocalAppDataFolder]

### DIFF
--- a/src/SettingsEngine/manifests/Dins_Curse.udm
+++ b/src/SettingsEngine/manifests/Dins_Curse.udm
@@ -6,7 +6,7 @@
         </Detect>
 
         <Data>
-            <Directory Namespace="Data" Location="LocalAppDataFolder:\DinsCurse">
+            <Directory Namespace="Data" Location="AppDataFolder:\DinsCurse">
                 <CfgFile Namespace="User.cfg" Location="User\user.cfg" Encoding="UTF8NoBOM">
                     <Value Separator=" ">
                        <SeparatorException Prefix="VirtualKey "/>

--- a/src/SettingsEngine/manifests/Drox_Operative.udm
+++ b/src/SettingsEngine/manifests/Drox_Operative.udm
@@ -8,7 +8,7 @@
         </Detect>
 
         <Data>
-            <Directory Namespace="Data" Location="LocalAppDataFolder:\DroxOperative">
+            <Directory Namespace="Data" Location="AppDataFolder:\DroxOperative">
                 <CfgFile Namespace="User.cfg" Location="User\user.cfg" Encoding="UTF8NoBOM">
                     <Value Separator=" ">
                        <SeparatorException Prefix="VirtualKey "/>

--- a/src/SettingsEngine/manifests/SpaceChem.udm
+++ b/src/SettingsEngine/manifests/SpaceChem.udm
@@ -6,7 +6,7 @@
         </Detect>
 
         <Data>
-            <Directory Namespace="Data" Location="LocalAppDataFolder:\Zachtronics Industries\SpaceChem"/>
+            <Directory Namespace="Data" Location="AppDataFolder:\Zachtronics Industries\SpaceChem"/>
         </Data>
 
         <Filter>

--- a/src/chm/documents/wixui/dialog_reference/WixUI_advanced.html.md
+++ b/src/chm/documents/wixui/dialog_reference/WixUI_advanced.html.md
@@ -24,7 +24,7 @@ To use WixUI_Advanced, you must include the following information in your setup 
   
 1. A property with an Id named <b>ApplicationFolderName</b> and a value set to a string that represents the default folder name. This property is used to form the default installation location.
 
-    For a per-machine installation, the default installation location will be [ProgramFilesFolder][ApplicationFolderName] and the user will be able to change it in the setup UI. For a per-user installation, the default installation location will be [LocalAppDataFolder]Apps\[ApplicationFolderName] and the user will not be able to change it in the setup UI.
+    For a per-machine installation, the default installation location will be [ProgramFilesFolder][ApplicationFolderName] and the user will be able to change it in the setup UI. For a per-user installation, the default installation location will be [AppDataFolder]Apps\[ApplicationFolderName] and the user will not be able to change it in the setup UI.
 
     For example:
 

--- a/src/ext/IsolatedAppExtension/wixlib/IsolatedApp.wxs
+++ b/src/ext/IsolatedAppExtension/wixlib/IsolatedApp.wxs
@@ -11,7 +11,7 @@
         <Property Id="TargetComponentId" Value="!(wix.TargetComponentId)"/>
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="LocalAppDataFolder" Name="AppData">
+            <Directory Id="AppDataFolder" Name="AppData">
                 <Directory Id="ApplicationsFolder" Name="Apps">
                     <!--Component Id="ThisApplicationVersionRegistryKeyComponent" Guid="{00000000-0000-0000-0000-000000000000}">
                         <CreateFolder />
@@ -62,10 +62,10 @@
             <ComponentRef Id="SystemApplicationUpdateExeComponent" />
         </Feature>
 
-        <!--CustomAction Id="SetCacheDirectory" Property="ApplicationsCacheFolder" Value="[LocalAppDataFolder]..\Apps\Cache" />
-        <CustomAction Id="SetSystemDirectory" Property="SystemApplicationsFolder" Value="[LocalAppDataFolder]..\Apps\System" />
+        <!--CustomAction Id="SetCacheDirectory" Property="ApplicationsCacheFolder" Value="[AppDataFolder]..\Apps\Cache" />
+        <CustomAction Id="SetSystemDirectory" Property="SystemApplicationsFolder" Value="[AppDataFolder]..\Apps\System" />
         <CustomAction Id="PerMachineDirectory" Property="ApplicationsFolder" Value="[ProgramFilesFolder]" />
-        <CustomAction Id="PerUserDirectory" Property="ApplicationsFolder" Value="[LocalAppDataFolder]..\Apps" /-->
+        <CustomAction Id="PerUserDirectory" Property="ApplicationsFolder" Value="[AppDataFolder]..\Apps" /-->
 
         <CustomAction Id="LaunchNewlyInstalledApp" FileKey="SystemApplicationUpdateExeFile" ExeCommand="-ac [ProductCode]" Return="asyncNoWait" Execute="oncePerProcess" />
 

--- a/src/ext/OfficeExtension/wixlib/OfficeAddin.wxs
+++ b/src/ext/OfficeExtension/wixlib/OfficeAddin.wxs
@@ -42,8 +42,8 @@
         </Feature>
 
         <!--CustomAction Id="PerMachineDirectory" Property="ApplicationsFolder" Value="[ProgramFilesFolder]" />
-        <CustomAction Id="PerUserDirectory" Property="ApplicationsFolder" Value="[LocalAppDataFolder]..\Apps" />
-        <CustomAction Id="SetCacheDirectory" Property="ApplicationsCacheFolder" Value="[LocalAppDataFolder]..\Apps\Cache" /-->
+        <CustomAction Id="PerUserDirectory" Property="ApplicationsFolder" Value="[AppDataFolder]..\Apps" />
+        <CustomAction Id="SetCacheDirectory" Property="ApplicationsCacheFolder" Value="[AppDataFolder]..\Apps\Cache" /-->
 
         <InstallExecuteSequence>
             <!--Custom Action="PerMachineDirectory" After="CostInitialize">Not Installed AND (ALLUSERS=1 OR (Privileged AND ALLUSERS=2))</Custom>

--- a/src/ext/TagExtension/wixlib/TagFolder.wxs
+++ b/src/ext/TagExtension/wixlib/TagFolder.wxs
@@ -12,7 +12,7 @@
             </Directory>
         </DirectoryRef>
 
-        <SetProperty Action="SetWixTagFolderPerUser" Id="WixTagFolder" Value="[LocalAppDataFolder]" Sequence="both" Before="CostFinalize">NOT ALLUSERS</SetProperty>
+        <SetProperty Action="SetWixTagFolderPerUser" Id="WixTagFolder" Value="[AppDataFolder]" Sequence="both" Before="CostFinalize">NOT ALLUSERS</SetProperty>
         <SetProperty Action="SetWixTagFolderPerMachine" Id="WixTagFolder" Value="[CommonAppDataFolder]" Sequence="both" Before="CostFinalize">ALLUSERS</SetProperty>
     </Fragment>
 </Wix>

--- a/src/ext/UIExtension/wixlib/WixUI_Advanced.wxs
+++ b/src/ext/UIExtension/wixlib/WixUI_Advanced.wxs
@@ -29,7 +29,7 @@ Todo:
 
         <PropertyRef Id="ApplicationFolderName" />
 
-        <CustomAction Id="WixSetDefaultPerUserFolder" Property="WixPerUserFolder" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName]" Execute="immediate" />
+        <CustomAction Id="WixSetDefaultPerUserFolder" Property="WixPerUserFolder" Value="[AppDataFolder]Apps\[ApplicationFolderName]" Execute="immediate" />
         <CustomAction Id="WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder" Value="[ProgramFilesFolder][ApplicationFolderName]" Execute="immediate" />
         <CustomAction Id="WixSetPerUserFolder" Property="APPLICATIONFOLDER" Value="[WixPerUserFolder]" Execute="immediate" />
         <CustomAction Id="WixSetPerMachineFolder" Property="APPLICATIONFOLDER" Value="[WixPerMachineFolder]" Execute="immediate" />

--- a/src/tools/ambient/applib/applib.wxs
+++ b/src/tools/ambient/applib/applib.wxs
@@ -9,7 +9,7 @@
         <Media Id="1" Cabinet="cta.cab" EmbedCab="yes" />
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="LocalAppDataFolder" Name="AppData">
+            <Directory Id="AppDataFolder" Name="AppData">
                 <Directory Id="ApplicationsFolder" Name="Applications">
                     <Component Id="ThisApplicationVersionRegistryKeyComponent" Guid="ed6b3460-7774-4917-9619-2e7ca0ca8453">
                         <CreateFolder />
@@ -79,7 +79,7 @@
 
         <CustomAction Id="SpecifiedA" Property="ApplicationFolder" Value="[A]" Execute="immediate" />
         <CustomAction Id="PerMachineInstall" Property="ApplicationFolder" Value="[ProgramFilesFolder]\[ApplicationFolderName]" Execute="immediate" />
-        <CustomAction Id="PerUserInstall" Property="ApplicationFolder" Value="[LocalAppDataFolder]\Apps\[ApplicationFolderName]" Execute="immediate" />
+        <CustomAction Id="PerUserInstall" Property="ApplicationFolder" Value="[AppDataFolder]\Apps\[ApplicationFolderName]" Execute="immediate" />
 
         <InstallUISequence>
             <Custom Action="SpecifiedA" Before="LaunchConditions">NOT Installed</Custom>

--- a/test/data/Burn/DependencyTests/D.wxs
+++ b/test/data/Burn/DependencyTests/D.wxs
@@ -29,7 +29,7 @@
 
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder">
+      <Directory Id="AppDataFolder">
         <Directory Id="WixDir" Name="~Test WiX">
           <Directory Id="TestDir" Name="$(var.TestName)">
             <Directory Id="INSTALLFOLDER" Name="D"/>

--- a/test/data/Burn/DependencyTests/E.wxs
+++ b/test/data/Burn/DependencyTests/E.wxs
@@ -25,7 +25,7 @@
   </Product>
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder">
+      <Directory Id="AppDataFolder">
         <Directory Id="WixDir" Name="~Test WiX">
           <Directory Id="TestDir" Name="$(var.TestName)">
             <Directory Id="INSTALLFOLDER" Name="E" />

--- a/test/data/Burn/ForwardCompatibleTests/C.wxs
+++ b/test/data/Burn/ForwardCompatibleTests/C.wxs
@@ -30,7 +30,7 @@
 
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder">
+      <Directory Id="AppDataFolder">
         <Directory Id="WixDir" Name="~Test WiX">
           <Directory Id="TestDir" Name="$(var.TestName) v$(var.Version)">
             <Directory Id="INSTALLFOLDER" Name="C"/>

--- a/test/data/Burn/UpdateBundleTests/B.wxs
+++ b/test/data/Burn/UpdateBundleTests/B.wxs
@@ -31,7 +31,7 @@
 
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder">
+      <Directory Id="AppDataFolder">
         <Directory Id="WixDir" Name="~Test WiX">
           <Directory Id="TestDir" Name="$(var.TestName)">
             <Directory Id="INSTALLFOLDER" Name="B"/>

--- a/test/data/BurnTestPayloads/Products/PerUserMsi/WixAuthoring/hello_world_non_admin.wxs
+++ b/test/data/BurnTestPayloads/Products/PerUserMsi/WixAuthoring/hello_world_non_admin.wxs
@@ -37,7 +37,7 @@
     <!-- This is a list of directories that are used by this product as installation locations or custom -->
     <!-- action file search locations.                                                                   -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder" Name="AppData">
+      <Directory Id="AppDataFolder" Name="AppData">
         <Directory Id="AppRootDirectory" Name="HelloWorldNonAdmin_Readme"/>
       </Directory>
     </Directory>

--- a/test/data/BurnTestPayloads/Products/PerUserMsiExtCab/WixAuthoring/hello_world_non_admin.wxs
+++ b/test/data/BurnTestPayloads/Products/PerUserMsiExtCab/WixAuthoring/hello_world_non_admin.wxs
@@ -37,7 +37,7 @@
     <!-- This is a list of directories that are used by this product as installation locations or custom -->
     <!-- action file search locations.                                                                   -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="LocalAppDataFolder" Name="AppData">
+      <Directory Id="AppDataFolder" Name="AppData">
         <Directory Id="AppRootDirectory" Name="HelloWorldNonAdmin_Readme_External"/>
       </Directory>
     </Directory>

--- a/test/src/WixTests/Extensions/UIExtension/UIExtension.AdvancedUITests.cs
+++ b/test/src/WixTests/Extensions/UIExtension/UIExtension.AdvancedUITests.cs
@@ -26,7 +26,7 @@ namespace WixTest.Tests.Extensions.UIExtension
             Verifier.VerifyCustomActionTableData(msiFile,
                 new CustomActionTableData("WixUIValidatePath", 65, "WixUIWixca", "ValidatePath"),
                 new CustomActionTableData("WixUIPrintEula", 65, "WixUIWixca", "PrintEula"),
-                new CustomActionTableData("WixSetDefaultPerUserFolder", 51, "WixPerUserFolder", @"[LocalAppDataFolder]Apps\[ApplicationFolderName]"),
+                new CustomActionTableData("WixSetDefaultPerUserFolder", 51, "WixPerUserFolder", @"[AppDataFolder]Apps\[ApplicationFolderName]"),
                 new CustomActionTableData("WixSetDefaultPerMachineFolder", 51, "WixPerMachineFolder", "[ProgramFilesFolder][ApplicationFolderName]"),
                 new CustomActionTableData("WixSetPerUserFolder", 51, "APPLICATIONFOLDER", "[WixPerUserFolder]"),
                 new CustomActionTableData("WixSetPerMachineFolder", 51, "APPLICATIONFOLDER", "[WixPerMachineFolder]"));


### PR DESCRIPTION
As I have seen the serious data loss issue https://sourceforge.net/p/wix/feature-requests/656/ is not fixed, here you get the pull with the fixes

Basic issue is - files in LocalAppDataFolder get deleted in roaming user profiles by a Windows GPO that cleans up user folder on logoff and LocalAppData is typically excluded from roaming for data size reasons. **That means the application gets deleted on user logoff.** More details can be found at https://www.hass.de/content/developers-best-practice-windows-user-profiles.