### PR TITLE
Update BindDatabaseCommand.cs

### DIFF
--- a/src/tools/wix/Bind/BindDatabaseCommand.cs
+++ b/src/tools/wix/Bind/BindDatabaseCommand.cs
@@ -491,6 +491,7 @@ namespace WixToolset.Bind
                 command.Output = this.Output;
                 command.OutputPath = tempDatabaseFile;
                 command.SuppressedTableNames = suppressedTableNames;
+                command.TempFilesLocation = this.TempFilesLocation;
                 command.Execute();
 
                 // stop processing if an error previously occurred


### PR DESCRIPTION
The `TempFilesLocation` is null before `execute()`, so this can lead to crashes like this one:

```
Exception Type: System.ArgumentNullException

Stack Trace:
   at System.IO.Path.Combine(String path1, String path2)
   at WixToolset.Bind.Databases.MergeModulesCommand.Execute() in [...]\wix4\src\tools\wix\Bind\Databases\MergeModulesCommand.cs:line 56
   at WixToolset.Bind.BindDatabaseCommand.Execute() in [...]\wix4\src\tools\wix\Bind\BindDatabaseCommand.cs:line 495
   at WixToolset.Binder.BindDatabase(Output output, String databaseFile, IEnumerable`1& fileTransfers, IEnumerable`1& contentPaths) in [...]\wix4\src\tools\wix\Binder.cs:line:line 435
   at WixToolset.Binder.Bind(Output output, String file) in [...]\wix4\src\tools\wix\Binder.cs:line 272
   at WixToolset.Tools.Light.Run() in [...]\wix4\src\tools\light\light.cs:line 319
   at WixToolset.Tools.Light.Execute(String[] args) in [...]\wix4\src\tools\light\light.cs:line 68
```