### PR TITLE
Fix NullReferenceException in MsuPackage processing

### DIFF
--- a/src/tools/wix/Bind/BindBundleCommand.cs
+++ b/src/tools/wix/Bind/BindBundleCommand.cs
@@ -234,6 +234,7 @@ namespace WixToolset.Bind
                     case WixBundlePackageType.Msu:
                         {
                             ProcessMsuPackageCommand command = new ProcessMsuPackageCommand();
+                            command.AuthoredPayloads = payloads;
                             command.Facade = facade;
                             command.Execute();
                         }


### PR DESCRIPTION
This PR fixes a NullReferenceException when creating a bundle containing an `MsuPackage`.

The first line in `ProcessMsuPackageCommand.Execute()` contains a call to `AuthoredPayloads.Get()`, but `AuthoredPayloads` was not set. For other package types, `AuthoredPayloads` is set just after the command object is constructed, so I did the same for `ProcessMsuPackageCommand`.

I will open a pull request in the wixtoolset/Core repository as well.