### PR TITLE
WIXFEAT:5658 - Retry elevation once if we think it failed due to AV

### DIFF
--- a/history/5658.md
+++ b/history/5658.md
@@ -1,0 +1,1 @@
+* ipetrovic11,stukselbax,SeanHall: WIXFEAT:5658 - Retry launching the elevated bundle once if we think it failed due to antivirus interference.

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -508,10 +508,11 @@ extern "C" HRESULT CoreElevate(
     )
 {
     HRESULT hr = S_OK;
+    DWORD cAVRetryAttempts = 0;
 
-    // If the elevated companion pipe isn't created yet, let's make that happen.
-    if (INVALID_HANDLE_VALUE == pEngineState->companionConnection.hPipe)
+    while (INVALID_HANDLE_VALUE == pEngineState->companionConnection.hPipe)
     {
+        // If the elevated companion pipe isn't created yet, let's make that happen.
         if (!pEngineState->sczBundleEngineWorkingPath)
         {
             hr = CacheBundleToWorkingDirectory(pEngineState->registration.sczId, pEngineState->registration.sczExecutableName, &pEngineState->userExperience.payloads, &pEngineState->section, &pEngineState->sczBundleEngineWorkingPath);
@@ -519,6 +520,11 @@ extern "C" HRESULT CoreElevate(
         }
 
         hr = ElevationElevate(pEngineState, hwndParent);
+        if (E_SUSPECTED_AV_INTERFERENCE == hr && 1 > cAVRetryAttempts)
+        {
+            ++cAVRetryAttempts;
+            continue;
+        }
         ExitOnFailure(hr, "Failed to actually elevate.");
 
         hr = VariableSetNumeric(&pEngineState->variables, BURN_BUNDLE_ELEVATED, TRUE, TRUE);

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -291,6 +291,10 @@ extern "C" HRESULT ElevationElevate(
             LogId(REPORT_STANDARD, MSG_LAUNCH_ELEVATED_ENGINE_SUCCESS);
 
             hr = PipeWaitForChildConnect(&pEngineState->companionConnection);
+            if (HRESULT_FROM_WIN32(ERROR_NO_DATA) == hr)
+            {
+                hr = E_SUSPECTED_AV_INTERFERENCE;
+            }
             ExitOnFailure(hr, "Failed to connect to elevated child process.");
 
             LogId(REPORT_STANDARD, MSG_CONNECT_TO_ELEVATED_ENGINE_SUCCESS);

--- a/src/burn/inc/BootstrapperEngine.h
+++ b/src/burn/inc/BootstrapperEngine.h
@@ -9,6 +9,10 @@ extern "C" {
 #define IDERROR -1
 #define IDNOACTION 0
 
+#define FACILITY_WIX 500
+
+static const HRESULT E_SUSPECTED_AV_INTERFERENCE = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 2000);
+
 // Note that ordering of the enumeration values is important.
 // Some code paths use < or > comparisions and simply reording values will break those comparisons.
 enum BOOTSTRAPPER_ACTION

--- a/src/libs/balutil/inc/balutil.h
+++ b/src/libs/balutil/inc/balutil.h
@@ -13,8 +13,6 @@ extern "C" {
 #define BalExitOnRootFailure(x, f, ...) if (FAILED(x)) { BalLogError(x, f, __VA_ARGS__); Dutil_RootFailure(__FILE__, __LINE__, x); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
 #define BalExitOnNullWithLastError(p, x, f, ...) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, __VA_ARGS__); ExitTrace(x, f, __VA_ARGS__); goto LExit; }
 
-#define FACILITY_WIX 500
-
 const LPCWSTR BAL_MANIFEST_FILENAME = L"BootstrapperApplicationData.xml";
 
 static const HRESULT E_WIXSTDBA_CONDITION_FAILED = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 1);


### PR DESCRIPTION
This feels pretty hacky to me. But it does work, I tested with Avast. The log looks like this:

    [02C0:0DB4][2018-12-18T03:16:51]i300: Apply begin
    [02C0:0DB4][2018-12-18T03:16:51]i010: Launching elevated engine process.
    [02C0:0DB4][2018-12-18T03:17:22]i011: Launched elevated engine process.
    [02C0:0DB4][2018-12-18T03:17:22]e000: Error 0x800700e8: Failed to wait for child to connect to pipe.
    [02C0:0DB4][2018-12-18T03:17:22]e000: Error 0x81f407d0: Failed to connect to elevated child process.
    [02C0:0DB4][2018-12-18T03:17:22]i010: Launching elevated engine process.
    [02C0:0DB4][2018-12-18T03:17:25]i011: Launched elevated engine process.
    [02C0:0DB4][2018-12-18T03:17:25]i012: Connected to elevated engine.
    [1048:172C][2018-12-18T03:17:25]i358: Pausing automatic updates.

The user experience is that they click Install. They get a UAC prompt and after they confirm it, Avast pops up saying it found something suspicious and will scan for 15 seconds. When Avast completes it scan, Burn immediately tries to elevate again. The second UAC prompt comes up before they can see from Avast that it completed its scan. After confirming the second UAC prompt, installation completes normally.